### PR TITLE
github: Create an action to build-test-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,17 @@ jobs:
         rust:
           - stable
     steps:
+      - name: Install latest-stable weechat for Ubuntu 18.04
+        run: |
+          sudo apt update
+          sudo apt install dirmngr gpg-agent apt-transport-https
+          sudo apt-key adv --keyserver hkps://keys.openpgp.org --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E
+          echo "deb https://weechat.org/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/weechat.list
+          echo "deb-src https://weechat.org/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/weechat.list
+          sudo apt update
+          sudo apt install weechat-curses weechat-plugins weechat-python weechat-perl weechat-dev
+          grep -m 1  "WEECHAT_PLUGIN_API_VERSION" "/usr/include/weechat/weechat-plugin.h"
+
       - name: Checkout sources
         uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'weechat-matrix-rs-x86_64-unknown-linux-gnu'
-          path: target/release/weechat-matrix-rs
+          path: target/release/libmatrix.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
           echo "deb-src https://weechat.org/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/weechat.list
           sudo apt update
           sudo apt install weechat-curses weechat-plugins weechat-python weechat-perl weechat-dev
-          grep -m 1  "WEECHAT_PLUGIN_API_VERSION" "/usr/include/weechat/weechat-plugin.h"
+          echo "version of weechat-plugin.h that weechat-sys uses by default:"
+          grep -m 1 -n -H "WEECHAT_PLUGIN_API_VERSION" "/usr/include/weechat/weechat-plugin.h"
 
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,8 @@
 on: [push]
 
-name: build-and-test-and-release
+name: build-test-release
 
 jobs:
-  x86_64_musl:
-    name: Ubuntu 18.04
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        rust:
-          - stable
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-musl
-          override: true
-
-      - name: Install dependencies for musl libc
-        run: |
-          sudo apt-get update
-          sudo apt-get install musl-tools
-      - name: Run cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target x86_64-unknown-linux-musl
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target x86_64-unknown-linux-musl
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: 'weechat-matrix-rs-x86_64-unknown-linux-musl'
-          path: target/x86_64-unknown-linux-musl/release/weechat-matrix-rs
-
   x86_64_glibc:
     name: Ubuntu 18.04 (glibc)
     runs-on: ubuntu-18.04
@@ -77,4 +37,3 @@ jobs:
         with:
           name: 'weechat-matrix-rs-x86_64-unknown-linux-gnu'
           path: target/release/weechat-matrix-rs
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+on: [push]
+
+name: build-and-test-and-release
+
+jobs:
+  x86_64_musl:
+    name: Ubuntu 18.04
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+
+      - name: Install dependencies for musl libc
+        run: |
+          sudo apt-get update
+          sudo apt-get install musl-tools
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target x86_64-unknown-linux-musl
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target x86_64-unknown-linux-musl
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'weechat-matrix-rs-x86_64-unknown-linux-musl'
+          path: target/x86_64-unknown-linux-musl/release/weechat-matrix-rs
+
+  x86_64_glibc:
+    name: Ubuntu 18.04 (glibc)
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'weechat-matrix-rs-x86_64-unknown-linux-gnu'
+          path: target/release/weechat-matrix-rs
+


### PR DESCRIPTION
To quickly test `weechat-matrix-rs`, I created this github action to generate the binary (in `--release` mode) for Ubuntu 18.04 with latest stable weechat headers for the distro. It can be downloaded from [here](https://github.com/pvonmoradi/weechat-matrix-rs/releases) and I've tested it locally.

Note that it seems you are already using Travis for CI/CD. So either ignore this PR or consider migrating your solutions to Github Actions.