### PR TITLE
feat: add /invite command

### DIFF
--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -1,0 +1,91 @@
+use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg};
+use matrix_sdk::ruma::{OwnedUserId, UserId};
+use weechat::{
+    buffer::Buffer,
+    hooks::{Command, CommandCallback, CommandSettings},
+    Args, Prefix, Weechat,
+};
+
+use super::parse_and_run;
+use crate::Servers;
+
+pub struct InviteCommand {
+    servers: Servers,
+}
+
+impl InviteCommand {
+    pub fn create(servers: &Servers) -> Result<Command, ()> {
+        let settings = CommandSettings::new("invite")
+            .description("Invite a Matrix user to the current room.")
+            .add_argument("<user-id>")
+            .arguments_description(
+                "user-id: The Matrix user ID to invite to the current room.",
+            )
+            .add_completion("%(matrix-users)");
+
+        Command::new(
+            settings,
+            InviteCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+
+    fn invite(&self, buffer: &Buffer, user_id: OwnedUserId) {
+        if let Some(room) = self.servers.find_room(buffer) {
+            let room = room.room().clone();
+            let invited_user = user_id.clone();
+
+            Weechat::spawn(async move {
+                match room.invite_user_by_id(&user_id).await {
+                    Ok(()) => Weechat::print(&format!(
+                        "{}Invited {} to the room.",
+                        Weechat::prefix(Prefix::Network),
+                        invited_user
+                    )),
+                    Err(error) => Weechat::print(&format!(
+                        "{}Failed to invite {}: {}",
+                        Weechat::prefix(Prefix::Error),
+                        invited_user,
+                        error
+                    )),
+                }
+            })
+            .detach();
+        } else {
+            Weechat::print(
+                "The /invite command needs to be run in a Matrix room buffer.",
+            );
+        }
+    }
+}
+
+impl CommandCallback for InviteCommand {
+    fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
+        let parser = Argparse::new("invite")
+            .about("Invite a Matrix user to the current room.")
+            .settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+            ])
+            .arg(Arg::with_name("user-id").required(true).validator(|u| {
+                UserId::parse(u)
+                    .map_err(|_| {
+                        "The given user isn't a valid user ID".to_owned()
+                    })
+                    .map(|_| ())
+            }));
+
+        parse_and_run(parser, arguments, |matches| {
+            let user_id = matches
+                .value_of("user-id")
+                .map(|u| {
+                    UserId::parse(u)
+                        .expect("Argument was already validated as a user ID")
+                })
+                .expect("User ID not set but was required");
+
+            self.invite(buffer, user_id);
+        });
+    }
+}

--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -31,32 +31,34 @@ impl InviteCommand {
         )
     }
 
-    fn invite(&self, buffer: &Buffer, user_id: OwnedUserId) {
-        if let Some(room) = self.servers.find_room(buffer) {
-            let room = room.room().clone();
-            let invited_user = user_id.clone();
+    fn print_error(buffer: &Buffer, message: &str) {
+        buffer.print(&format!("{}{}", Weechat::prefix(Prefix::Error), message));
+    }
 
-            Weechat::spawn(async move {
-                match room.invite_user_by_id(&user_id).await {
-                    Ok(()) => Weechat::print(&format!(
-                        "{}Invited {} to the room.",
-                        Weechat::prefix(Prefix::Network),
-                        invited_user
-                    )),
-                    Err(error) => Weechat::print(&format!(
-                        "{}Failed to invite {}: {}",
-                        Weechat::prefix(Prefix::Error),
-                        invited_user,
-                        error
-                    )),
-                }
-            })
-            .detach();
-        } else {
-            Weechat::print(
+    fn invite(&self, buffer: &Buffer, input: &str) {
+        let Some(room) = self.servers.find_room(buffer) else {
+            Self::print_error(
+                buffer,
                 "The /invite command needs to be run in a Matrix room buffer.",
             );
-        }
+            return;
+        };
+
+        let domain = room
+            .room_id()
+            .server_name()
+            .map(|server_name| server_name.as_str())
+            .unwrap_or_default();
+
+        let user_id = match normalize_invitee(input, domain) {
+            Ok(user_id) => user_id,
+            Err(error) => {
+                Self::print_error(buffer, &error);
+                return;
+            }
+        };
+
+        Weechat::spawn(async move { room.invite_user(user_id).await }).detach();
     }
 }
 
@@ -68,24 +70,60 @@ impl CommandCallback for InviteCommand {
                 ArgParseSettings::DisableHelpFlags,
                 ArgParseSettings::DisableVersion,
             ])
