### PR TITLE
fix: show help for nested verification command

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -316,6 +316,7 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("verification")
                     .about(VerificationCommand::DESCRIPTION)
+                    .settings(VerificationCommand::SETTINGS)
                     .subcommands(VerificationCommand::subcommands()),
             )
             .subcommand(

--- a/src/commands/verification.rs
+++ b/src/commands/verification.rs
@@ -26,6 +26,12 @@ impl VerificationCommand {
         "Control interactive verification flows";
 
     pub const COMPLETION: &'static str = "accept|confirm|cancel";
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
 
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("verification")
@@ -104,10 +110,7 @@ impl CommandCallback for VerificationCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
         let argparse = Argparse::new("verification")
             .about(Self::DESCRIPTION)
-            .global_setting(ArgParseSettings::DisableHelpFlags)
-            .global_setting(ArgParseSettings::DisableVersion)
-            .global_setting(ArgParseSettings::VersionlessSubcommands)
-            .setting(ArgParseSettings::SubcommandRequiredElseHelp)
+            .settings(Self::SETTINGS)
             .subcommands(Self::subcommands());
 
         parse_and_run(argparse, arguments, |matches| {


### PR DESCRIPTION
This fixes `/matrix verification` with no subcommand.

The top-level `/verification` command already asks clap to print help when `accept`, `confirm`, or `cancel` is missing. The nested `/matrix verification` command did not use the same settings, so it could reach the `unreachable!()` arm and crash.

Fixes #121.

Checked with `cargo fmt --check` and `git diff --check`.

Fix requested by @strk.
