### PR TITLE
feat: configure nick prefix colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,14 @@ The plugin keeps Matrix state and encryption data in
 If the cache grows or causes too much disk I/O, disconnect WeeChat and remove
 only the `-cache` directory. Do not remove the main server directory unless you
 want to reset stored Matrix state.
+Nick prefix colors for Matrix power levels can be changed with:
+
+       /set matrix-rust.color.nick_prefix_admin lightgreen
+       /set matrix-rust.color.nick_prefix_moderator lightmagenta
+       /set matrix-rust.color.nick_prefix_power yellow
+
+Existing nicklist entries may need a member update or plugin restart before the new colors are visible.
+
 
 # Helpful Commands
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,30 @@ config!(
         },
     },
 
+    Section color {
+        nick_prefix_admin: Color {
+            // Description.
+            "Color for the admin nick prefix (&)",
+            // Default value.
+            "lightgreen",
+        },
+
+        nick_prefix_moderator: Color {
+            // Description.
+            "Color for the moderator nick prefix (@)",
+            // Default value.
+            "lightmagenta",
+        },
+
+        nick_prefix_power: Color {
+            // Description.
+            "Color for the nick prefix (+) used by users with a non-default \
+             power level below moderator",
+            // Default value.
+            "yellow",
+        },
+    },
+
     Section network {
         debug_buffer: bool {
             // Description

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 use dashmap::DashMap;
 use tokio::runtime::Handle;
@@ -24,7 +24,9 @@ use weechat::{
     Prefix, Weechat,
 };
 
-use crate::{render::render_membership, room::buffer::RoomBuffer};
+use crate::{
+    config::Config, render::render_membership, room::buffer::RoomBuffer,
+};
 
 #[derive(Clone)]
 pub struct Members {
@@ -33,6 +35,7 @@ pub struct Members {
     ambiguity_map: Rc<DashMap<OwnedUserId, bool>>,
     nicks: Rc<DashMap<OwnedUserId, String>>,
     last_active: Rc<DashMap<OwnedUserId, MilliSecondsSinceUnixEpoch>>,
+    config: Rc<RefCell<Config>>,
     buffer: RoomBuffer,
 }
 
@@ -40,6 +43,7 @@ pub struct Members {
 pub struct WeechatRoomMember {
     inner: RoomMember,
     color: Rc<String>,
+    prefix_color: Rc<String>,
     ambiguous_nick: Rc<bool>,
 }
 
@@ -50,13 +54,19 @@ impl PartialEq for WeechatRoomMember {
 }
 
 impl Members {
-    pub fn new(room: Room, runtime: Handle, buffer: RoomBuffer) -> Self {
+    pub fn new(
+        room: Room,
+        runtime: Handle,
+        config: Rc<RefCell<Config>>,
+        buffer: RoomBuffer,
+    ) -> Self {
         Self {
             room,
             runtime,
             nicks: DashMap::new().into(),
             ambiguity_map: DashMap::new().into(),
             last_active: DashMap::new().into(),
+            config,
             buffer,
         }
     }
@@ -222,6 +232,10 @@ impl Members {
             .expect("Fetching the room member from the store panicked")
         {
             Ok(m) => m.map(|m| WeechatRoomMember {
+                prefix_color: Rc::new(Self::prefix_color_for_power_level(
+                    &self.config.borrow(),
+                    m.normalized_power_level(),
+                )),
                 color: Rc::new(color),
                 ambiguous_nick: Rc::new(
                     self.ambiguity_map
@@ -240,6 +254,25 @@ impl Members {
                 None
             }
         }
+    }
+
+    fn prefix_color_for_power_level(
+        config: &Config,
+        power_level: UserPowerLevel,
+    ) -> String {
+        let color = config.color();
+
+        match power_level {
+            UserPowerLevel::Infinite => color.nick_prefix_admin(),
+            p if p >= Int::from(100) => color.nick_prefix_admin(),
+            p if p >= Int::from(50) => color.nick_prefix_moderator(),
+            p if p > Int::from(0) => color.nick_prefix_power(),
+            _ => "default".to_owned(),
+        }
+    }
+
+    fn room(&self) -> &Room {
+        &self.room
     }
 
     pub fn mark_active(
@@ -427,12 +460,7 @@ impl WeechatRoomMember {
     }
 
     fn prefix_color(&self) -> &str {
-        match self.prefix() {
-            "&" => "lightgreen",
-            "@" => "lightmagenta",
-            "+" => "yellow",
-            _ => "default",
-        }
+        &self.prefix_color
     }
 
     pub fn nick_colored(&self) -> String {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -237,8 +237,12 @@ impl RoomHandle {
         own_user_id: &UserId,
     ) -> Self {
         let buffer = RoomBuffer::new(room.clone(), runtime.clone());
-        let members =
-            Members::new(room.clone(), runtime.clone(), buffer.clone());
+        let members = Members::new(
+            room.clone(),
+            runtime.clone(),
+            config.clone(),
+            buffer.clone(),
+        );
 
         let own_nick = runtime
             .block_on(room.get_member_no_sync(own_user_id))


### PR DESCRIPTION
Adds configurable WeeChat color options for Matrix nick prefixes:

`matrix-rust.color.nick_prefix_admin`
`matrix-rust.color.nick_prefix_moderator`
`matrix-rust.color.nick_prefix_power`

The defaults keep the current Rust colors. Existing nicklist entries may need a member update or plugin restart before they repaint.

Fixes #25.

Ports the configurability requested by poljar/weechat-matrix#211 by Denis Kasak while preserving this Rust plugin's existing default prefix colors.

Checked with `cargo fmt --check`, `git diff --check`, and `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/tmp/weechat-prefix-colors-check cargo check` after cherry-picking onto #127.

Fix requested by @strk.