-            .arg(Arg::with_name("user-id").required(true).validator(|u| {
-                UserId::parse(u)
-                    .map_err(|_| {
-                        "The given user isn't a valid user ID".to_owned()
-                    })
-                    .map(|_| ())
-            }));
+            .arg(Arg::with_name("user-id").required(true));
 
         parse_and_run(parser, arguments, |matches| {
             let user_id = matches
                 .value_of("user-id")
-                .map(|u| {
-                    UserId::parse(u)
-                        .expect("Argument was already validated as a user ID")
-                })
                 .expect("User ID not set but was required");
 
             self.invite(buffer, user_id);
         });
+    }
+}
+
+fn normalize_invitee(
+    input: &str,
+    default_domain: &str,
+) -> Result<OwnedUserId, String> {
+    let input = input.trim();
+    let candidate = if input.contains(':') {
+        input.to_owned()
+    } else {
+        let localpart = input.strip_prefix('@').unwrap_or(input);
+        format!("@{}:{}", localpart, default_domain)
+    };
+
+    UserId::parse(candidate.as_str()).map_err(|error| {
+        format!("Invalid Matrix user ID `{}`: {}", candidate, error)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_invitee;
+
+    #[test]
+    fn keeps_fully_qualified_user_ids() {
+        let user = normalize_invitee("@strk:osgeo.org", "matrix.org").unwrap();
+        assert_eq!("@strk:osgeo.org", user.as_str());
+    }
+
+    #[test]
+    fn appends_room_domain_to_local_user_ids() {
+        let user = normalize_invitee("@strk", "matrix.org").unwrap();
+        assert_eq!("@strk:matrix.org", user.as_str());
+    }
+
+    #[test]
+    fn accepts_localparts_without_at_sign() {
+        let user = normalize_invitee("strk", "matrix.org").unwrap();
+        assert_eq!("@strk:matrix.org", user.as_str());
+    }
+
+    #[test]
+    fn reports_the_candidate_user_id_on_error() {
+        let error = normalize_invitee("@strk", "").unwrap_err();
+        assert!(error.contains("@strk:"));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::{config::ConfigHandle, Servers};
 
 mod buffer_clear;
 mod devices;
+mod invite;
 mod join;
 mod keys;
 mod matrix;
@@ -21,6 +22,7 @@ mod verification;
 
 use buffer_clear::BufferClearCommand;
 use devices::DevicesCommand;
+use invite::InviteCommand;
 use join::JoinCommand;
 use keys::KeysCommand;
 use matrix::MatrixCommand;
@@ -34,6 +36,7 @@ pub struct Commands {
     _matrix: Command,
     _keys: Command,
     _devices: Command,
+    _invite: Command,
     _page_up: CommandRun,
     _verification: Command,
     _buffer_clear: CommandRun,
@@ -51,6 +54,7 @@ impl Commands {
         Ok(Commands {
             _matrix: MatrixCommand::create(servers, config)?,
             _devices: DevicesCommand::create(servers)?,
+            _invite: InviteCommand::create(servers)?,
             _keys: KeysCommand::create(servers)?,
             _page_up: PageUpCommand::create(servers)?,
             _verification: VerificationCommand::create(servers)?,

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -769,6 +769,16 @@ impl MatrixRoom {
         }
     }
 
+    fn print_network(&self, message: &str) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            buffer.print(&format!(
+                "{}{}",
+                Weechat::prefix(Prefix::Network),
+                message
+            ));
+        }
+    }
+
     fn print_error(&self, message: &str) {
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             buffer.print(&format!(
@@ -776,6 +786,30 @@ impl MatrixRoom {
                 Weechat::prefix(Prefix::Error),
                 message
             ));
+        }
+    }
+
+    pub async fn invite_user(&self, user_id: OwnedUserId) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        let invited_user = user_id.clone();
+        let room = self.room().clone();
+
+        match connection
+            .spawn(async move { room.invite_user_by_id(&user_id).await })
+            .await
+        {
+            Ok(()) => self.print_network(&format!(
+                "Invited {} to the room.",
+                invited_user
+            )),
+            Err(error) => self.print_error(&format!(
+                "Failed to invite {}: {}",
+                invited_user, error
+            )),
         }
     }
 


### PR DESCRIPTION
Adds `/invite <user-id>` for Matrix room buffers.

The command validates the Matrix user ID, runs the Matrix SDK invite API asynchronously, and prints success or error feedback when the invite request finishes.

Adapted from the `/invite` command in #106 by panekj, with current command parsing and async success/error feedback.

Fixes #30.

Validation:
- `cargo fmt --check`
- `git diff --check`

Fix requested by @strk.
