### PR TITLE
Added type localvar and updated github action to include ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, ubuntu-latest]
         include:
           - os: ubuntu-18.04
             artifact_name: libmatrix.so
             asset_name: libmatrix.so-ubuntu-18.04
+          - os: ubuntu-latest
+            artifact_name: libmatrix.so
+            asset_name: libmatrix.so-ubuntu-latest
         rust:
           - stable
       fail-fast: false
@@ -54,14 +57,8 @@ jobs:
           command: test
           args: --release
 
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
         with:
-          release_name: ${{ matrix.artifact_name }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref }}
-          overwrite: true
-          prerelease: true
-          body: Unstable binary for `${{ matrix.os }}` built against `${{ steps.build_env.outputs.W_API_V }}`. Rename it to `matrix.so` and put it inside `$WEECHAT_HOME/plugins`
+          name: 'libmatrix.so-${{ matrix.os }}'
+          path: target/release/libmatrix.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,37 @@
-on: [push]
+on: [push, pull_request]
 
 name: build-test-release
 
 jobs:
-  x86_64_glibc:
-    name: Ubuntu 18.04 (glibc)
-    runs-on: ubuntu-18.04
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-18.04]
+        include:
+          - os: ubuntu-18.04
+            artifact_name: libmatrix.so
+            asset_name: libmatrix.so-ubuntu-18.04
         rust:
           - stable
+      fail-fast: false
+
     steps:
-      - name: Install latest-stable weechat for Ubuntu 18.04
+      - name: Install latest-stable weechat for Ubuntu
+        id: build_env
         run: |
           sudo apt update
           sudo apt install dirmngr gpg-agent apt-transport-https
           sudo apt-key adv --keyserver hkps://keys.openpgp.org --recv-keys 11E9DE8848F2B65222AA75B8D1820DB22A11534E
-          echo "deb https://weechat.org/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/weechat.list
-          echo "deb-src https://weechat.org/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/weechat.list
+          echo "deb https://weechat.org/ubuntu $(lsb_release -c | awk '{ print $NF }') main" | sudo tee /etc/apt/sources.list.d/weechat.list
+          echo "deb-src https://weechat.org/ubuntu $(lsb_release -c | awk '{ print $NF }') main" | sudo tee -a /etc/apt/sources.list.d/weechat.list
           sudo apt update
           sudo apt install weechat-curses weechat-plugins weechat-python weechat-perl weechat-dev
           echo "version of weechat-plugin.h that weechat-sys uses by default:"
           grep -m 1 -n -H "WEECHAT_PLUGIN_API_VERSION" "/usr/include/weechat/weechat-plugin.h"
+          v="$(grep -m 1 -o  'WEECHAT_PLUGIN_API_VERSION.*' '/usr/include/weechat/weechat-plugin.h')"
+          echo "::set-output name=W_API_V::$v"
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -44,8 +54,14 @@ jobs:
           command: test
           args: --release
 
-      - name: Upload binary
-        uses: actions/upload-artifact@v2
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          name: 'weechat-matrix-rs-x86_64-unknown-linux-gnu'
-          path: target/release/libmatrix.so
+          release_name: ${{ matrix.artifact_name }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          prerelease: true
+          body: Unstable binary for `${{ matrix.os }}` built against `${{ steps.build_env.outputs.W_API_V }}`. Rename it to `matrix.so` and put it inside `$WEECHAT_HOME/plugins`

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -278,6 +278,11 @@ impl RoomHandle {
         buffer.set_localvar("nick", &own_nick);
         buffer.set_localvar("domain", room.room_id().server_name().as_str());
         buffer.set_localvar("room_id", room.room_id().as_str());
+        if room.is_direct() {
+            buffer.set_localvar("type", "private")
+        } else {
+            buffer.set_localvar("type", "channel")
+        }
 
         if let Some(alias) = room.alias() {
             buffer.set_localvar("alias", alias.as_str());
@@ -356,6 +361,10 @@ impl MatrixRoom {
 
     pub fn is_public(&self) -> bool {
         self.room.is_public()
+    }
+
+    pub fn is_direct(&self) -> bool {
+        self.room.is_direct()
     }
 
     pub fn alias(&self) -> Option<RoomAliasId> {


### PR DESCRIPTION
localvar `type` is introduced. For DMs, it is set to `private` and for non-DMs, it is set to `channel`.  
Note that I'm not familiar with Rust; I've added `is_direct` to `MatrixRoom` and I assume it uses https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_base/struct.Room.html#method.is_direct 

Also, the workflow is updated to upload the binary directly to the Releases.