### PR TITLE
fix: call to clone generating cargo warning

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -324,7 +324,7 @@ impl RoomHandle {
             config,
             room_clone,
             homeserver,
-            room_id.clone(),
+            room_id,
             own_user_id,
         );
 


### PR DESCRIPTION
Fixes a warning generated when compiling against rust/cargo version 1.73.0