### PR TITLE
feat: add matrix room join command

### DIFF
--- a/src/commands/join.rs
+++ b/src/commands/join.rs
@@ -1,0 +1,92 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    Prefix, ReturnCode, Weechat,
+};
+
+use crate::{Servers, PLUGIN_NAME};
+
+pub struct JoinCommand {
+    servers: Servers,
+}
+
+impl JoinCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/join *",
+            JoinCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+
+    pub fn join_room(
+        servers: &Servers,
+        buffer: &Buffer,
+        room_id_or_alias: String,
+        allow_single_server_fallback: bool,
+    ) -> bool {
+        let server = servers.find_server(buffer).or_else(|| {
+            if allow_single_server_fallback {
+                let servers = servers.borrow();
+
+                if servers.len() == 1 {
+                    return servers.values().next().cloned();
+                }
+            }
+
+            None
+        });
+
+        if let Some(server) = server {
+            Weechat::spawn(async move {
+                server.join_room(room_id_or_alias).await;
+            })
+            .detach();
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl CommandRunCallback for JoinCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        command: Cow<str>,
+    ) -> ReturnCode {
+        let Some(room_id_or_alias) = command.strip_prefix("/join ") else {
+            return ReturnCode::Ok;
+        };
+
+        let room_id_or_alias = room_id_or_alias.trim();
+
+        if room_id_or_alias.is_empty() {
+            return ReturnCode::Ok;
+        }
+
+        if Self::join_room(
+            &self.servers,
+            buffer,
+            room_id_or_alias.to_owned(),
+            false,
+        ) {
+            ReturnCode::OkEat
+        } else {
+            ReturnCode::Ok
+        }
+    }
+}
+
+pub fn print_no_join_server_error() {
+    Weechat::print(&format!(
+        "{}{}: Run /matrix join from a Matrix buffer or configure exactly one server.",
+        Weechat::prefix(Prefix::Error),
+        PLUGIN_NAME
+    ));
+}

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -10,7 +10,11 @@ use weechat::{
     Args, Prefix, Weechat,
 };
 
