### PR TITLE
fix: build on rustc 1.94 and newer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Increase recursion limit to pre-rustc 1.94 level for macro expansion and auto-dereferencing.
+#![recursion_limit = "256"]
+
 mod bar_items;
 mod commands;
 mod completions;


### PR DESCRIPTION
The default compile time recursion_limit was lowered, and matrix-sdk depends on higher limits.

Fixes poljar/weechat-matrix-rs#122