### PR TITLE
Verification suport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -23,9 +23,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aead"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
+checksum = "6e3e798aa0c8239776f54415bc06f3d74b1850f3f830b45c35cfc80556973f70"
 dependencies = [
  "generic-array",
 ]
@@ -39,20 +39,20 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "ctr",
+ "ctr 0.7.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
 dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr",
+ "ctr 0.8.0",
  "ghash",
  "subtle",
 ]
@@ -108,9 +108,9 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.58"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fb5a785d6b44fd9d6700935608639af1b8356de1e55d5f7c2740f4faa15d82"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
  "cc",
@@ -204,7 +204,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "regex",
  "rustc-hash",
@@ -229,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytemuck"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
 
 [[package]]
 name = "byteorder"
@@ -253,9 +253,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cexpr"
@@ -280,9 +280,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
+checksum = "ea8756167ea0aca10e066cdbe7813bd71d2f24e69b0bc7b50509590cef2ce0b9"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
+checksum = "175a11316f33592cf2b71416ee65283730b5b7849813c4891d02a12906ed9acc"
 dependencies = [
  "aead",
  "chacha20",
@@ -380,9 +380,9 @@ checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "const_fn"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402da840495de3f976eaefc3485b7f5eb5b0bf9761f9a47be27fe975b3b8c2ec"
+checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
 name = "core-foundation"
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -454,20 +454,19 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -478,6 +477,15 @@ name = "ctr"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -541,9 +549,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "ed25519"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "signature",
 ]
@@ -579,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -708,9 +716,9 @@ checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -829,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -849,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "glob"
@@ -901,19 +909,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.2"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -941,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -952,15 +966,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -970,9 +984,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -984,7 +998,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -1037,12 +1051,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -1057,22 +1071,22 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "time 0.2.26",
+ "time 0.2.27",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1109,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "js_int"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcae89e078a96b781b38f36225bb3a174b8f6e905dfec550dd16a13539c82acc"
+checksum = "defaba9bcd19568a4b4b3736b23e368e5b75e3ea126fd4cb3e4ad2ea5af274fd"
 dependencies = [
  "serde",
 ]
