### PR TITLE
Use XDG_CONFIG_HOME for the default WEECHAT_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-WEECHAT_HOME ?= $(HOME)/.weechat
+XDG_CONFIG_HOME ?= $(HOME)/.config
+WEECHAT_HOME ?= $(XDG_CONFIG_HOME)/weechat
 PREFIX ?= $(WEECHAT_HOME)
 
 SOURCES := $(wildcard src/*.rs src/commands/*.rs Cargo.lock)


### PR DESCRIPTION
Modern systems use that new path. For sure I know weechat 4.5.1 does, not sure since when