### PR TITLE
fix(commands): Require a subcommand even if the command is a /matrix subcommand.

### DIFF
--- a/src/commands/devices.rs
+++ b/src/commands/devices.rs
@@ -21,6 +21,13 @@ impl DevicesCommand {
     pub const DESCRIPTION: &'static str =
         "List, delete or rename Matrix devices";
 
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
+
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("devices")
             .description(Self::DESCRIPTION)
@@ -115,10 +122,7 @@ impl CommandCallback for DevicesCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("devices")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {

--- a/src/commands/keys.rs
+++ b/src/commands/keys.rs
@@ -21,6 +21,12 @@ pub struct KeysCommand {
 impl KeysCommand {
     pub const DESCRIPTION: &'static str = "Import or export E2EE keys.";
     pub const COMPLETION: &'static str = "import|export %(filename)";
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
 
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("keys")
@@ -116,10 +122,7 @@ impl CommandCallback for KeysCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("keys")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -272,19 +272,23 @@ impl CommandCallback for MatrixCommand {
 
         let argparse = Argparse::new("matrix")
             .about("Matrix chat protocol command.")
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
+            .global_settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+                ArgParseSettings::VersionlessSubcommands,
+            ])
             .setting(ArgParseSettings::SubcommandRequiredElseHelp)
             .subcommand(server_command)
             .subcommand(
                 SubCommand::with_name("devices")
                     .about(DevicesCommand::DESCRIPTION)
+                    .settings(DevicesCommand::SETTINGS)
                     .subcommands(DevicesCommand::subcommands()),
             )
             .subcommand(
                 SubCommand::with_name("keys")
                     .about(KeysCommand::DESCRIPTION)
+                    .settings(KeysCommand::SETTINGS)
                     .subcommands(KeysCommand::subcommands()),
             )
             .subcommand(


### PR DESCRIPTION
This closes: #51.