@@ -1130,9 +1144,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -1183,7 +1197,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1210,7 +1224,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "matrix-qrcode"
 version = "0.1.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=e919a82b2c8ea881e00982c5ce26521ec91894cf#e919a82b2c8ea881e00982c5ce26521ec91894cf"
 dependencies = [
  "base64",
  "byteorder",
@@ -1224,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk"
 version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=e919a82b2c8ea881e00982c5ce26521ec91894cf#e919a82b2c8ea881e00982c5ce26521ec91894cf"
 dependencies = [
  "backoff",
  "bytes",
@@ -1249,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=e919a82b2c8ea881e00982c5ce26521ec91894cf#e919a82b2c8ea881e00982c5ce26521ec91894cf"
 dependencies = [
  "chacha20poly1305",
  "dashmap",
@@ -1274,7 +1288,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=e919a82b2c8ea881e00982c5ce26521ec91894cf#e919a82b2c8ea881e00982c5ce26521ec91894cf"
 dependencies = [
  "async-trait",
  "futures",
@@ -1290,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=e919a82b2c8ea881e00982c5ce26521ec91894cf#e919a82b2c8ea881e00982c5ce26521ec91894cf"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1323,9 +1337,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -1357,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -1480,9 +1494,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "olm-rs"
@@ -1499,24 +1516,24 @@ dependencies = [
 
 [[package]]
 name = "olm-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d29b3debd2916908e725d936ef5722d014a338a57c74e59dbf4c8c43855254d"
+checksum = "067ed86d3c0ab5d9009601082cd16a438e2104174f956d38fc81e0ad56f5696b"
 dependencies = [
  "cmake",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "onig"
-version = "6.1.1"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b46fd9edbc018f0be4e366c24c46db44fac49cd01c039ae85308088b089dd5"
+checksum = "b16fd3c0e73b516af509c13c4ba76ec0c987ce20d78b38cff356b8d01fc6a6c0"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1526,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.6.0"
+version = "69.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed063c96cf4c0f2e5d09324409d158b38a0a85a7b90fbd68c8cad75c495d5775"
+checksum = "9fd9442a09e4fbd08d196ddf419b2c79a43c3a46c800320cc841d45c2449a240"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1542,9 +1559,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1556,15 +1573,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.62"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -1627,29 +1644,29 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1669,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
+checksum = "87bb2d5c68b7505a3a89eb2f3583a4d56303863005226c2ef99319930a262be4"
 dependencies = [
  "der",
  "spki",
@@ -1712,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
+checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -1723,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1772,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -1815,7 +1832,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
 ]
 
 [[package]]
@@ -1838,9 +1855,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1855,12 +1872,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1874,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -1892,11 +1909,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1926,18 +1943,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1946,11 +1963,10 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
@@ -1971,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
  "bytes",
@@ -2035,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-api"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51df85b3e2c4097abc60919864502083def5c3b12982b0c46f6431e5b1e1476d"
+checksum = "b6473753f244f057181f975224aeaf5b4e2003f43f2a6279bf0b95f4e0126335"
 dependencies = [
  "bytes",
  "http",
@@ -2052,14 +2068,14 @@ dependencies = [
 
 [[package]]
 name = "ruma-api-macros"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe79932728de6a753163f4f30acfd70ebe4355c35fc638edb3f47c7cf47ab128"
+checksum = "85286e2c65897079e7dcc120964cca47d5a3c23b7d1e9f730f533060919fedf7"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2101,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88457e98e1ec2279e2c75467479b597cb0a72781a52aeb070956a29df08fa68d"
+checksum = "338ba384badd1f4bdc924d3fc3021ebfee5d5e9d4ab8122fc86a15ac732a3e60"
 dependencies = [
  "indoc",
  "js_int",
@@ -2118,14 +2134,14 @@ dependencies = [
 
 [[package]]
 name = "ruma-events-macros"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28dd0388ce09f110f374388078ed107eddf2e1192c0f6b05a6d41e057930442"
+checksum = "e4d7d41acbe4833798babeb953862726952785aa5efd2164bbb69a6c65974c1e"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2166,7 +2182,7 @@ checksum = "e3c7bc7e132a84f8d03924cf63d3a37bd87ffee5c29fee69b9125d045c7e4020"
 dependencies = [
  "quote 1.0.9",
  "ruma-identifiers-validation",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2197,9 +2213,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "025cad7b962e7fb95f9e2df20339ec8ab1c250c9fb148b201f374ce41919d32c"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2241,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
+checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc-hash"
@@ -2305,9 +2321,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2318,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2362,9 +2378,9 @@ version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2426,9 +2442,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 
 [[package]]
 name = "slab"
@@ -2506,11 +2522,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde",
  "serde_derive",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2520,13 +2536,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2554,16 +2570,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2578,24 +2594,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "unicode-xid 0.2.2",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "unicode-xid 0.2.2",
 ]
 
@@ -2655,22 +2671,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2706,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
  "libc",
@@ -2731,22 +2747,22 @@ dependencies = [
 
 [[package]]
 name = "time-macros-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "standback",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2759,9 +2775,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2785,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2830,9 +2846,9 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -2929,18 +2945,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -2968,9 +2984,9 @@ checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
@@ -3000,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3076,9 +3092,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-shared",
 ]
 
@@ -3110,9 +3126,9 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3125,9 +3141,9 @@ checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3136,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "weechat"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#fafc7e7e7118981daa1d140df000a5c5253c8095"
+source = "git+https://github.com/poljar/rust-weechat?rev=8209460a4313bdcaef161ec423ae8de97a6ee412#8209460a4313bdcaef161ec423ae8de97a6ee412"
 dependencies = [
  "async-task",
  "async-trait",
@@ -3153,12 +3169,12 @@ dependencies = [
 [[package]]
 name = "weechat-macro"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#fafc7e7e7118981daa1d140df000a5c5253c8095"
+source = "git+https://github.com/poljar/rust-weechat?rev=8209460a4313bdcaef161ec423ae8de97a6ee412#8209460a4313bdcaef161ec423ae8de97a6ee412"
 dependencies = [
  "libc",
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
 ]
 
 [[package]]
@@ -3189,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "weechat-sys"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#fafc7e7e7118981daa1d140df000a5c5253c8095"
+source = "git+https://github.com/poljar/rust-weechat?rev=8209460a4313bdcaef161ec423ae8de97a6ee412#8209460a4313bdcaef161ec423ae8de97a6ee412"
 dependencies = [
  "bindgen",
  "libc",
@@ -3286,8 +3302,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.72",
+ "syn 1.0.73",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,42 +16,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.3.2"
+name = "adler32"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "aead"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "922b33332f54fc0ad13fa3e514601e8d30fb54e1f3eadc36643f6526db645621"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.6.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if 1.0.0",
  "cipher",
-]
-
-[[package]]
-name = "aes-ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7729c3cde54d67063be556aeac75a81330d802f0259500ca40cb52967f975763"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher",
+ "cpufeatures",
  "ctr",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
@@ -62,24 +58,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-soft"
-version = "0.6.4"
+name = "ahash"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
@@ -126,9 +108,9 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -164,10 +146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "futures-core",
- "getrandom",
+ "getrandom 0.2.3",
  "instant",
  "pin-project",
- "rand",
+ "rand 0.8.4",
  "tokio",
 ]
 
@@ -181,7 +163,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -222,8 +204,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
  "regex",
  "rustc-hash",
  "shlex",
@@ -250,6 +232,12 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "bytemuck"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
 
 [[package]]
 name = "byteorder"
@@ -292,19 +280,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8738f14471a99f0e316c327e68fc82a3611cc2895fcb604b89eedaf8f39d95"
+checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
 dependencies = [
+ "cfg-if 1.0.0",
  "cipher",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1fc18e6d90c40164bf6c317476f2a98f04661e310e79830366b7e914c58a8e"
+checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
  "aead",
  "chacha20",
@@ -312,6 +302,12 @@ dependencies = [
  "poly1305",
  "zeroize",
 ]
+
+[[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
@@ -328,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
@@ -371,6 +367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "const-oid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+
+[[package]]
 name = "const_fn"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,15 +402,12 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -411,6 +416,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -439,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -449,11 +475,24 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -464,6 +503,25 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
+]
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
+name = "der"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -480,6 +538,35 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "ed25519"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -512,7 +599,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -558,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -573,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -583,15 +670,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -600,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-locks"
@@ -615,27 +702,28 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-timer"
@@ -649,10 +737,11 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -677,6 +766,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "g2gen"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc100b16c63808c5c388cd23ff94c5a35cf28ea459f336323f7948a39480555"
+dependencies = [
+ "g2poly",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "g2p"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf09bc632629cbe5420b330e45bcc8f80403e74ba1027d213258914fd5c62755"
+dependencies = [
+ "g2gen",
+ "g2poly",
+]
+
+[[package]]
+name = "g2poly"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e837767888fca507f07e89c90e0b350da7bbb89170f67a4655dc9bdc4cca457b"
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,25 +805,46 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -758,6 +896,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -779,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -876,6 +1017,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+ "png",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,16 +1075,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
-name = "js-sys"
-version = "0.3.50"
+name = "jpeg-decoder"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -952,9 +1130,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -1000,6 +1178,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,9 +1208,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "matrix-qrcode"
+version = "0.1.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
+dependencies = [
+ "base64",
+ "byteorder",
+ "image",
+ "qrcode",
+ "rqrr",
+ "ruma-identifiers",
+ "thiserror",
+]
+
+[[package]]
 name = "matrix-sdk"
-version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#8dbbacfbe618c5301490984f4ba63c4633224264"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
 dependencies = [
  "backoff",
  "bytes",
@@ -1035,6 +1236,7 @@ dependencies = [
  "matrix-sdk-common",
  "mime",
  "reqwest",
+ "ruma",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1046,17 +1248,19 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#8dbbacfbe618c5301490984f4ba63c4633224264"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
 dependencies = [
  "chacha20poly1305",
  "dashmap",
  "futures",
  "hmac",
+ "lru",
  "matrix-sdk-common",
  "matrix-sdk-crypto",
  "pbkdf2",
- "rand",
+ "rand 0.8.4",
+ "ruma",
  "serde",
  "serde_json",
  "sha2",
@@ -1069,8 +1273,8 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#8dbbacfbe618c5301490984f4ba63c4633224264"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
 dependencies = [
  "async-trait",
  "futures",
@@ -1085,21 +1289,23 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.2.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#8dbbacfbe618c5301490984f4ba63c4633224264"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk/?rev=b62f725bead1f44b2038784e5321909f71a4af4a#b62f725bead1f44b2038784e5321909f71a4af4a"
 dependencies = [
- "aes-ctr",
+ "aes",
  "aes-gcm",
  "atomic",
  "base64",
  "byteorder",
  "dashmap",
  "futures",
- "getrandom",
+ "getrandom 0.2.3",
  "hmac",
+ "matrix-qrcode",
  "matrix-sdk-common",
  "olm-rs",
  "pbkdf2",
+ "ruma",
  "serde",
  "serde_json",
  "sha2",
@@ -1129,6 +1335,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1223,6 +1438,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,7 +1490,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8962a1fc909accf520991dcda872888554ecf16320097e02d3bd9981844a24ae"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
  "olm-sys",
  "serde",
  "serde_json",
@@ -1369,9 +1606,9 @@ checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "pbkdf2"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac",
 ]
@@ -1403,9 +1640,9 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1431,6 +1668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,22 +1699,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "poly1305"
-version = "0.6.2"
+name = "png"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
- "cpuid-bool",
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
 dependencies = [
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1501,11 +1763,20 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -1520,24 +1791,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
+ "image",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.26",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1547,7 +1860,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1556,7 +1878,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1565,7 +1896,32 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1648,9 +2004,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rqrr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a63da014e6f18dbe76e3084feb2f6c5a570ad8d524cc1afff4a6db18404cd"
+dependencies = [
+ "g2p",
+ "image",
+ "lru",
+]
+
+[[package]]
 name = "ruma"
-version = "0.0.3"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4acf77afac731e1fa133e6952d074af052f02d64909677a66619f52e758261"
 dependencies = [
  "assign",
  "js_int",
@@ -1661,12 +2029,15 @@ dependencies = [
  "ruma-federation-api",
  "ruma-identifiers",
  "ruma-serde",
+ "ruma-signatures",
+ "ruma-state-res",
 ]
 
 [[package]]
 name = "ruma-api"
-version = "0.17.0-alpha.4"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51df85b3e2c4097abc60919864502083def5c3b12982b0c46f6431e5b1e1476d"
 dependencies = [
  "bytes",
  "http",
@@ -1681,19 +2052,21 @@ dependencies = [
 
 [[package]]
 name = "ruma-api-macros"
-version = "0.17.0-alpha.4"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe79932728de6a753163f4f30acfd70ebe4355c35fc638edb3f47c7cf47ab128"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "ruma-client-api"
-version = "0.10.0-alpha.3"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b86eba1c6fce6dd5c7a17ed632515aa7d04bbe6fbaa74c1699fb72c9fcc2d3d"
 dependencies = [
  "assign",
  "bytes",
@@ -1712,12 +2085,12 @@ dependencies = [
 
 [[package]]
 name = "ruma-common"
-version = "0.5.0"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146a88f34b7a084d54eaf790aaf4c25f5d2366ca8f3d1f326985fa5d31d72595"
 dependencies = [
  "indexmap",
  "js_int",
- "maplit",
  "ruma-identifiers",
  "ruma-serde",
  "serde",
@@ -1728,9 +2101,11 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.22.0-alpha.3"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88457e98e1ec2279e2c75467479b597cb0a72781a52aeb070956a29df08fa68d"
 dependencies = [
+ "indoc",
  "js_int",
  "pulldown-cmark",
  "ruma-common",
@@ -1743,19 +2118,21 @@ dependencies = [
 
 [[package]]
 name = "ruma-events-macros"
-version = "0.22.0-alpha.3"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28dd0388ce09f110f374388078ed107eddf2e1192c0f6b05a6d41e057930442"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "ruma-federation-api"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5206d4922c5dbd3b6faf2aaec9b5551fdf710ef73cc2145f13d0a5bb3945dc"
 dependencies = [
  "js_int",
  "ruma-api",
@@ -1769,8 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-identifiers"
-version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be9ce339ce206dd5eb5eb29b7ad1b964652d46345bc46f25d68105effc75f4b"
 dependencies = [
  "paste",
  "ruma-identifiers-macros",
@@ -1782,24 +2160,26 @@ dependencies = [
 
 [[package]]
 name = "ruma-identifiers-macros"
-version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c7bc7e132a84f8d03924cf63d3a37bd87ffee5c29fee69b9125d045c7e4020"
 dependencies = [
- "proc-macro2",
- "quote",
+ "quote 1.0.9",
  "ruma-identifiers-validation",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "ruma-identifiers-validation"
-version = "0.3.0"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edeb165c4dcb8c93d1b7396b32fd5f52c5d9c7e7898ab87d772f824fe642f7c"
 
 [[package]]
 name = "ruma-serde"
-version = "0.3.1"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63074bc5313acbb4145c7a98c2aa90f1a5b218926ed10d3d71c469664326a4dc"
 dependencies = [
  "bytes",
  "form_urlencoded",
@@ -1812,13 +2192,51 @@ dependencies = [
 
 [[package]]
 name = "ruma-serde-macros"
-version = "0.3.1"
-source = "git+https://github.com/ruma/ruma?rev=1e005f576e4640ee5ce6e357bcf33293819502d1#1e005f576e4640ee5ce6e357bcf33293819502d1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025cad7b962e7fb95f9e2df20339ec8ab1c250c9fb148b201f374ce41919d32c"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
+
+[[package]]
+name = "ruma-signatures"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d83873429181c7747b42fce80d86be84d63fd178e83573472c93143643b7a67"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "pkcs8",
+ "rand 0.7.3",
+ "ruma-identifiers",
+ "ruma-serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ruma-state-res"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50be7be79f1036dfdacda38e94f334e99f845db2e414887eedb757d065a05594"
+dependencies = [
+ "itertools",
+ "js_int",
+ "maplit",
+ "ruma-common",
+ "ruma-events",
+ "ruma-identifiers",
+ "ruma-serde",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1874,6 +2292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,22 +2349,22 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1974,9 +2398,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f6b75b17576b792bef0db1bcc4b8b8bcdf9506744cf34b974195487af6cff2"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -1999,6 +2423,12 @@ name = "shlex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+
+[[package]]
+name = "signature"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
@@ -2039,6 +2469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "standback"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,11 +2506,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2081,13 +2520,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2115,9 +2554,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2128,13 +2567,24 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -2143,10 +2593,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -2179,7 +2629,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2205,22 +2655,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2233,13 +2683,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder",
+ "miniz_oxide 0.4.4",
+ "weezl",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -2275,10 +2736,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
  "standback",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2298,9 +2759,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2309,6 +2770,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "winapi",
 ]
 
 [[package]]
@@ -2368,9 +2830,9 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2415,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2488,6 +2950,12 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
@@ -2510,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2526,7 +2994,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
  "serde",
 ]
 
@@ -2577,15 +3045,21 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2595,24 +3069,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2622,32 +3096,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
- "quote",
+ "quote 1.0.9",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
@@ -2682,9 +3156,9 @@ version = "0.4.0"
 source = "git+https://github.com/poljar/rust-weechat#fafc7e7e7118981daa1d140df000a5c5253c8095"
 dependencies = [
  "libc",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2695,8 +3169,10 @@ dependencies = [
  "clap",
  "dashmap",
  "futures",
+ "image",
  "indoc",
  "matrix-sdk",
+ "qrcode",
  "serde_json",
  "strum",
  "strum_macros",
@@ -2718,6 +3194,12 @@ dependencies = [
  "bindgen",
  "libc",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
 
 [[package]]
 name = "which"
@@ -2804,8 +3286,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,26 @@ default = []
 clap = "2.33.3"
 chrono = "0.4.19"
 dashmap = "4.0.2"
-futures = "0.3.14"
+futures = "0.3.15"
 indoc = "1.0.3"
-url = "2.2.1"
+url = "2.2.2"
 serde_json = "1.0.64"
 strum = "0.20.0"
 strum_macros = "0.20.1"
 syntect = "4.5.0"
-tokio = { version = "1.5.0", features = [ "rt-multi-thread", "sync" ] }
-tracing = "0.1.25"
-tracing-subscriber = "0.2.17"
+tokio = { version = "1.7.1", features = [ "rt-multi-thread", "sync" ] }
+tracing = "0.1.26"
+tracing-subscriber = "0.2.19"
 uuid = { version = "0.8.2", features = ["v4"] }
 unicode-segmentation = "1.7.1"
+qrcode = { version = "0.12.0", default-features = false }
+image = "0.23.14"
 
 [dependencies.weechat]
 git = "https://github.com/poljar/rust-weechat"
 features = ["async", "config_macro"]
 
 [dependencies.matrix-sdk]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
+git = "https://github.com/matrix-org/matrix-rust-sdk/"
+rev = "b62f725bead1f44b2038784e5321909f71a4af4a"
 features = ["markdown"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,10 @@ image = "0.23.14"
 
 [dependencies.weechat]
 git = "https://github.com/poljar/rust-weechat"
+rev = "8209460a4313bdcaef161ec423ae8de97a6ee412"
 features = ["async", "config_macro"]
 
 [dependencies.matrix-sdk]
 git = "https://github.com/matrix-org/matrix-rust-sdk/"
-rev = "b62f725bead1f44b2038784e5321909f71a4af4a"
+rev = "e919a82b2c8ea881e00982c5ce26521ec91894cf"
 features = ["markdown"]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 WEECHAT_HOME ?= $(HOME)/.weechat
 PREFIX ?= $(WEECHAT_HOME)
 
-SOURCES := $(wildcard src/*.rs src/commands/*.rs)
+.PHONY: install install-dir lint target/debug/libmatrix.so
 
-.PHONY: install install-dir lint
-
-target/debug/libmatrix.so: $(SOURCES)
+target/debug/libmatrix.so:
 	cargo build
 
 install: install-dir target/debug/libmatrix.so

--- a/src/bar_items/buffer_name.rs
+++ b/src/bar_items/buffer_name.rs
@@ -45,6 +45,11 @@ impl BarItemCallback for BufferName {
                 format!("{}{}", Weechat::color(color), buffer.short_name())
             }
 
+            BufferOwner::Verification(_, _) => {
+                // TODO special format this
+                format!("{}{}", Weechat::color("status_name"), buffer.name())
+            }
+
             BufferOwner::None => {
                 format!("{}{}", Weechat::color("status_name"), buffer.name())
             }

--- a/src/bar_items/buffer_name.rs
+++ b/src/bar_items/buffer_name.rs
@@ -35,7 +35,8 @@ impl BarItemCallback for BufferName {
                 )
             }
 
-            BufferOwner::Room(server, _) => {
+            BufferOwner::Room(server, _)
+            | BufferOwner::Verification(server, _) => {
                 let color = if server.is_connection_secure() {
                     "status_name_ssl"
                 } else {
@@ -43,11 +44,6 @@ impl BarItemCallback for BufferName {
                 };
 
                 format!("{}{}", Weechat::color(color), buffer.short_name())
-            }
-
-            BufferOwner::Verification(_, _) => {
-                // TODO special format this
-                format!("{}{}", Weechat::color("status_name"), buffer.name())
             }
 
             BufferOwner::None => {

--- a/src/bar_items/buffer_plugin.rs
+++ b/src/bar_items/buffer_plugin.rs
@@ -20,7 +20,9 @@ impl BufferPlugin {
 impl BarItemCallback for BufferPlugin {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer) -> String {
         match self.servers.buffer_owner(buffer) {
-            BufferOwner::Server(s) | BufferOwner::Room(s, _) => {
+            BufferOwner::Server(s)
+            | BufferOwner::Room(s, _)
+            | BufferOwner::Verification(s, _) => {
                 format!(
                     "{plugin_name}{del_color}/{color}{name}",
                     plugin_name = PLUGIN_NAME,

--- a/src/commands/devices.rs
+++ b/src/commands/devices.rs
@@ -2,7 +2,7 @@ use clap::{
     App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches,
     SubCommand,
 };
-use matrix_sdk::identifiers::DeviceIdBox;
+use matrix_sdk::ruma::identifiers::DeviceIdBox;
 
 use weechat::{
     buffer::Buffer,

--- a/src/commands/devices.rs
+++ b/src/commands/devices.rs
@@ -21,6 +21,13 @@ impl DevicesCommand {
     pub const DESCRIPTION: &'static str =
         "List, delete or rename Matrix devices";
 
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
+
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("devices")
             .description(Self::DESCRIPTION)
@@ -115,10 +122,7 @@ impl CommandCallback for DevicesCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("devices")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -21,6 +21,12 @@ pub struct KeysCommand {
 impl KeysCommand {
     pub const DESCRIPTION: &'static str = "Import or export E2EE keys.";
     pub const COMPLETION: &'static str = "import|export %(filename)";
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
 
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("keys")
@@ -116,10 +122,7 @@ impl CommandCallback for KeysCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("keys")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -12,7 +12,9 @@ use weechat::{
 
 use super::parse_and_run;
 use crate::{
-    commands::{DevicesCommand, KeysCommand},
+    commands::{
+        verification::VerificationCommand, DevicesCommand, KeysCommand,
+    },
     config::ConfigHandle,
     MatrixServer, Servers, PLUGIN_NAME,
 };
@@ -38,20 +40,26 @@ impl MatrixCommand {
             .add_argument("reconnect <server-name>")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(&format!(
-                "      server: List, add, or remove Matrix servers.
-     connect: Connect to Matrix servers.
-  disconnect: Disconnect from one or all Matrix servers.
-   reconnect: Reconnect to server(s).
-     devices: {}
-        keys: {}
+                "        server: List, add, or remove Matrix servers.
+       connect: Connect to Matrix servers.
+    disconnect: Disconnect from one or all Matrix servers.
+     reconnect: Reconnect to server(s).
+       devices: {}
+          keys: {}
+  verification: {}
         help: Show detailed command help.\n
 Use /matrix [command] help to find out more.\n",
                 DevicesCommand::DESCRIPTION,
                 KeysCommand::DESCRIPTION,
+                VerificationCommand::DESCRIPTION,
             ))
             .add_completion("server |add|delete|list|listfull")
             .add_completion("devices |list|delete|set-name")
             .add_completion(&format!("keys {}", KeysCommand::COMPLETION))
+            .add_completion(&format!(
+                "verification {}",
+                VerificationCommand::COMPLETION
+            ))
             .add_completion("connect %(matrix_servers)")
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
@@ -224,6 +232,9 @@ Use /matrix [command] help to find out more.\n",
             ("keys", Some(subargs)) => {
                 KeysCommand::run(buffer, &self.servers, subargs)
             }
+            ("verification", Some(subargs)) => {
+                VerificationCommand::run(buffer, &self.servers, subargs)
+            }
             _ => unreachable!(),
         }
     }
@@ -285,6 +296,11 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("keys")
                     .about(KeysCommand::DESCRIPTION)
+                    .subcommands(KeysCommand::subcommands()),
+            )
+            .subcommand(
+                SubCommand::with_name("verification")
+                    .about(VerificationCommand::DESCRIPTION)
                     .subcommands(KeysCommand::subcommands()),
             )
             .subcommand(

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -283,19 +283,23 @@ impl CommandCallback for MatrixCommand {
 
         let argparse = Argparse::new("matrix")
             .about("Matrix chat protocol command.")
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
+            .global_settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+                ArgParseSettings::VersionlessSubcommands,
+            ])
             .setting(ArgParseSettings::SubcommandRequiredElseHelp)
             .subcommand(server_command)
             .subcommand(
                 SubCommand::with_name("devices")
                     .about(DevicesCommand::DESCRIPTION)
+                    .settings(DevicesCommand::SETTINGS)
                     .subcommands(DevicesCommand::subcommands()),
             )
             .subcommand(
                 SubCommand::with_name("keys")
                     .about(KeysCommand::DESCRIPTION)
+                    .settings(KeysCommand::SETTINGS)
                     .subcommands(KeysCommand::subcommands()),
             )
             .subcommand(

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -305,7 +305,8 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("verification")
                     .about(VerificationCommand::DESCRIPTION)
-                    .subcommands(KeysCommand::subcommands()),
+                    .settings(VerificationCommand::SETTINGS)
+                    .subcommands(VerificationCommand::subcommands()),
             )
             .subcommand(
                 SubCommand::with_name("connect")

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,18 +11,21 @@ mod devices;
 mod keys;
 mod matrix;
 mod page_up;
+mod verification;
 
 use buffer_clear::BufferClearCommand;
 use devices::DevicesCommand;
 use keys::KeysCommand;
 use matrix::MatrixCommand;
 use page_up::PageUpCommand;
+use verification::VerificationCommand;
 
 pub struct Commands {
     _matrix: Command,
     _keys: Command,
     _devices: Command,
     _page_up: CommandRun,
+    _verification: Command,
     _buffer_clear: CommandRun,
 }
 
@@ -36,6 +39,7 @@ impl Commands {
             _devices: DevicesCommand::create(servers)?,
             _keys: KeysCommand::create(servers)?,
             _page_up: PageUpCommand::create(servers)?,
+            _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,
         })
     }

--- a/src/commands/verification.rs
+++ b/src/commands/verification.rs
@@ -1,0 +1,117 @@
+use clap::{
+    App as Argparse, AppSettings as ArgParseSettings, ArgMatches, SubCommand,
+};
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{Command, CommandCallback, CommandSettings},
+    Args, Weechat,
+};
+
+use super::parse_and_run;
+use crate::{BufferOwner, Servers};
+
+pub struct VerificationCommand {
+    servers: Servers,
+}
+
+enum CommandType {
+    Accept,
+    Confirm,
+    Cancel,
+}
+
+impl VerificationCommand {
+    pub const DESCRIPTION: &'static str =
+        "Control interactive verification flows";
+
+    pub const COMPLETION: &'static str = "accept|confirm|cancel";
+
+    pub fn create(servers: &Servers) -> Result<Command, ()> {
+        let settings = CommandSettings::new("verification")
+            .description(Self::DESCRIPTION)
+            .add_argument("verification accept|confirm|cancel")
+            .arguments_description(
+                "accept: accept the verification request
+                confirm: confirm that the emojis match on both sides or \
+                confirm that the other side has scanned our QR code
+                cancel: cancel the verification flow or request",
+            )
+            .add_completion(Self::COMPLETION)
+            .add_completion("help accept|confirm|cancel");
+
+        Command::new(
+            settings,
+            VerificationCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+
+    fn verification(servers: &Servers, buffer: &Buffer, command: CommandType) {
+        let buffer_owner = servers.buffer_owner(buffer);
+
+        match buffer_owner {
+            BufferOwner::Room(_, b) => match command {
+                CommandType::Accept => b.accept_verification(),
+                CommandType::Confirm => b.confirm_verification(),
+                CommandType::Cancel => b.cancel_verification(),
+            },
+            BufferOwner::Verification(_, b) => match command {
+                CommandType::Accept => b.accept(),
+                CommandType::Confirm => b.confirm(),
+                CommandType::Cancel => b.cancel(),
+            },
+            BufferOwner::Server(_) | BufferOwner::None => {
+                Weechat::print(
+                    "The verification command needs to be executed in a room or \
+                    verification buffer",
+                );
+            }
+        }
+    }
+
+    pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
+        match args.subcommand() {
+            ("accept", _) => {
+                Self::verification(servers, buffer, CommandType::Accept)
+            }
+            ("confirm", _) => {
+                Self::verification(servers, buffer, CommandType::Confirm)
+            }
+            ("cancel", _) => {
+                Self::verification(servers, buffer, CommandType::Cancel)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn subcommands() -> Vec<Argparse<'static, 'static>> {
+        vec![
+            SubCommand::with_name("accept")
+                .about("Accept a verification request"),
+            SubCommand::with_name("confirm").about(
+                "Confirm that the emoji matches or that the other side has \
+                   scanned our QR code",
+            ),
+            SubCommand::with_name("cancel")
+                .about("Cancel the verification flow"),
+        ]
+    }
+}
+
+impl CommandCallback for VerificationCommand {
+    fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
+        let argparse = Argparse::new("verification")
+            .about(Self::DESCRIPTION)
+            .global_setting(ArgParseSettings::DisableHelpFlags)
+            .global_setting(ArgParseSettings::DisableVersion)
+            .global_setting(ArgParseSettings::VersionlessSubcommands)
+            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .subcommands(Self::subcommands());
+
+        parse_and_run(argparse, arguments, |matches| {
+            Self::run(buffer, &self.servers, &matches)
+        });
+    }
+}

--- a/src/commands/verification.rs
+++ b/src/commands/verification.rs
@@ -18,6 +18,7 @@ pub struct VerificationCommand {
 enum CommandType {
     Accept,
     Confirm,
+    UseEmoji,
     Cancel,
 }
 
@@ -25,14 +26,23 @@ impl VerificationCommand {
     pub const DESCRIPTION: &'static str =
         "Control interactive verification flows";
 
-    pub const COMPLETION: &'static str = "accept|confirm|cancel";
+    pub const COMPLETION: &'static str = "accept|confirm|cancel|use-emoji";
+
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
 
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("verification")
             .description(Self::DESCRIPTION)
-            .add_argument("verification accept|confirm|cancel")
+            .add_argument("verification accept|confirm|cancel|use-emoji")
             .arguments_description(
                 "accept: accept the verification request
+                use-emoji: switch to emoji verification QR code verification \
+                isn't possible
                 confirm: confirm that the emojis match on both sides or \
                 confirm that the other side has scanned our QR code
                 cancel: cancel the verification flow or request",
@@ -56,11 +66,15 @@ impl VerificationCommand {
                 CommandType::Accept => b.accept_verification(),
                 CommandType::Confirm => b.confirm_verification(),
                 CommandType::Cancel => b.cancel_verification(),
+                CommandType::UseEmoji => Weechat::print(
+                    "The 'use-emoji' command can only be used for self verifications"
+                ),
             },
             BufferOwner::Verification(_, b) => match command {
                 CommandType::Accept => b.accept(),
                 CommandType::Confirm => b.confirm(),
                 CommandType::Cancel => b.cancel(),
+                CommandType::UseEmoji => b.start_sas(),
             },
             BufferOwner::Server(_) | BufferOwner::None => {
                 Weechat::print(
@@ -79,6 +93,9 @@ impl VerificationCommand {
             ("confirm", _) => {
                 Self::verification(servers, buffer, CommandType::Confirm)
             }
+            ("use-emoji", _) => {
+                Self::verification(servers, buffer, CommandType::UseEmoji)
+            }
             ("cancel", _) => {
                 Self::verification(servers, buffer, CommandType::Cancel)
             }
@@ -90,6 +107,8 @@ impl VerificationCommand {
         vec![
             SubCommand::with_name("accept")
                 .about("Accept a verification request"),
+            SubCommand::with_name("use-emoji")
+                .about("Switch to emoji verification"),
             SubCommand::with_name("confirm").about(
                 "Confirm that the emoji matches or that the other side has \
                    scanned our QR code",
@@ -104,10 +123,7 @@ impl CommandCallback for VerificationCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("verification")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -1,0 +1,269 @@
+use std::{borrow::Cow, cell::RefCell, rc::Rc};
+
+use futures::executor::block_on;
+use matrix_sdk::{
+    room::Joined,
+    ruma::identifiers::{EventId, RoomAliasId, UserId},
+    StoreError,
+};
+use uuid::Uuid;
+use weechat::{
+    buffer::{Buffer, BufferHandle, BufferLine, LineData},
+    Prefix, Weechat,
+};
+
+use crate::{render::RenderedEvent, utils::ToTag};
+
+#[derive(Clone)]
+pub struct RoomBuffer {
+    room: Joined,
+    pub(super) inner: Rc<RefCell<Option<BufferHandle>>>,
+}
+
+impl RoomBuffer {
+    pub fn new(room: Joined) -> Self {
+        Self {
+            room,
+            inner: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    pub fn buffer_handle(&self) -> BufferHandle {
+        self.inner
+            .borrow()
+            .as_ref()
+            .expect("Room struct wasn't initialized properly")
+            .clone()
+    }
+
+    pub fn short_name(&self) -> String {
+        self.inner
+            .borrow()
+            .as_ref()
+            .and_then(|b| b.upgrade().ok().map(|b| b.short_name().to_string()))
+            .unwrap_or_default()
+    }
+
+    /// Replace the local echo of an event with a fully rendered one.
+    pub fn replace_local_echo(&self, uuid: Uuid, rendered: RenderedEvent) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            let uuid_tag =
+                Cow::from(format!("matrix_echo_{}", uuid.to_string()));
+            let line_contains_uuid =
+                |l: &BufferLine| l.tags().contains(&uuid_tag);
+
+            let mut lines = buffer.lines();
+            let mut current_line = lines.rfind(line_contains_uuid);
+
+            // We go in reverse order here since we also use rfind(). We got from
+            // the bottom of the buffer to the top since we're expecting these
+            // lines to be freshly printed and thus at the bottom.
+            let mut line_num = rendered.content.lines.len();
+
+            while let Some(line) = &current_line {
+                line_num -= 1;
+                let rendered_line = &rendered.content.lines[line_num];
+
+                line.set_message(&rendered_line.message);
+                current_line = lines.next_back().filter(line_contains_uuid);
+            }
+        }
+    }
+
+    pub fn replace_edit(
+        &self,
+        event_id: &EventId,
+        sender: &UserId,
+        event: RenderedEvent,
+    ) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            let sender_tag = Cow::from(sender.to_tag());
+            let event_id_tag = Cow::from(event_id.to_tag());
+
+            let lines: Vec<BufferLine> = buffer
+                .lines()
+                .filter(|l| l.tags().contains(&event_id_tag))
+                .collect();
+
+            if lines
+                .get(0)
+                .map(|l| l.tags().contains(&sender_tag))
+                .unwrap_or(false)
+            {
+                self.replace_event_helper(&buffer, lines, event);
+            }
+        }
+    }
+
+    fn replace_event_helper(
+        &self,
+        buffer: &Buffer,
+        lines: Vec<BufferLine<'_>>,
+        event: RenderedEvent,
+    ) {
+        use std::cmp::Ordering;
+        let date = lines.get(0).map(|l| l.date()).unwrap_or_default();
+
+        for (line, new) in lines.iter().zip(event.content.lines.iter()) {
+            let data = LineData {
+                // Our prefixes always come with a \t character, but when we
+                // replace stuff we're able to replace the prefix and the
+                // message separately, so trim the whitespace in the prefix.
+                prefix: Some(event.prefix.trim_end()),
+                message: Some(&new.message),
+                ..Default::default()
+            };
+
+            line.update(data);
+        }
+
+        match lines.len().cmp(&event.content.lines.len()) {
+            Ordering::Greater => {
+                for line in &lines[event.content.lines.len()..] {
+                    line.set_message("");
+                }
+            }
+            Ordering::Less => {
+                for line in &event.content.lines[lines.len()..] {
+                    let message = format!("{}{}", &event.prefix, &line.message);
+                    let tags: Vec<&str> =
+                        line.tags.iter().map(|t| t.as_str()).collect();
+                    buffer.print_date_tags(date, &tags, &message)
+                }
+
+                self.sort_messages()
+            }
+            Ordering::Equal => (),
+        }
+    }
+
+    pub fn sort_messages(&self) {
+        struct LineCopy {
+            date: i64,
+            date_printed: i64,
+            tags: Vec<String>,
+            prefix: String,
+            message: String,
+        }
+
+        impl<'a> From<BufferLine<'a>> for LineCopy {
+            fn from(line: BufferLine) -> Self {
+                Self {
+                    date: line.date(),
+                    date_printed: line.date_printed(),
+                    message: line.message().to_string(),
+                    prefix: line.prefix().to_string(),
+                    tags: line.tags().iter().map(|t| t.to_string()).collect(),
+                }
+            }
+        }
+
+        // TODO update the highlight once Weechat starts supporting it.
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            let mut lines: Vec<LineCopy> =
+                buffer.lines().map(|l| l.into()).collect();
+            lines.sort_by_key(|l| l.date);
+
+            for (line, new) in buffer.lines().zip(lines.drain(..)) {
+                let tags =
+                    new.tags.iter().map(|t| t.as_str()).collect::<Vec<&str>>();
+                let data = LineData {
+                    prefix: Some(&new.prefix),
+                    message: Some(&new.message),
+                    date: Some(new.date),
+                    date_printed: Some(new.date_printed),
+                    tags: Some(&tags),
+                };
+                line.update(data)
+            }
+        }
+    }
+
+    pub fn set_topic(&self) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            buffer.set_title(&self.room.topic().unwrap_or_default());
+        }
+    }
+
+    pub fn set_alias(&self) {
+        if let Some(alias) = self.alias() {
+            if let Ok(b) = self.buffer_handle().upgrade() {
+                b.set_localvar("alias", alias.as_str());
+            }
+        }
+    }
+
+    fn alias(&self) -> Option<RoomAliasId> {
+        self.room.canonical_alias()
+    }
+
+    pub fn calculate_buffer_name(&self) -> Result<String, StoreError> {
+        let room = self.room.clone();
+        let room_name = block_on(room.display_name())?;
+
+        let room_name = if room_name == "#" {
+            "##".to_owned()
+        } else if room_name.starts_with('#') || room.is_direct() {
+            room_name
+        } else {
+            format!("#{}", room_name)
+        };
+
+        Ok(room_name)
+    }
+
+    pub fn update_buffer_name(&self) {
+        let buffer = self.buffer_handle();
+
+        let buffer = if let Ok(b) = buffer.upgrade() {
+            b
+        } else {
+            return;
+        };
+
+        match self.calculate_buffer_name() {
+            Ok(name) => buffer.set_short_name(&name),
+            Err(e) => {
+                Weechat::print(&format!(
+                    "{}: Error fetching the room name from the store: {}",
+                    Weechat::prefix(Prefix::Error),
+                    e.to_string(),
+                ));
+            }
+        }
+    }
+
+    pub fn replace_verification_event(
+        &self,
+        event_id: &EventId,
+        event: RenderedEvent,
+    ) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            let event_id_tag = Cow::from(event_id.to_tag());
+
+            let lines: Vec<BufferLine> = buffer
+                .lines()
+                .filter(|l| l.tags().contains(&event_id_tag))
+                .collect();
+
+            self.replace_event_helper(&buffer, lines, event);
+        }
+    }
+
+    pub fn print_rendered_event(&self, rendered: RenderedEvent) {
+        let buffer = self.buffer_handle();
+
+        if let Ok(buffer) = buffer.upgrade() {
+            for line in rendered.content.lines {
+                let message = format!("{}{}", &rendered.prefix, &line.message);
+                let tags: Vec<&str> =
+                    line.tags.iter().map(|t| t.as_str()).collect();
+                buffer.print_date_tags(
+                    rendered.message_timestamp,
+                    &tags,
+                    &message,
+                )
+            }
+        }
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -22,11 +22,15 @@
 //! we're sending ourselves before we receive them in a sync response, or if we
 //! decrypt a previously undecryptable event.
 
+mod buffer;
 mod members;
+mod verification;
 
+use buffer::RoomBuffer;
 use members::Members;
 pub use members::WeechatRoomMember;
 use tracing::{debug, trace};
+use verification::Verification;
 
 use std::{
     borrow::Cow,
@@ -38,7 +42,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Mutex, MutexGuard,
     },
-    time::SystemTime,
 };
 
 use futures::executor::block_on;
@@ -49,20 +52,23 @@ use url::Url;
 use matrix_sdk::{
     async_trait,
     deserialized_responses::AmbiguityChange,
-    events::{
-        room::{
-            member::MemberEventContent,
-            message::{
-                MessageEventContent, MessageType, TextMessageEventContent,
-            },
-            redaction::SyncRedactionEvent,
-        },
-        AnyMessageEventContent, AnyRedactedSyncMessageEvent, AnyRoomEvent,
-        AnySyncMessageEvent, AnySyncRoomEvent, AnySyncStateEvent,
-        SyncMessageEvent, SyncStateEvent,
-    },
-    identifiers::{EventId, RoomAliasId, RoomId, UserId},
     room::Joined,
+    ruma::{
+        events::{
+            room::{
+                member::MemberEventContent,
+                message::{
+                    MessageEventContent, MessageType, TextMessageEventContent,
+                },
+                redaction::SyncRedactionEvent,
+            },
+            AnyMessageEventContent, AnyRedactedSyncMessageEvent, AnyRoomEvent,
+            AnySyncMessageEvent, AnySyncRoomEvent, AnySyncStateEvent,
+            SyncMessageEvent, SyncStateEvent,
+        },
+        identifiers::{EventId, RoomAliasId, RoomId, UserId},
+        MilliSecondsSinceUnixEpoch,
+    },
     uuid::Uuid,
     StoreError,
 };
@@ -70,7 +76,7 @@ use matrix_sdk::{
 use weechat::{
     buffer::{
         Buffer, BufferBuilderAsync, BufferHandle, BufferInputCallbackAsync,
-        BufferLine, LineData,
+        BufferLine,
     },
     Weechat,
 };
@@ -79,7 +85,7 @@ use crate::{
     config::{Config, RedactionStyle},
     connection::Connection,
     render::{Render, RenderedEvent},
-    utils::{Edit, ToTag},
+    utils::{Edit, VerificationEvent},
     PLUGIN_NAME,
 };
 
@@ -149,7 +155,7 @@ pub struct MatrixRoom {
     room_id: Rc<RoomId>,
     own_user_id: Rc<UserId>,
     room: Joined,
-    buffer: Rc<RefCell<Option<BufferHandle>>>,
+    buffer: RoomBuffer,
 
     config: Rc<RefCell<Config>>,
     connection: Rc<RefCell<Option<Connection>>>,
@@ -160,6 +166,7 @@ pub struct MatrixRoom {
     outgoing_messages: MessageQueue,
 
     members: Members,
+    verification: Verification,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -197,13 +204,23 @@ impl RoomHandle {
         room_id: RoomId,
         own_user_id: &UserId,
     ) -> Self {
-        let members = Members::new(room.clone());
+        let buffer = RoomBuffer::new(room.clone());
+        let members = Members::new(room.clone(), buffer.clone());
 
         let own_nick = block_on(room.get_member_no_sync(own_user_id))
             .ok()
             .flatten()
             .map(|m| m.name().to_owned())
             .unwrap_or_else(|| own_user_id.localpart().to_owned());
+
+        let own_user_id: Rc<UserId> = own_user_id.to_owned().into();
+
+        let verification = Verification::new(
+            own_user_id.clone(),
+            connection.clone(),
+            members.clone(),
+            buffer.clone(),
+        );
 
         let room = MatrixRoom {
             homeserver: Rc::new(homeserver),
@@ -213,9 +230,10 @@ impl RoomHandle {
             prev_batch: Rc::new(RefCell::new(
                 room.last_prev_batch().map(PrevBatch::Backwards),
             )),
-            own_user_id: Rc::new(own_user_id.to_owned()),
-            members: members.clone(),
-            buffer: members.buffer,
+            own_user_id,
+            members,
+            buffer,
+            verification,
             outgoing_messages: MessageQueue::new(),
             messages_in_flight: IntMutex::new(),
             room,
@@ -283,7 +301,7 @@ impl RoomHandle {
             buffer.set_localvar("alias", alias.as_str());
         }
 
-        *room.members.buffer.borrow_mut() = Some(buffer_handle.clone());
+        *room.buffer.inner.borrow_mut() = Some(buffer_handle.clone());
 
         Self {
             inner: room,
@@ -325,8 +343,8 @@ impl RoomHandle {
         *room_buffer.prev_batch.borrow_mut() =
             prev_batch.map(PrevBatch::Forward);
 
-        room_buffer.update_buffer_name();
-        room_buffer.set_topic();
+        room_buffer.buffer.update_buffer_name();
+        room_buffer.buffer.set_topic();
 
         Ok(room_buffer)
     }
@@ -367,28 +385,21 @@ impl MatrixRoom {
     }
 
     pub fn buffer_handle(&self) -> BufferHandle {
-        self.buffer
-            .borrow()
-            .as_ref()
-            .expect("Room struct wasn't initialized properly")
-            .clone()
+        self.buffer.buffer_handle()
     }
 
-    fn print_rendered_event(&self, rendered: RenderedEvent) {
-        let buffer = self.buffer_handle();
+    pub fn accept_verification(&self) {
+        let verification = self.verification.clone();
+        Weechat::spawn(async move { verification.accept().await }).detach();
+    }
 
-        if let Ok(buffer) = buffer.upgrade() {
-            for line in rendered.content.lines {
-                let message = format!("{}{}", &rendered.prefix, &line.message);
-                let tags: Vec<&str> =
-                    line.tags.iter().map(|t| t.as_str()).collect();
-                buffer.print_date_tags(
-                    rendered.message_timestamp,
-                    &tags,
-                    &message,
-                )
-            }
-        }
+    pub fn confirm_verification(&self) {
+        let verification = self.verification.clone();
+        Weechat::spawn(async move { verification.confirm().await }).detach();
+    }
+
+    pub fn cancel_verification(&self) {
+        todo!()
     }
 
     async fn redact_event(&self, event: &SyncRedactionEvent) {
@@ -488,7 +499,7 @@ impl MatrixRoom {
     async fn render_message_content(
         &self,
         event_id: &EventId,
-        send_time: &SystemTime,
+        send_time: &MilliSecondsSinceUnixEpoch,
         sender: &WeechatRoomMember,
         content: &AnyMessageEventContent,
     ) -> Option<RenderedEvent> {
@@ -592,7 +603,7 @@ impl MatrixRoom {
                 let local_echo = c
                     .render_with_prefix_for_echo(&sender, uuid, &())
                     .add_self_tags();
-                self.print_rendered_event(local_echo);
+                self.buffer.print_rendered_event(local_echo);
 
                 self.outgoing_messages.add_with_echo(uuid, content.clone());
             } else {
@@ -742,12 +753,12 @@ impl MatrixRoom {
 
                 if let Some(PrevBatch::Forward(t)) = prev_batch.as_ref() {
                     *prev_batch = Some(PrevBatch::Backwards(t.to_owned()));
-                    self.sort_messages();
+                    self.buffer.sort_messages();
                 } else if r.chunk.is_empty() {
                     *prev_batch = None;
                 } else {
                     *prev_batch = r.end.map(PrevBatch::Backwards);
-                    self.sort_messages();
+                    self.buffer.sort_messages();
                 }
             }
         }
@@ -758,80 +769,11 @@ impl MatrixRoom {
         Weechat::bar_item_update("matrix_modes");
     }
 
-    fn sort_messages(&self) {
-        struct LineCopy {
-            date: i64,
-            date_printed: i64,
-            tags: Vec<String>,
-            prefix: String,
-            message: String,
-        }
-
-        impl<'a> From<BufferLine<'a>> for LineCopy {
-            fn from(line: BufferLine) -> Self {
-                Self {
-                    date: line.date(),
-                    date_printed: line.date_printed(),
-                    message: line.message().to_string(),
-                    prefix: line.prefix().to_string(),
-                    tags: line.tags().iter().map(|t| t.to_string()).collect(),
-                }
-            }
-        }
-
-        // TODO update the highlight once Weechat starts supporting it.
-        if let Ok(buffer) = self.buffer_handle().upgrade() {
-            let mut lines: Vec<LineCopy> =
-                buffer.lines().map(|l| l.into()).collect();
-            lines.sort_by_key(|l| l.date);
-
-            for (line, new) in buffer.lines().zip(lines.drain(..)) {
-                let tags =
-                    new.tags.iter().map(|t| t.as_str()).collect::<Vec<&str>>();
-                let data = LineData {
-                    prefix: Some(&new.prefix),
-                    message: Some(&new.message),
-                    date: Some(new.date),
-                    date_printed: Some(new.date_printed),
-                    tags: Some(&tags),
-                };
-                line.update(data)
-            }
-        }
-    }
-
-    /// Replace the local echo of an event with a fully rendered one.
-    fn replace_local_echo(
-        &self,
-        uuid: Uuid,
-        buffer: &Buffer,
-        rendered: RenderedEvent,
-    ) {
-        let uuid_tag = Cow::from(format!("matrix_echo_{}", uuid.to_string()));
-        let line_contains_uuid = |l: &BufferLine| l.tags().contains(&uuid_tag);
-
-        let mut lines = buffer.lines();
-        let mut current_line = lines.rfind(line_contains_uuid);
-
-        // We go in reverse order here since we also use rfind(). We got from
-        // the bottom of the buffer to the top since we're expecting these
-        // lines to be freshly printed and thus at the bottom.
-        let mut line_num = rendered.content.lines.len();
-
-        while let Some(line) = &current_line {
-            line_num -= 1;
-            let rendered_line = &rendered.content.lines[line_num];
-
-            line.set_message(&rendered_line.message);
-            current_line = lines.next_back().filter(line_contains_uuid);
-        }
-    }
-
     async fn handle_outgoing_message(&self, uuid: Uuid, event_id: &EventId) {
         if let Some((echo, content)) = self.outgoing_messages.remove(uuid) {
             let event = SyncMessageEvent {
                 sender: (&*self.own_user_id).clone(),
-                origin_server_ts: std::time::SystemTime::now(),
+                origin_server_ts: MilliSecondsSinceUnixEpoch::now(),
                 event_id: event_id.clone(),
                 content,
                 unsigned: Default::default(),
@@ -844,100 +786,11 @@ impl MatrixRoom {
                 .await
                 .expect("Sent out an event that we don't know how to render");
 
-            if let Ok(buffer) = self.buffer_handle().upgrade() {
-                if echo {
-                    self.replace_local_echo(uuid, &buffer, rendered);
-                } else {
-                    self.print_rendered_event(rendered);
-                }
+            if echo {
+                self.buffer.replace_local_echo(uuid, rendered);
+            } else {
+                self.buffer.print_rendered_event(rendered);
             }
-        }
-    }
-
-    fn set_topic(&self) {
-        if let Ok(buffer) = self.buffer_handle().upgrade() {
-            buffer.set_title(&self.room().topic().unwrap_or_default());
-        }
-    }
-
-    fn set_alias(&self) {
-        if let Some(alias) = self.alias() {
-            if let Ok(b) = self.buffer_handle().upgrade() {
-                b.set_localvar("alias", alias.as_str());
-            }
-        }
-    }
-
-    fn update_buffer_name(&self) {
-        self.members.update_buffer_name();
-    }
-
-    fn replace_edit(
-        &self,
-        event_id: &EventId,
-        sender: &UserId,
-        event: RenderedEvent,
-    ) {
-        if let Ok(buffer) = self.buffer_handle().upgrade() {
-            let sender_tag = Cow::from(sender.to_tag());
-            let event_id_tag = Cow::from(event_id.to_tag());
-
-            let lines: Vec<BufferLine> = buffer
-                .lines()
-                .filter(|l| l.tags().contains(&event_id_tag))
-                .collect();
-
-            if lines
-                .get(0)
-                .map(|l| l.tags().contains(&sender_tag))
-                .unwrap_or(false)
-            {
-                self.replace_event_helper(&buffer, lines, event);
-            }
-        }
-    }
-
-    fn replace_event_helper(
-        &self,
-        buffer: &Buffer,
-        lines: Vec<BufferLine<'_>>,
-        event: RenderedEvent,
-    ) {
-        use std::cmp::Ordering;
-        let date = lines.get(0).map(|l| l.date()).unwrap_or_default();
-
-        for (line, new) in lines.iter().zip(event.content.lines.iter()) {
-            let tags: Vec<&str> = new.tags.iter().map(|t| t.as_str()).collect();
-            let data = LineData {
-                // Our prefixes always come with a \t character, but when we
-                // replace stuff we're able to replace the prefix and the
-                // message separately, so trim the whitespace in the prefix.
-                prefix: Some(event.prefix.trim_end()),
-                message: Some(&new.message),
-                tags: Some(&tags),
-                ..Default::default()
-            };
-
-            line.update(data);
-        }
-
-        match lines.len().cmp(&event.content.lines.len()) {
-            Ordering::Greater => {
-                for line in &lines[event.content.lines.len()..] {
-                    line.set_message("");
-                }
-            }
-            Ordering::Less => {
-                for line in &event.content.lines[lines.len()..] {
-                    let message = format!("{}{}", &event.prefix, &line.message);
-                    let tags: Vec<&str> =
-                        line.tags.iter().map(|t| t.as_str()).collect();
-                    buffer.print_date_tags(date, &tags, &message)
-                }
-
-                self.sort_messages()
-            }
-            Ordering::Equal => (),
         }
     }
 
@@ -968,7 +821,7 @@ impl MatrixRoom {
                     }
                 })
             {
-                self.replace_edit(event_id, event.sender(), rendered);
+                self.buffer.replace_edit(event_id, event.sender(), rendered);
             }
         }
     }
@@ -986,10 +839,12 @@ impl MatrixRoom {
 
         if let AnySyncMessageEvent::RoomRedaction(r) = event {
             self.redact_event(r).await;
+        } else if event.is_verification() {
+            self.verification.handle_room_verification(event).await;
         } else if event.is_edit() {
             self.handle_edits(event).await;
         } else if let Some(rendered) = self.render_sync_message(event).await {
-            self.print_rendered_event(rendered);
+            self.buffer.print_rendered_event(rendered);
         }
     }
 
@@ -1016,7 +871,7 @@ impl MatrixRoom {
                 &redacter,
             );
 
-            self.print_rendered_event(rendered);
+            self.buffer.print_rendered_event(rendered);
         }
     }
 
@@ -1079,7 +934,7 @@ impl MatrixRoom {
                         )
                         .await
                     {
-                        self.print_rendered_event(rendered);
+                        self.buffer.print_rendered_event(rendered);
                     }
                 }
             }
@@ -1100,9 +955,9 @@ impl MatrixRoom {
         _state_event: bool,
     ) {
         match event {
-            AnySyncStateEvent::RoomName(_) => self.update_buffer_name(),
-            AnySyncStateEvent::RoomTopic(_) => self.set_topic(),
-            AnySyncStateEvent::RoomCanonicalAlias(_) => self.set_alias(),
+            AnySyncStateEvent::RoomName(_) => self.buffer.update_buffer_name(),
+            AnySyncStateEvent::RoomTopic(_) => self.buffer.set_topic(),
+            AnySyncStateEvent::RoomCanonicalAlias(_) => self.buffer.set_alias(),
             _ => (),
         }
     }

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -1,0 +1,209 @@
+use std::{cell::RefCell, rc::Rc};
+
+use matrix_sdk::{
+    ruma::{
+        events::{
+            key::verification::VerificationMethod, room::message::MessageType,
+            AnySyncMessageEvent,
+        },
+        identifiers::UserId,
+    },
+    verification::{SasVerification, VerificationRequest},
+};
+
+use crate::{
+    connection::Connection,
+    render::{Render, StartVerificationContext, VerificationContext},
+};
+
+use super::{buffer::RoomBuffer, members::Members};
+
+#[derive(Clone)]
+pub struct Verification {
+    own_user_id: Rc<UserId>,
+    connection: Rc<RefCell<Option<Connection>>>,
+    members: Members,
+    buffer: RoomBuffer,
+    inner: Rc<RefCell<Option<ActiveVerification>>>,
+}
+
+#[derive(Clone, Debug)]
+enum ActiveVerification {
+    Request(VerificationRequest),
+    Sas(SasVerification),
+}
+
+impl From<VerificationRequest> for ActiveVerification {
+    fn from(v: VerificationRequest) -> Self {
+        Self::Request(v)
+    }
+}
+
+impl From<SasVerification> for ActiveVerification {
+    fn from(v: SasVerification) -> Self {
+        Self::Sas(v)
+    }
+}
+
+impl Verification {
+    pub fn new(
+        own_user_id: Rc<UserId>,
+        connection: Rc<RefCell<Option<Connection>>>,
+        members: Members,
+        buffer: RoomBuffer,
+    ) -> Self {
+        Self {
+            own_user_id,
+            connection,
+            members,
+            buffer,
+            inner: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    pub async fn confirm(&self) {
+        let connection = self.connection.borrow().clone();
+
+        if let Some(c) = connection {
+            if let Some(ActiveVerification::Sas(verification)) =
+                self.inner.borrow().clone()
+            {
+                let ret =
+                    c.spawn(async move { verification.confirm().await }).await;
+            }
+        }
+    }
+
+    pub async fn accept(&self) {
+        let connection = self.connection.borrow().clone();
+        let verification = self.inner.borrow().clone();
+
+        if let Some(c) = connection {
+            if let Some(ActiveVerification::Request(verification)) =
+                verification
+            {
+                let verification_clone = verification.clone();
+
+                let ret = c
+                    .spawn(async move {
+                        verification
+                            .accept_with_methods(vec![
+                                VerificationMethod::SasV1,
+                            ])
+                            .await
+                    })
+                    .await;
+
+                // We automatically start SAS verification here since it's the
+                // only method we support.
+                if let Some(sas) = c
+                    .spawn(async move { verification_clone.start_sas().await })
+                    .await
+                    .unwrap()
+                {
+                    *self.inner.borrow_mut() = Some(sas.into());
+                }
+            }
+        }
+    }
+
+    pub async fn handle_room_verification(&self, event: &AnySyncMessageEvent) {
+        // TODO remove this expect.
+        let sender =
+            self.members.get(event.sender()).await.expect(
+                "Rendering a message but the sender isn't in the nicklist",
+            );
+        let own_member = self
+            .members
+            .get(&self.own_user_id)
+            .await
+            .expect("Own member missing from the store");
+        let send_time = event.origin_server_ts();
+        let connection = self.connection.borrow().clone();
+
+        match event {
+            AnySyncMessageEvent::KeyVerificationReady(_) => {}
+            AnySyncMessageEvent::KeyVerificationStart(e) => {
+                if let Some(connection) = connection {
+                    let flow_id = &e.content.relates_to.event_id;
+
+                    if let Some(sas) = connection
+                        .client()
+                        .get_verification(&e.sender, flow_id.as_str())
+                        .await
+                        .map(|s| s.sas())
+                        .flatten()
+                    {
+                        let context = StartVerificationContext::Room(
+                            e.sender.to_owned(),
+                            sas.clone().into(),
+                        );
+                        let rendered = e.content.render_with_prefix(
+                            send_time,
+                            event.event_id(),
+                            &sender,
+                            &context,
+                        );
+                        self.buffer
+                            .replace_verification_event(flow_id, rendered);
+                        *self.inner.borrow_mut() = Some(sas.clone().into());
+
+                        // We accept here automatically since the only method
+                        // we're supporting is SAS verification
+                        let ret = connection
+                            .spawn(async move { sas.accept().await })
+                            .await;
+                    }
+                }
+            }
+            AnySyncMessageEvent::KeyVerificationCancel(_) => {
+                self.inner.borrow_mut().take();
+            }
+            AnySyncMessageEvent::KeyVerificationAccept(_) => {}
+            AnySyncMessageEvent::KeyVerificationKey(e) => {
+                let flow_id = &e.content.relates_to.event_id;
+                if let Some(ActiveVerification::Sas(sas)) =
+                    self.inner.borrow().clone()
+                {
+                    if sas.can_be_presented() {
+                        let rendered = e.content.render_with_prefix(
+                            send_time,
+                            event.event_id(),
+                            &sender,
+                            &sas,
+                        );
+                        self.buffer
+                            .replace_verification_event(flow_id, rendered);
+                    }
+                }
+            }
+            AnySyncMessageEvent::KeyVerificationMac(_) => {}
+            AnySyncMessageEvent::KeyVerificationDone(_) => {}
+            AnySyncMessageEvent::RoomMessage(e) => {
+                if let MessageType::VerificationRequest(content) =
+                    &e.content.msgtype
+                {
+                    let rendered = content.render_with_prefix(
+                        send_time,
+                        &e.event_id,
+                        &sender.clone(),
+                        &VerificationContext::Room(sender, own_member),
+                    );
+                    self.buffer.print_rendered_event(rendered);
+
+                    if let Some(connection) = connection {
+                        if let Some(verification) = connection
+                            .client()
+                            .get_verification_request(&e.sender, &e.event_id)
+                            .await
+                        {
+                            *self.inner.borrow_mut() =
+                                Some(verification.into());
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -872,6 +872,12 @@ impl InnerServer {
     }
 
     pub async fn devices(&self) {
+        enum DeviceTrust {
+            Verified,
+            Unverified,
+            Unsupported,
+        }
+
         if let Some(c) = self.connection() {
             let mut response = match c.devices().await {
                 Ok(r) => r,
@@ -909,11 +915,15 @@ impl InnerServer {
                 )
                 .expect("Can't get device color");
 
-                let last_seen_date =
-                    device_info.last_seen_ts.map_or("?".to_owned(), |d| {
-                        let date: DateTime<Utc> = d.into();
-                        date.format("%Y/%m/%d %H:%M").to_string()
-                    });
+                let last_seen_date = device_info
+                    .last_seen_ts
+                    .and_then(|d| {
+                        d.to_system_time().map(|d| {
+                            let date: DateTime<Utc> = d.into();
+                            date.format("%Y/%m/%d %H:%M").to_string()
+                        })
+                    })
+                    .unwrap_or_else(|| "?".to_string());
 
                 let last_seen = format!(
                     "{} @ {}",
@@ -943,32 +953,87 @@ impl InnerServer {
                             d.get_key(DeviceKeyAlgorithm::Ed25519).cloned()
                         })
                         .flatten()
-                }
-                .unwrap_or_else(|| "-".to_owned());
+                };
 
-                let fingerprint = fingerprint
-                    .chars()
-                    .collect::<Vec<char>>()
-                    .chunks(4)
-                    .map(|c| c.iter().collect::<String>())
-                    .collect::<Vec<String>>()
-                    .join(" ");
+                let verified = if is_own_device {
+                    DeviceTrust::Verified
+                } else {
+                    c.client()
+                        .get_device(&own_user_id, &device_info.device_id)
+                        .await
+                        .unwrap()
+                        .map(|d| {
+                            if d.is_trusted() {
+                                DeviceTrust::Verified
+                            } else {
+                                DeviceTrust::Unverified
+                            }
+                        })
+                        .unwrap_or(DeviceTrust::Unsupported)
+                };
+
+                let verified = match verified {
+                    DeviceTrust::Verified => {
+                        format!(
+                            "{}Trusted{}",
+                            Weechat::color("green"),
+                            Weechat::color("reset")
+                        )
+                    }
+                    DeviceTrust::Unverified => {
+                        format!(
+                            "{}Not trusted{}",
+                            Weechat::color("red"),
+                            Weechat::color("reset")
+                        )
+                    }
+                    DeviceTrust::Unsupported => {
+                        format!(
+                            "{}No encryption support{}",
+                            Weechat::color("darkgray"),
+                            Weechat::color("reset")
+                        )
+                    }
+                };
+
+                let fingerprint = if let Some(fingerprint) = fingerprint {
+                    let fingerprint = fingerprint
+                        .chars()
+                        .collect::<Vec<char>>()
+                        .chunks(4)
+                        .map(|c| c.iter().collect::<String>())
+                        .collect::<Vec<String>>()
+                        .join(" ");
+
+                    format!(
+                        "{}{}{}",
+                        Weechat::color("magenta"),
+                        fingerprint,
+                        Weechat::color("reset")
+                    )
+                } else {
+                    format!(
+                        "{}-{}",
+                        Weechat::color("darkgray"),
+                        Weechat::color("reset")
+                    )
+                };
 
                 let info = format!(
                     "       \
                             Name: {}{}\n  \
-                       Device ID: {}{}{}\n  \
-                       Last seen: {}\n\
-                     Fingerprint: {}{}{}\n",
+                       Device ID: {}{}{}\n   \
+                        Security: {}\n\
+                     Fingerprint: {}\n  \
+                       Last seen: {}\n",
                     bold,
                     device_info.display_name.as_deref().unwrap_or(""),
                     Weechat::color(&color),
                     device_info.device_id.as_str(),
                     Weechat::color("reset"),
-                    last_seen,
-                    Weechat::color("magenta"),
+                    verified,
                     fingerprint,
-                    Weechat::color("reset"),
+                    last_seen,
                 );
 
                 lines.push(info);

--- a/src/verification_buffer.rs
+++ b/src/verification_buffer.rs
@@ -1,0 +1,375 @@
+use std::{cell::RefCell, convert::TryInto, rc::Rc};
+
+use weechat::{
+    buffer::{
+        Buffer, BufferBuilderAsync, BufferCloseCallback, BufferHandle,
+        BufferInputCallbackAsync,
+    },
+    Weechat,
+};
+
+use qrcode::render::unicode::Dense1x2;
+
+use matrix_sdk::{
+    async_trait,
+    ruma::{
+        events::{
+            key::verification::{
+                key::KeyToDeviceEventContent, VerificationMethod,
+            },
+            AnyToDeviceEvent,
+        },
+        identifiers::UserId,
+    },
+    verification::{
+        QrVerification, SasVerification, Verification as SdkVerification,
+        VerificationRequest,
+    },
+    Error,
+};
+
+use crate::{
+    connection::Connection,
+    render::{
+        Render, RenderedContent, StartVerificationContext, VerificationContext,
+    },
+};
+
+#[derive(Clone)]
+pub struct VerificationBuffer {
+    inner: InnerVerificationBuffer,
+    buffer: BufferHandle,
+}
+
+#[derive(Clone, Debug)]
+pub enum Verification {
+    Request(VerificationRequest),
+    Sas(SasVerification),
+    Qr(QrVerification),
+}
+
+impl TryInto<SdkVerification> for Verification {
+    type Error = ();
+
+    fn try_into(self) -> Result<SdkVerification, Self::Error> {
+        match self {
+            Verification::Request(_) => Err(()),
+            Verification::Sas(s) => Ok(s.into()),
+            Verification::Qr(qr) => Ok(qr.into()),
+        }
+    }
+}
+
+impl From<SasVerification> for Verification {
+    fn from(s: SasVerification) -> Self {
+        Self::Sas(s)
+    }
+}
+
+impl From<VerificationRequest> for Verification {
+    fn from(v: VerificationRequest) -> Self {
+        Self::Request(v)
+    }
+}
+
+impl From<QrVerification> for Verification {
+    fn from(v: QrVerification) -> Self {
+        Self::Qr(v)
+    }
+}
+
+impl Verification {
+    async fn accept(&self) -> Result<(), Error> {
+        match self {
+            Verification::Request(r) => r.accept().await,
+            Verification::Sas(s) => s.accept().await,
+            Verification::Qr(qr) => qr.confirm().await,
+        }
+    }
+
+    async fn generate_qr_code(&self) -> Option<QrVerification> {
+        match self {
+            Verification::Request(r) => r.generate_qr_code().await.unwrap(),
+            Verification::Sas(_) => None,
+            Verification::Qr(_) => None,
+        }
+    }
+
+    async fn cancel(&self) -> Result<(), Error> {
+        match self {
+            Verification::Request(r) => r.cancel().await,
+            Verification::Sas(s) => s.cancel().await,
+            Verification::Qr(qr) => qr.cancel().await,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct InnerVerificationBuffer {
+    verification: Rc<RefCell<Verification>>,
+    connection: Rc<RefCell<Option<Connection>>>,
+}
+
+impl InnerVerificationBuffer {
+    fn print_done(&self, buffer: BufferHandle) {}
+
+    pub async fn accept(&self, buffer: BufferHandle) -> Result<(), Error> {
+        if let Some(c) = self.connection.borrow().clone() {
+            let verification = self.verification.borrow().clone();
+            let verification_clone = verification.clone();
+
+            c.spawn(async move { verification_clone.accept().await })
+                .await?;
+
+            if let Verification::Request(request) = verification {
+                if request
+                    .their_supported_methods()
+                    .unwrap_or_default()
+                    .contains(&VerificationMethod::QrCodeShowV1)
+                {
+                    if let Some(qr_code) = request.generate_qr_code().await? {
+                        if let Ok(code) = qr_code.to_qr_code() {
+                            if let Ok(b) = buffer.upgrade() {
+                                let string = code
+                                    .render::<Dense1x2>()
+                                    .light_color(Dense1x2::Dark)
+                                    .dark_color(Dense1x2::Light)
+                                    .build();
+                                b.print(&string);
+                            }
+                        }
+                    }
+                } else {
+                    if let Some(sas) = c
+                        .spawn(async move { request.start_sas().await })
+                        .await?
+                    {
+                        *self.verification.borrow_mut() = sas.into();
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn confirm(&self, buffer: BufferHandle) -> Result<(), Error> {
+        if let Some(c) = self.connection.borrow().clone() {
+            if let Verification::Sas(s) = self.verification.borrow().clone() {
+                let sas = s.clone();
+                c.spawn(async move { s.confirm().await }).await?;
+
+                if sas.is_done() {
+                    self.print_done(buffer);
+                }
+            } else if let Verification::Qr(qr) =
+                self.verification.borrow().clone()
+            {
+                c.spawn(async move { qr.confirm().await }).await?;
+
+                // if qr.is_done() {
+                //     self.print_done(buffer);
+                // }
+            } else {
+                if let Ok(b) = buffer.upgrade() {
+                    b.print("Error, can't confirm the verification yet");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn cancel(&self) -> Result<(), Error> {
+        if let Some(c) = self.connection.borrow().clone() {
+            let verification = self.verification.borrow().clone();
+            c.spawn(async move { verification.cancel().await }).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn handle_input(
+        &mut self,
+        buffer: BufferHandle,
+        input: &str,
+    ) -> Result<(), Error> {
+        if input == "accept" {
+            self.accept(buffer).await?;
+        } else if input == "confirm" {
+            self.confirm(buffer).await?;
+        } else if input == "cancel" {
+            self.cancel().await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait(?Send)]
+impl BufferInputCallbackAsync for InnerVerificationBuffer {
+    async fn callback(&mut self, buffer: BufferHandle, input: String) {
+        if let Err(e) = self.handle_input(buffer.clone(), &input).await {
+            if let Ok(buffer) = buffer.upgrade() {
+                buffer.print(&format!(
+                    "Error with the verification flow {:?}",
+                    e
+                ));
+            }
+        }
+    }
+}
+
+impl BufferCloseCallback for InnerVerificationBuffer {
+    fn callback(&mut self, _: &Weechat, _: &Buffer) -> Result<(), ()> {
+        let inner = self.clone();
+        Weechat::spawn(async move { inner.cancel().await }).detach();
+
+        Ok(())
+    }
+}
+
+impl VerificationBuffer {
+    pub fn new(
+        server_name: &str,
+        sender: &UserId,
+        verification: impl Into<Verification>,
+        connection: Rc<RefCell<Option<Connection>>>,
+    ) -> Self {
+        let inner = InnerVerificationBuffer {
+            verification: Rc::new(RefCell::new(verification.into())),
+            connection,
+        };
+
+        let buffer_name = format!("{}.verification", server_name);
+
+        let buffer_handle = BufferBuilderAsync::new(&buffer_name)
+            .input_callback(inner.clone())
+            .close_callback(|_weechat: &Weechat, _buffer: &Buffer| {
+                // TODO remove the roombuffer from the server here.
+                // TODO leave the room if the plugin isn't unloading.
+                Ok(())
+            })
+            .build()
+            .expect("Can't create new room buffer");
+
+        let buffer = buffer_handle
+            .upgrade()
+            .expect("Can't upgrade newly created buffer");
+
+        buffer.disable_nicklist();
+        buffer.disable_nicklist_groups();
+        buffer.enable_multiline();
+
+        buffer.set_localvar("server", server_name);
+
+        Self {
+            inner,
+            buffer: buffer_handle,
+        }
+    }
+
+    pub fn buffer(&self) -> BufferHandle {
+        self.buffer.clone()
+    }
+
+    pub fn accept(&self) {
+        let buffer = self.buffer();
+        let inner = self.inner.clone();
+        Weechat::spawn(async move { inner.accept(buffer).await }).detach();
+    }
+
+    pub fn cancel(&self) {
+        let inner = self.inner.clone();
+        Weechat::spawn(async move { inner.cancel().await }).detach();
+    }
+
+    pub fn confirm(&self) {
+        let buffer = self.buffer();
+        let inner = self.inner.clone();
+        Weechat::spawn(async move { inner.confirm(buffer).await }).detach();
+    }
+
+    pub async fn update_qr(&mut self, qr: QrVerification) {
+        *self.inner.verification.borrow_mut() = qr.into();
+    }
+
+    pub async fn update(&mut self, sas: SasVerification) -> Result<(), Error> {
+        *self.inner.verification.borrow_mut() = sas.into();
+        let verification = self.inner.verification.borrow().clone();
+
+        if let Some(c) = self.inner.connection.borrow().clone() {
+            c.spawn(async move { verification.accept().await }).await?;
+        } else {
+            // TODO print an error
+        }
+
+        Ok(())
+    }
+
+    pub async fn handle_event(&self, event: &AnyToDeviceEvent) {
+        match event {
+            AnyToDeviceEvent::KeyVerificationRequest(e) => {
+                if let Verification::Request(request) =
+                    self.inner.verification.borrow().clone()
+                {
+                    let content = e
+                        .content
+                        .render(&VerificationContext::ToDevice(request));
+
+                    self.print(&content);
+                }
+            }
+            AnyToDeviceEvent::KeyVerificationStart(e) => {
+                let verification = self.inner.verification.borrow().clone();
+
+                if let Ok(verification) = verification.try_into() {
+                    let content =
+                        e.content.render(&StartVerificationContext::ToDevice(
+                            e.sender.clone(),
+                            verification,
+                        ));
+
+                    self.print(&content);
+                }
+            }
+            AnyToDeviceEvent::KeyVerificationCancel(_) => {
+                // let message =
+                //     format!("The verification flow has been canceled");
+                // self.print(&message);
+            }
+            AnyToDeviceEvent::KeyVerificationKey(e) => {
+                self.print_sas(&e.content);
+            }
+            AnyToDeviceEvent::KeyVerificationMac(_) => {
+                if let Verification::Sas(sas) =
+                    self.inner.verification.borrow().clone()
+                {
+                    if sas.is_done() {
+                        self.inner.print_done(self.buffer.clone());
+                    }
+                }
+            }
+            AnyToDeviceEvent::KeyVerificationDone(_) => {}
+            _ => {}
+        }
+    }
+
+    fn print(&self, message: &RenderedContent) {
+        if let Ok(buffer) = self.buffer.upgrade() {
+            for line in &message.lines {
+                buffer.print_date_tags(0, &[], &line.message);
+            }
+        } else {
+            Weechat::print("BUFFER CLOSED");
+        }
+    }
+
+    fn print_sas(&self, content: &KeyToDeviceEventContent) {
+        if let Verification::Sas(sas) = self.inner.verification.borrow().clone()
+        {
+            let message = content.render(&sas);
+            self.print(&message);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for interactive verification, this needs a couple of things for everything to work correctly:

- [x] React to verification requests over to-device messaging
- [x] React to verification requests in DMs
- [ ] Command to request self verifications (this is over to-device messaging)
- [ ] Command to request verification of other users
- [x] Command to accept/cancel/confirm active verifications
- [x] Support rendering of emoji verifications
- [x] Support rendering of QR code verifications

![weechat-emoji](https://user-images.githubusercontent.com/552026/127544868-8a4991c4-c252-4cab-bf34-3f0a6c777330.png)
![weechat-qr](https://user-images.githubusercontent.com/552026/127544887-99681282-6258-4fe4-83ee-67a3d05d4e9e.png)

The command to control an active verification is called `/verification` it has the `accept`, `confirm`, `cancel`, and `use-emoji` subcommands.

The plan for the command that enables verifications to be requested should be called `/verify`:

`/verify <user_id> [<device_id>] [-fingerprint <device fingerprint>]`.

This would allow us to request verification with a user, or with a specific device if the device id is given, alternatively if we provide a fingerprint using the `-fingerprint` switch a user or device is manually marked as verified.

This closes: #32.
