### PR TITLE
feat: add /part command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ mod me;
 mod media;
 mod page_up;
 mod upload;
+mod part;
 mod verification;
 
 use buffer_clear::BufferClearCommand;
@@ -27,6 +28,7 @@ use me::MeCommand;
 use media::MediaCommand;
 use page_up::PageUpCommand;
 use upload::UploadCommand;
+use part::PartCommand;
 
 pub struct Commands {
     _matrix: Command,
@@ -38,6 +40,7 @@ pub struct Commands {
     _join: CommandRun,
     _me: CommandRun,
     _upload: CommandRun,
+    _part: CommandRun,
 }
 
 impl Commands {
@@ -55,6 +58,7 @@ impl Commands {
             _join: JoinCommand::create(servers)?,
             _me: MeCommand::create(servers)?,
             _upload: UploadCommand::create(servers)?,
+            _part: PartCommand::create(servers)?,
         })
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,8 +15,8 @@ mod matrix;
 mod me;
 mod media;
 mod page_up;
-mod upload;
 mod part;
+mod upload;
 mod verification;
 
 use buffer_clear::BufferClearCommand;
@@ -27,8 +27,8 @@ use matrix::MatrixCommand;
 use me::MeCommand;
 use media::MediaCommand;
 use page_up::PageUpCommand;
-use upload::UploadCommand;
 use part::PartCommand;
+use upload::UploadCommand;
 
 pub struct Commands {
     _matrix: Command,

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -1,0 +1,50 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::Servers;
+
+pub struct PartCommand {
+    servers: Servers,
+}
+
+impl PartCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/part",
+            PartCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for PartCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        _: Cow<str>,
+    ) -> ReturnCode {
+        if let Some(room) = self.servers.find_room(buffer) {
+            let room = room.room().clone();
+
+            match self.servers.runtime().block_on(room.leave()) {
+                Ok(()) => ReturnCode::Ok,
+                Err(error) => {
+                    Weechat::print(&format!("Failed to leave room: {}", error));
+                    ReturnCode::Error
+                }
+            }
+        } else {
+            Weechat::print(
+                "The /part command needs to be run in a Matrix room buffer.",
+            );
+            ReturnCode::Error
+        }
+    }
+}

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -35,22 +35,29 @@ impl CommandRunCallback for PartCommand {
                 .get_localvar("nick")
                 .map(|nick| nick.into_owned())
                 .unwrap_or_else(|| room.room_id().to_string());
+            let buffer_handle = room.buffer_handle();
             let matrix_room = room.room().clone();
 
-            match self.servers.runtime().block_on(matrix_room.leave()) {
-                Ok(()) => {
-                    buffer.print(&format!(
-                        "{}{} has left the room",
-                        Weechat::prefix(Prefix::Quit),
-                        display_name,
-                    ));
-                    ReturnCode::OkEat
+            Weechat::spawn(async move {
+                match matrix_room.leave().await {
+                    Ok(()) => {
+                        if let Ok(buffer) = buffer_handle.upgrade() {
+                            buffer.print(&format!(
+                                "{}{} has left the room",
+                                Weechat::prefix(Prefix::Quit),
+                                display_name,
+                            ));
+                        }
+                    }
+                    Err(error) => Weechat::print(&format!(
+                        "Failed to leave room: {}",
+                        error
+                    )),
                 }
-                Err(error) => {
-                    Weechat::print(&format!("Failed to leave room: {}", error));
-                    ReturnCode::Error
-                }
-            }
+            })
+            .detach();
+
+            ReturnCode::OkEat
         } else {
             Weechat::print(
                 "The /part command needs to be run in a Matrix room buffer.",

--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use weechat::{
     buffer::Buffer,
     hooks::{CommandRun, CommandRunCallback},
-    ReturnCode, Weechat,
+    Prefix, ReturnCode, Weechat,
 };
 
 use crate::Servers;
@@ -31,10 +31,21 @@ impl CommandRunCallback for PartCommand {
         _: Cow<str>,
     ) -> ReturnCode {
         if let Some(room) = self.servers.find_room(buffer) {
-            let room = room.room().clone();
+            let display_name = buffer
+                .get_localvar("nick")
+                .map(|nick| nick.into_owned())
+                .unwrap_or_else(|| room.room_id().to_string());
+            let matrix_room = room.room().clone();
 
-            match self.servers.runtime().block_on(room.leave()) {
-                Ok(()) => ReturnCode::Ok,
+            match self.servers.runtime().block_on(matrix_room.leave()) {
+                Ok(()) => {
+                    buffer.print(&format!(
+                        "{}{} has left the room",
+                        Weechat::prefix(Prefix::Quit),
+                        display_name,
+                    ));
+                    ReturnCode::OkEat
+                }
                 Err(error) => {
                     Weechat::print(&format!("Failed to leave room: {}", error));
                     ReturnCode::Error


### PR DESCRIPTION
Adds `/part` for the current Matrix room buffer.

The command calls the Matrix SDK leave API for the room backing the current buffer. It reports an error if the leave request fails or if `/part` is used outside a Matrix room.

Adapted from the `/part` command in #106 by panekj, with current Matrix SDK leave handling and user-facing errors.

Fixes #29.

Checked with `cargo fmt --check`, `git diff --check`, and `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/tmp/weechat-part-check cargo check` after cherry-picking onto #127.

Fix requested by @strk.
