### PR TITLE
feat: evaluate homeserver config option

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -324,21 +324,21 @@ impl MatrixServer {
         let homeserver =
             StringOptionSettings::new(format!("{}.homeserver", server_name))
                 .set_check_callback(|_, _, value| {
-                    let url = Weechat::eval_string_expression(&value)
-                        .expect("Can't evaluate homeserver");
-
-                    MatrixServer::is_url_valid(&url)
+                    Weechat::eval_string_expression(&value)
+                        .map(|value| MatrixServer::is_url_valid(&value))
+                        .unwrap_or(false)
                 })
                 .set_change_callback(move |_, option| {
                     let server_ref = server.upgrade().expect(
                         "Server got deleted while server config is alive",
                     );
 
-                    let url = Weechat::eval_string_expression(&option.value())
-                        .expect("Can't evaluate homeserver");
+                    let homeserver =
+                        Weechat::eval_string_expression(&option.value())
+                            .expect("Can't evaluate homeserver");
 
                     server_ref.settings.borrow_mut().homeserver =
-                        MatrixServer::parse_url_unchecked(&url);
+                        MatrixServer::parse_url_unchecked(&homeserver);
                 });
 
         server_section

--- a/src/server.rs
+++ b/src/server.rs
@@ -324,15 +324,21 @@ impl MatrixServer {
         let homeserver =
             StringOptionSettings::new(format!("{}.homeserver", server_name))
                 .set_check_callback(|_, _, value| {
-                    MatrixServer::is_url_valid(&value)
+                    let url = Weechat::eval_string_expression(&value)
+                        .expect("Can't evaluate homeserver");
+
+                    MatrixServer::is_url_valid(&url)
                 })
                 .set_change_callback(move |_, option| {
                     let server_ref = server.upgrade().expect(
                         "Server got deleted while server config is alive",
                     );
 
+                    let url = Weechat::eval_string_expression(&option.value())
+                        .expect("Can't evaluate homeserver");
+
                     server_ref.settings.borrow_mut().homeserver =
-                        MatrixServer::parse_url_unchecked(&option.value());
+                        MatrixServer::parse_url_unchecked(&url);
                 });
 
         server_section


### PR DESCRIPTION
This ports #111 onto current `main` without losing later verification work.

The `homeserver` config option now evaluates WeeChat string expressions before validation/storage, matching the existing username/password behavior. That allows values such as `${sec.data.my-homeserver}`.

The branch is split into sand4rt's #111 patch and a small Komzpa follow-up that keeps expression-evaluation failures from panicking the option check.

Fixes #96.

Checked with `cargo fmt --check`, `git diff --check`, and Docker `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo check --locked`.

Fix requested by @strk.