-use super::{parse_and_run, verification::VerificationCommand};
+use super::{
+    join::{print_no_join_server_error, JoinCommand},
+    parse_and_run,
+    verification::VerificationCommand,
+};
 use crate::{
     commands::{DevicesCommand, KeysCommand, MediaCommand},
     config::ConfigHandle,
@@ -32,7 +36,7 @@ impl MatrixCommand {
             .add_argument("server add <server-name> <hostname>[:<port>]")
             .add_argument("server delete|list|listfull <server-name>")
             .add_argument("connect <server-name>")
-            .add_argument("join <server-name> <room-id-or-alias>")
+            .add_argument("join <room-id-or-alias>")
             .add_argument("devices delete|list|set-name")
             .add_argument("keys import|export <file> <passphrase>")
             .add_argument("media download <mxc-uri> <file>")
@@ -44,7 +48,7 @@ impl MatrixCommand {
      connect: Connect to Matrix servers.
   disconnect: Disconnect from one or all Matrix servers.
    reconnect: Reconnect to server(s).
-        join: Join a Matrix room by ID or alias (e.g. #room:matrix.org).
+        join: Join a Matrix room by ID or alias.
      devices: {}
         keys: {}
        media: {}
@@ -67,7 +71,6 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("connect %(matrix_servers)")
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
-            .add_completion("join %(matrix_servers)")
             .add_completion(
                 "help server|connect|disconnect|reconnect|join|keys|devices|media",
             );
@@ -226,23 +229,19 @@ Use /matrix [command] help to find out more.\n",
         }
     }
 
-    fn join_command(&self, args: &ArgMatches) {
-        let server_name = args
-            .value_of("server")
-            .expect("Server name not set but was required");
+    fn join_command(&self, buffer: &Buffer, args: &ArgMatches) {
         let room_id_or_alias = args
             .value_of("room")
             .expect("Room not set but was required")
-            .to_string();
+            .to_owned();
 
-        if let Some(s) = self.servers.get(server_name) {
-            let server = s.clone();
-            Weechat::spawn(async move {
-                server.join_room(room_id_or_alias).await;
-            })
-            .detach();
-        } else {
-            self.server_not_found(server_name)
+        if !JoinCommand::join_room(
+            &self.servers,
+            buffer,
+            room_id_or_alias,
+            true,
+        ) {
+            print_no_join_server_error();
         }
     }
 
@@ -250,7 +249,7 @@ Use /matrix [command] help to find out more.\n",
         match args.subcommand() {
             ("connect", Some(subargs)) => self.connect_command(subargs),
             ("disconnect", Some(subargs)) => self.disconnect_command(subargs),
-            ("join", Some(subargs)) => self.join_command(subargs),
+            ("join", Some(subargs)) => self.join_command(buffer, subargs),
             ("server", Some(subargs)) => self.server_command(subargs),
             ("devices", Some(subargs)) => {
                 DevicesCommand::run(buffer, &self.servers, subargs)
@@ -363,18 +362,11 @@ impl CommandCallback for MatrixCommand {
             )
             .subcommand(
                 SubCommand::with_name("join")
-                    .about("Join a Matrix room by ID or alias.")
-                    .arg(
-                        Arg::with_name("server")
-                            .value_name("server-name")
-                            .required(true)
-                            .index(1),
-                    )
+                    .about("Join a Matrix room by ID or alias")
                     .arg(
                         Arg::with_name("room")
                             .value_name("room-id-or-alias")
-                            .required(true)
-                            .index(2),
+                            .required(true),
                     ),
             );
 

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -32,6 +32,7 @@ impl MatrixCommand {
             .add_argument("server add <server-name> <hostname>[:<port>]")
             .add_argument("server delete|list|listfull <server-name>")
             .add_argument("connect <server-name>")
+            .add_argument("join <server-name> <room-id-or-alias>")
             .add_argument("devices delete|list|set-name")
             .add_argument("keys import|export <file> <passphrase>")
             .add_argument("media download <mxc-uri> <file>")
@@ -43,6 +44,7 @@ impl MatrixCommand {
      connect: Connect to Matrix servers.
   disconnect: Disconnect from one or all Matrix servers.
    reconnect: Reconnect to server(s).
+        join: Join a Matrix room by ID or alias (e.g. #room:matrix.org).
      devices: {}
         keys: {}
        media: {}
@@ -65,8 +67,9 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("connect %(matrix_servers)")
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
+            .add_completion("join %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|keys|devices|media",
             );
 
         Command::new(
@@ -223,10 +226,31 @@ Use /matrix [command] help to find out more.\n",
         }
     }
 
+    fn join_command(&self, args: &ArgMatches) {
+        let server_name = args
+            .value_of("server")
+            .expect("Server name not set but was required");
+        let room_id_or_alias = args
+            .value_of("room")
+            .expect("Room not set but was required")
+            .to_string();
+
+        if let Some(s) = self.servers.get(server_name) {
+            let server = s.clone();
+            Weechat::spawn(async move {
+                server.join_room(room_id_or_alias).await;
+            })
+            .detach();
+        } else {
+            self.server_not_found(server_name)
+        }
+    }
+
     fn run(&self, buffer: &Buffer, args: &ArgMatches) {
         match args.subcommand() {
             ("connect", Some(subargs)) => self.connect_command(subargs),
             ("disconnect", Some(subargs)) => self.disconnect_command(subargs),
+            ("join", Some(subargs)) => self.join_command(subargs),
             ("server", Some(subargs)) => self.server_command(subargs),
             ("devices", Some(subargs)) => {
                 DevicesCommand::run(buffer, &self.servers, subargs)
@@ -335,6 +359,22 @@ impl CommandCallback for MatrixCommand {
                         Arg::with_name("name")
                             .value_name("server-name")
                             .required(true),
+                    ),
+            )
+            .subcommand(
+                SubCommand::with_name("join")
+                    .about("Join a Matrix room by ID or alias.")
+                    .arg(
+                        Arg::with_name("server")
+                            .value_name("server-name")
+                            .required(true)
+                            .index(1),
+                    )
+                    .arg(
+                        Arg::with_name("room")
+                            .value_name("room-id-or-alias")
+                            .required(true)
+                            .index(2),
                     ),
             );
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::{config::ConfigHandle, Servers};
 
 mod buffer_clear;
 mod devices;
+mod join;
 mod keys;
 mod matrix;
 mod me;
@@ -18,6 +19,7 @@ mod verification;
 
 use buffer_clear::BufferClearCommand;
 use devices::DevicesCommand;
+use join::JoinCommand;
 use keys::KeysCommand;
 use matrix::MatrixCommand;
 use me::MeCommand;
@@ -31,6 +33,7 @@ pub struct Commands {
     _page_up: CommandRun,
     _verification: Command,
     _buffer_clear: CommandRun,
+    _join: CommandRun,
     _me: CommandRun,
 }
 
@@ -46,6 +49,7 @@ impl Commands {
             _page_up: PageUpCommand::create(servers)?,
             _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,
+            _join: JoinCommand::create(servers)?,
             _me: MeCommand::create(servers)?,
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -252,7 +252,7 @@ impl MatrixServer {
                 self.print_error(&format!(
                     "Failed to join {}: {}",
                     target,
-                    format_join_error(&error)
+                    format_join_error(&error, &target)
                 ));
             }
         }
@@ -462,11 +462,21 @@ impl MatrixServer {
     }
 }
 
-fn format_join_error(error: &Error) -> String {
-    error
+fn format_join_error(error: &Error, target: &str) -> String {
+    let message = error
         .as_client_api_error()
         .map(ToString::to_string)
-        .unwrap_or_else(|| error.to_string())
+        .unwrap_or_else(|| error.to_string());
+
+    if target.starts_with('#')
+        && message.contains("Expected RoomID of the form")
+    {
+        format!(
+            "{message}; the alias may point to a room v12 ID without a server part. Update the homeserver/client stack or join from a homeserver that supports room v12."
+        )
+    } else {
+        message
+    }
 }
 
 impl Drop for MatrixServer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -214,6 +214,73 @@ impl MatrixServer {
         Rc::downgrade(&self.inner)
     }
 
+    /// Join a Matrix room by ID or alias
+    pub async fn join_room(&self, room_id_or_alias: String) {
+        let connection = if let Some(c) = self.connection() {
+            c
+        } else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        self.print_network(&format!("Joining room {}...", room_id_or_alias));
+
+        // Determine if it's a room ID or alias
+        let result = if room_id_or_alias.starts_with('!') {
+            // It's a room ID
+            use matrix_sdk::ruma::OwnedRoomId;
+            match room_id_or_alias.parse::<OwnedRoomId>() {
+                Ok(room_id) => {
+                    let client = connection.client().clone();
+                    connection.spawn(async move {
+                        client.join_room_by_id(&room_id).await
+                    }).await
+                }
+                Err(e) => {
+                    self.print_error(&format!("Invalid room ID: {:?}", e));
+                    return;
+                }
+            }
+        } else {
+            // It's a room alias (starts with # or we add it)
+            use matrix_sdk::ruma::OwnedRoomOrAliasId;
+            let alias = if room_id_or_alias.starts_with('#') {
+                room_id_or_alias.clone()
+            } else {
+                format!("#{}", room_id_or_alias)
+            };
+
+            match alias.parse::<OwnedRoomOrAliasId>() {
+                Ok(room_or_alias) => {
+                    let client = connection.client().clone();
+                    connection
+                        .spawn(async move {
+                            client
+                                .join_room_by_id_or_alias(&room_or_alias, &[])
+                                .await
+                        })
+                        .await
+                }
+                Err(e) => {
+                    self.print_error(&format!("Invalid room alias: {:?}", e));
+                    return;
+                }
+            }
+        };
+
+        match result {
+            Ok(room) => {
+                self.print_network(&format!(
+                    "Successfully joined room {}",
+                    room.room_id()
+                ));
+            }
+            Err(e) => {
+                self.print_error(&format!("Failed to join room: {:?}", e));
+            }
+        }
+    }
+
     pub fn connect(&self) -> Result<(), ServerError> {
         if self.connected() {
             self.print_error(&format!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -80,7 +80,8 @@ use matrix_sdk::{
             SyncStateEvent,
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
-        OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, UserId,
+        OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedRoomOrAliasId,
+        OwnedUserId, RoomId, UserId,
     },
     Client, Error,
 };
@@ -214,59 +215,31 @@ impl MatrixServer {
         Rc::downgrade(&self.inner)
     }
 
-    /// Join a Matrix room by ID or alias
+    /// Join a Matrix room by ID or alias.
     pub async fn join_room(&self, room_id_or_alias: String) {
-        let connection = if let Some(c) = self.connection() {
-            c
-        } else {
+        let Ok(room_id_or_alias) =
+            room_id_or_alias.parse::<OwnedRoomOrAliasId>()
+        else {
+            self.print_error("Invalid room ID or alias.");
+            return;
+        };
+
+        let Some(connection) = self.connection() else {
             self.print_error("Not connected. Please connect first.");
             return;
         };
 
         self.print_network(&format!("Joining room {}...", room_id_or_alias));
 
-        // Determine if it's a room ID or alias
-        let result = if room_id_or_alias.starts_with('!') {
-            // It's a room ID
-            use matrix_sdk::ruma::OwnedRoomId;
-            match room_id_or_alias.parse::<OwnedRoomId>() {
-                Ok(room_id) => {
-                    let client = connection.client().clone();
-                    connection.spawn(async move {
-                        client.join_room_by_id(&room_id).await
-                    }).await
-                }
-                Err(e) => {
-                    self.print_error(&format!("Invalid room ID: {:?}", e));
-                    return;
-                }
-            }
-        } else {
-            // It's a room alias (starts with # or we add it)
-            use matrix_sdk::ruma::OwnedRoomOrAliasId;
-            let alias = if room_id_or_alias.starts_with('#') {
-                room_id_or_alias.clone()
-            } else {
-                format!("#{}", room_id_or_alias)
-            };
-
-            match alias.parse::<OwnedRoomOrAliasId>() {
-                Ok(room_or_alias) => {
-                    let client = connection.client().clone();
-                    connection
-                        .spawn(async move {
-                            client
-                                .join_room_by_id_or_alias(&room_or_alias, &[])
-                                .await
-                        })
-                        .await
-                }
-                Err(e) => {
-                    self.print_error(&format!("Invalid room alias: {:?}", e));
-                    return;
-                }
-            }
-        };
+        let client = connection.client().clone();
+        let target = room_id_or_alias.to_string();
+        let result = connection
+            .spawn(async move {
+                client
+                    .join_room_by_id_or_alias(&room_id_or_alias, &[])
+                    .await
+            })
+            .await;
 
         match result {
             Ok(room) => {
@@ -275,8 +248,12 @@ impl MatrixServer {
                     room.room_id()
                 ));
             }
-            Err(e) => {
-                self.print_error(&format!("Failed to join room: {:?}", e));
+            Err(error) => {
+                self.print_error(&format!(
+                    "Failed to join {}: {}",
+                    target,
+                    format_join_error(&error)
+                ));
             }
         }
     }
@@ -483,6 +460,13 @@ impl MatrixServer {
             .new_boolean_option(ssl_verify)
             .expect("Can't create autoconnect option");
     }
+}
+
+fn format_join_error(error: &Error) -> String {
+    error
+        .as_client_api_error()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| error.to_string())
 }
 
 impl Drop for MatrixServer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,6 +62,7 @@ use std::{
     io::Write,
     path::PathBuf,
     rc::{Rc, Weak},
+    time::Duration,
 };
 use tracing::error;
 use url::Url;
@@ -91,6 +92,8 @@ use weechat::{
     config::{BooleanOptionSettings, ConfigSection, StringOptionSettings},
     Prefix, Weechat,
 };
+
+const JOIN_ROOM_TIMEOUT: Duration = Duration::from_secs(120);
 
 use crate::{
     config::ServerBuffer,
@@ -235,27 +238,38 @@ impl MatrixServer {
         let target = room_id_or_alias.to_string();
         let result = connection
             .spawn(async move {
-                let servers =
-                    resolve_alias_servers(&client, &room_id_or_alias).await;
+                tokio::time::timeout(JOIN_ROOM_TIMEOUT, async move {
+                    let servers =
+                        resolve_alias_servers(&client, &room_id_or_alias).await;
 
-                client
-                    .join_room_by_id_or_alias(&room_id_or_alias, &servers)
-                    .await
+                    client
+                        .join_room_by_id_or_alias(&room_id_or_alias, &servers)
+                        .await
+                })
+                .await
             })
             .await;
 
         match result {
-            Ok(room) => {
+            Ok(Ok(room)) => {
                 self.print_network(&format!(
                     "Successfully joined room {}",
                     room.room_id()
                 ));
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 self.print_error(&format!(
                     "Failed to join {}: {}",
                     target,
                     format_join_error(&error, &target)
+                ));
+            }
+            Err(error) => {
+                self.print_error(&format!(
+                    "Timed out joining {} after {} seconds: {}",
+                    target,
+                    JOIN_ROOM_TIMEOUT.as_secs(),
+                    error
                 ));
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -80,8 +80,8 @@ use matrix_sdk::{
             SyncStateEvent,
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
-        OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedRoomOrAliasId,
-        OwnedUserId, RoomId, UserId,
+        OwnedDeviceId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
+        OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomId, UserId,
     },
     Client, Error,
 };
@@ -235,8 +235,11 @@ impl MatrixServer {
         let target = room_id_or_alias.to_string();
         let result = connection
             .spawn(async move {
+                let servers =
+                    resolve_alias_servers(&client, &room_id_or_alias).await;
+
                 client
-                    .join_room_by_id_or_alias(&room_id_or_alias, &[])
+                    .join_room_by_id_or_alias(&room_id_or_alias, &servers)
                     .await
             })
             .await;
@@ -477,6 +480,22 @@ fn format_join_error(error: &Error, target: &str) -> String {
     } else {
         message
     }
+}
+
+async fn resolve_alias_servers(
+    client: &Client,
+    room_id_or_alias: &OwnedRoomOrAliasId,
+) -> Vec<OwnedServerName> {
+    let Ok(alias) = room_id_or_alias.as_str().parse::<OwnedRoomAliasId>()
+    else {
+        return Vec::new();
+    };
+
+    client
+        .resolve_room_alias(&alias)
+        .await
+        .map(|response| response.servers)
+        .unwrap_or_default()
 }
 
 impl Drop for MatrixServer {


### PR DESCRIPTION
Adds Matrix room joining by alias or ID.

`/matrix join <room-id-or-alias>` still works, and `/join <room-id-or-alias>` now works directly from Matrix buffers. The direct `/join` hook leaves non-Matrix buffers alone so other WeeChat protocols can keep handling their own joins.

Alias joins resolve the alias first and pass the returned participating servers as `via` servers to the join request. This gives homeservers routing information for aliases that point at room IDs without an embedded server name.

Stalled alias resolution or room joins now time out after 120 seconds instead of leaving WeeChat at `Joining room ...` forever.

Adapted from poljar/weechat-matrix-rs#120 by Bogdan Dobrelya, with the Komzpa follow-ups split into separate commits.

Fixes poljar/weechat-matrix-rs#23.

Checked with `cargo fmt --check`, `git diff --check`, and Debian trixie/Rust 1.88 Docker `cargo check --no-default-features`.

Fix requested by @strk.
