### PR TITLE
render: Create a Render trait using associated types and constants.

### DIFF
--- a/src/room_buffer.rs
+++ b/src/room_buffer.rs
@@ -50,7 +50,7 @@ use tracing::{debug, error, trace};
 
 use crate::{
     connection::{Connection, TYPING_NOTICE_TIMEOUT},
-    render::{render_membership, render_message},
+    render::{render_message, MembershipContext, Render},
 };
 use std::{
     cell::{Ref, RefCell, RefMut},
@@ -709,7 +709,8 @@ impl RoomBuffer {
             // Display the event message
             let message = match (&sender, &target) {
                 (Some(sender), Some(target)) => {
-                    render_membership(event, sender, target)
+                    let context = MembershipContext { sender, target };
+                    event.render(&context).message
                 }
 
                 _ => {


### PR DESCRIPTION
This adds a render trait back, the trait now allows adding custom additional context that might be needed to render the event to be passed to the render method.

It also naturally scopes the event specific tags in the associated constant of the trait.