### PR TITLE
github: remove ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-latest]
         include:
-          - os: ubuntu-20.04
-            artifact_name: libmatrix.so
-            asset_name: libmatrix.so-ubuntu-20.04
           - os: ubuntu-22.04
             artifact_name: libmatrix.so
             asset_name: libmatrix.so-ubuntu-22.04
+          - os: ubuntu-24.04
+            artifact_name: libmatrix.so
+            asset_name: libmatrix.so-ubuntu-24.04
           - os: ubuntu-latest # currently 24.04
             artifact_name: libmatrix.so
             asset_name: libmatrix.so-ubuntu-latest


### PR DESCRIPTION
Ubuntu 20 is being deprecated
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/