### PR TITLE
docs: update README to include dev/release builds instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,28 @@
 XDG_DATA_HOME ?= $(HOME)/.local/share
 WEECHAT_DATA_DIR ?= $(XDG_DATA_HOME)/weechat
 
-SOURCES := $(wildcard src/*.rs src/commands/*.rs Cargo.lock)
+SOURCES := $(wildcard src/*.rs src/bar_items/*.rs src/commands/*.rs src/room/*.rs Cargo.lock)
 
-.PHONY: install install-dir lint
+PROFILE ?= release
 
-target/debug/libmatrix.so: $(SOURCES)
+.PHONY: install install-dir lint all help
+
+all: help
+
+help: ## Print this help message
+	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+target/debug/libmatrix.so: $(SOURCES) ## Build plugin in dev profile
 	cargo build
 
-install: install-dir target/debug/libmatrix.so
-	install -m644  target/debug/libmatrix.so $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins/matrix.so
+target/release/libmatrix.so: $(SOURCES) ## Build plugin release profile
+	cargo build --release
 
-install-dir:
+install: install-dir target/$(PROFILE)/libmatrix.so ## Install plugin to weechat dir
+	install -m644  target/$(PROFILE)/libmatrix.so $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins/matrix.so
+
+install-dir: ## Create plugins directory
 	install -d $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins
 
-lint:
+lint: ## Lint issues with clippy
 	cargo clippy

--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ If you are interested in helping out take a look at the issue tracker.
 
 After Rust is installed the plugin can be compiled with:
 
+    cargo build --release
+
+If you are developing on weechat-matrix-rs, use debug builds which are faster at the expense of plugin performance:
+
     cargo build
 
-On Linux this creates a `libmatrix.so` file in the `target/debug/` folder, this
+On Linux this creates a `libmatrix.so` file in the `target/release/` (`target/debug` for dev builds) folder, this
 file needs to be renamed to `matrix.so` and copied to your Weechat plugin
 directory. A plugin directory can be created in your `$WEECHAT_HOME` folder, by
 default `.weechat/plugins/`.
 
-Alternatively, `make install` will build and install the plugin in your
+Alternatively, `make install` (`make install PROFILE=debug` for dev build) will build and install the plugin in your
 `$WEECHAT_HOME` as well.
 
 # Configuration


### PR DESCRIPTION
Fixes #53 

also changes that `make` will display `help` target instead of building something