### PR TITLE
feat: add /topic command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ mod names;
 mod page_up;
 mod part;
 mod redact;
+mod topic;
 mod upload;
 mod verification;
 
@@ -34,6 +35,7 @@ use names::NamesCommand;
 use page_up::PageUpCommand;
 use part::PartCommand;
 use redact::RedactCommand;
+use topic::TopicCommand;
 use upload::UploadCommand;
 
 pub struct Commands {
@@ -43,6 +45,7 @@ pub struct Commands {
     _invite: Command,
     _page_up: CommandRun,
     _redact: Command,
+    _topic: Command,
     _verification: Command,
     _buffer_clear: CommandRun,
     _join: CommandRun,
@@ -64,6 +67,7 @@ impl Commands {
             _keys: KeysCommand::create(servers)?,
             _page_up: PageUpCommand::create(servers)?,
             _redact: RedactCommand::create(servers)?,
+            _topic: TopicCommand::create(servers)?,
             _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,
             _join: JoinCommand::create(servers)?,

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -8,6 +8,13 @@ use weechat::{
 use super::parse_and_run;
 use crate::Servers;
 
+#[derive(Debug, Eq, PartialEq)]
+enum TopicAction {
+    Show,
+    Clear,
+    Set(String),
+}
+
 pub struct TopicCommand {
     servers: Servers,
 }
@@ -15,10 +22,11 @@ pub struct TopicCommand {
 impl TopicCommand {
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("topic")
-            .description("Set or clear the current Matrix room topic.")
-            .add_argument("[topic]")
+            .description("Show, set, or clear the current Matrix room topic.")
+            .add_argument("[--clear] [topic]")
             .arguments_description(
-                "topic: The new topic for the current room. Omit it to clear the topic.",
+                "topic: The new topic for the current room. Omit it to show the current topic.\n\
+                 --clear: Clear the topic.",
             );
 
         Command::new(
@@ -27,6 +35,54 @@ impl TopicCommand {
                 servers: servers.clone(),
             },
         )
+    }
+
+    fn parser() -> Argparse<'static, 'static> {
+        Argparse::new("topic")
+            .about("Show, set, or clear the current Matrix room topic.")
+            .settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+            ])
+            .arg(
+                Arg::with_name("clear")
+                    .long("clear")
+                    .help("Clear the current room topic.")
+                    .conflicts_with("topic"),
+            )
+            .arg(
+                Arg::with_name("topic")
+                    .multiple(true)
+                    .allow_hyphen_values(true),
+            )
+    }
+
+    fn action(matches: &clap::ArgMatches) -> TopicAction {
+        if matches.is_present("clear") {
+            TopicAction::Clear
+        } else {
+            matches
+                .values_of("topic")
+                .map(|t| TopicAction::Set(t.collect::<Vec<_>>().join(" ")))
+                .unwrap_or(TopicAction::Show)
+        }
+    }
+
+    fn show_topic(&self, buffer: &Buffer) {
+        if let Some(room) = self.servers.find_room(buffer) {
+            match room.room().topic() {
+                Some(topic) if !topic.is_empty() => {
+                    buffer.print(&format!("Topic: {}", topic));
+                }
+                _ => {
+                    buffer.print("No topic is set.");
+                }
+            }
+        } else {
+            Weechat::print(
+                "The /topic command needs to be run in a Matrix room buffer.",
+            );
+        }
     }
 
     fn set_topic(&self, buffer: &Buffer, topic: String) {
@@ -53,24 +109,50 @@ impl TopicCommand {
 
 impl CommandCallback for TopicCommand {
     fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
-        let parser = Argparse::new("topic")
-            .about("Set or clear the current Matrix room topic.")
-            .settings(&[
-                ArgParseSettings::DisableHelpFlags,
-                ArgParseSettings::DisableVersion,
-            ])
-            .arg(
-                Arg::with_name("topic")
-                    .multiple(true)
-                    .allow_hyphen_values(true),
-            );
-
-        parse_and_run(parser, arguments, |matches| {
-            let topic = matches
-                .values_of("topic")
-                .map(|t| t.collect::<Vec<_>>().join(" "));
-
-            self.set_topic(buffer, topic.unwrap_or_default());
+        parse_and_run(Self::parser(), arguments, |matches| match Self::action(
+            matches,
+        ) {
+            TopicAction::Show => self.show_topic(buffer),
+            TopicAction::Clear => self.set_topic(buffer, String::new()),
+            TopicAction::Set(topic) => self.set_topic(buffer, topic),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TopicAction, TopicCommand};
+
+    fn parse(args: &[&str]) -> TopicAction {
+        let matches = TopicCommand::parser()
+            .get_matches_from_safe(args)
+            .expect("topic arguments should parse");
+
+        TopicCommand::action(&matches)
+    }
+
+    #[test]
+    fn omitted_topic_shows_current_topic() {
+        assert_eq!(TopicAction::Show, parse(&["topic"]));
+    }
+
+    #[test]
+    fn clear_flag_explicitly_clears_topic() {
+        assert_eq!(TopicAction::Clear, parse(&["topic", "--clear"]));
+    }
+
+    #[test]
+    fn clear_flag_rejects_topic_text() {
+        assert!(TopicCommand::parser()
+            .get_matches_from_safe(&["topic", "--clear", "not empty"])
+            .is_err());
+    }
+
+    #[test]
+    fn non_empty_topic_selects_set_action() {
+        assert_eq!(
+            TopicAction::Set("new room topic".to_owned()),
+            parse(&["topic", "new", "room", "topic"])
+        );
     }
 }

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -33,14 +33,16 @@ impl TopicCommand {
         if let Some(room) = self.servers.find_room(buffer) {
             let room = room.room().clone();
 
-            match self.servers.runtime().block_on(room.set_room_topic(&topic)) {
-                Ok(_) => (),
-                Err(error) => Weechat::print(&format!(
-                    "{}Failed to set room topic: {}",
-                    Weechat::prefix(Prefix::Error),
-                    error
-                )),
-            }
+            Weechat::spawn(async move {
+                if let Err(error) = room.set_room_topic(&topic).await {
+                    Weechat::print(&format!(
+                        "{}Failed to set room topic: {}",
+                        Weechat::prefix(Prefix::Error),
+                        error
+                    ));
+                }
+            })
+            .detach();
         } else {
             Weechat::print(
                 "The /topic command needs to be run in a Matrix room buffer.",

--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -1,0 +1,74 @@
+use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg};
+use weechat::{
+    buffer::Buffer,
+    hooks::{Command, CommandCallback, CommandSettings},
+    Args, Prefix, Weechat,
+};
+
+use super::parse_and_run;
+use crate::Servers;
+
+pub struct TopicCommand {
+    servers: Servers,
+}
+
+impl TopicCommand {
+    pub fn create(servers: &Servers) -> Result<Command, ()> {
+        let settings = CommandSettings::new("topic")
+            .description("Set or clear the current Matrix room topic.")
+            .add_argument("[topic]")
+            .arguments_description(
+                "topic: The new topic for the current room. Omit it to clear the topic.",
+            );
+
+        Command::new(
+            settings,
+            TopicCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+
+    fn set_topic(&self, buffer: &Buffer, topic: String) {
+        if let Some(room) = self.servers.find_room(buffer) {
+            let room = room.room().clone();
+
+            match self.servers.runtime().block_on(room.set_room_topic(&topic)) {
+                Ok(_) => (),
+                Err(error) => Weechat::print(&format!(
+                    "{}Failed to set room topic: {}",
+                    Weechat::prefix(Prefix::Error),
+                    error
+                )),
+            }
+        } else {
+            Weechat::print(
+                "The /topic command needs to be run in a Matrix room buffer.",
+            );
+        }
+    }
+}
+
+impl CommandCallback for TopicCommand {
+    fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
+        let parser = Argparse::new("topic")
+            .about("Set or clear the current Matrix room topic.")
+            .settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+            ])
+            .arg(
+                Arg::with_name("topic")
+                    .multiple(true)
+                    .allow_hyphen_values(true),
+            );
+
+        parse_and_run(parser, arguments, |matches| {
+            let topic = matches
+                .values_of("topic")
+                .map(|t| t.collect::<Vec<_>>().join(" "));
+
+            self.set_topic(buffer, topic.unwrap_or_default());
+        });
+    }
+}


### PR DESCRIPTION
Adds `/topic` for Matrix room buffers.

- `/topic` displays the current room topic.
- `/topic --clear` clears the topic explicitly.
- `/topic <topic>` sets a non-empty topic asynchronously, so a slow homeserver does not block WeeChat's command callback.
- Combining `--clear` with topic text is rejected.

Based on the room-topic idea in poljar/weechat-matrix-rs#106 by panekj, exposed as the dedicated `/topic` command requested in poljar/weechat-matrix-rs#24.

Fixes poljar/weechat-matrix-rs#24.

Validation on current head `5242e7b6a81d7249955e7a0e2c9d9cb0c2aef1db`:

- `cargo fmt --check`
- `git diff --check`
- focused topic tests in a Rust 1.96 container
- all four hosted build/package jobs pass

Fix requested by @strk.
