### PR TITLE
fix: add smart filter tags for membership events

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ _(replace the placeholders in brackets [] with your own details)_:
 
        /save
 
+To hide join/leave noise from users who have not spoken recently, add a WeeChat
+filter for Matrix smart-filter tags:
+
+       /filter add matrix_smart * matrix_smart_filter *
+
 
 # Helpful Commands
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,14 @@ _(replace the placeholders in brackets [] with your own details)_:
 
        /save
 
-To hide join/leave noise from users who have not spoken recently, add a WeeChat
+To hide join/leave noise from users who have not been active recently, add a WeeChat
 filter for Matrix smart-filter tags:
 
        /filter add matrix_smart * matrix_smart_filter *
+
+The inactivity delay defaults to five minutes and can be changed with:
+
+       /set matrix-rust.look.smart_filter_delay 300000
 
 
 # Helpful Commands

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,16 @@ config!(
             "The style that should be used when a message needs to be redacted",
             RedactionStyle,
         },
+
+        smart_filter_delay: Integer {
+            // Description
+            "How long a room member can be inactive, in milliseconds, before \
+             membership events from them get the matrix_smart_filter tag",
+            // Default value.
+            300000,
+            // Range: 0 ms to one day.
+            0..86400000,
+        },
     },
 
     Section network {

--- a/src/render.rs
+++ b/src/render.rs
@@ -825,8 +825,7 @@ pub fn render_membership(
     event: &OriginalSyncStateEvent<RoomMemberEventContent>,
     sender: &WeechatRoomMember,
     target: &WeechatRoomMember,
-) -> String {
-    const _TAGS: &[&str] = &["matrix_membership"];
+) -> RenderedLine {
     use MembershipChange::*;
     let change_op = event.membership_change();
 
@@ -893,8 +892,7 @@ pub fn render_membership(
         color_reset = Weechat::color("reset")
     );
 
-    // TODO: we should return the tags as well.
-    match change_op {
+    let message = match change_op {
         ProfileChanged {
             displayname_change,
             avatar_url_change,
@@ -970,6 +968,11 @@ pub fn render_membership(
             target = target_name,
             op = operation
         ),
+    };
+
+    RenderedLine {
+        tags: vec!["matrix_membership".to_owned()],
+        message,
     }
 }
 

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -267,12 +267,15 @@ impl Members {
         &self,
         user_id: &UserId,
         timestamp: MilliSecondsSinceUnixEpoch,
+        smart_filter_delay_ms: i64,
     ) -> bool {
         let Some(last_active) = self.last_active.get(user_id) else {
             return true;
         };
 
-        timestamp.0.saturating_sub(last_active.0) > uint!(300000)
+        let inactive_ms: i64 = timestamp.0.saturating_sub(last_active.0).into();
+
+        inactive_ms > smart_filter_delay_ms
     }
 
     pub async fn handle_membership_event(
@@ -280,6 +283,7 @@ impl Members {
         event: &SyncStateEvent<RoomMemberEventContent>,
         state_event: bool,
         ambiguity_change: Option<&AmbiguityChange>,
+        smart_filter_delay_ms: i64,
     ) {
         let buffer = self.buffer.buffer_handle();
         let buffer = if let Ok(b) = buffer.upgrade() {
@@ -371,7 +375,11 @@ impl Members {
                 (event.origin_server_ts.0 / uint!(1000)).into();
             let mut tags = line.tags;
 
-            if self.should_smart_filter(&target_id, event.origin_server_ts) {
+            if self.should_smart_filter(
+                &target_id,
+                event.origin_server_ts,
+                smart_filter_delay_ms,
+            ) {
                 tags.push("matrix_smart_filter".to_owned());
             }
 

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -15,7 +15,7 @@ use matrix_sdk::{
             },
             SyncStateEvent,
         },
-        uint, Int, OwnedUserId, UserId,
+        uint, Int, MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
     },
 };
 
@@ -32,6 +32,7 @@ pub struct Members {
     pub(super) runtime: Handle,
     ambiguity_map: Rc<DashMap<OwnedUserId, bool>>,
     nicks: Rc<DashMap<OwnedUserId, String>>,
+    last_active: Rc<DashMap<OwnedUserId, MilliSecondsSinceUnixEpoch>>,
     buffer: RoomBuffer,
 }
 
@@ -55,6 +56,7 @@ impl Members {
             runtime,
             nicks: DashMap::new().into(),
             ambiguity_map: DashMap::new().into(),
+            last_active: DashMap::new().into(),
             buffer,
         }
     }
@@ -244,6 +246,35 @@ impl Members {
         &self.room
     }
 
+    pub fn mark_active(
+        &self,
+        user_id: &UserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+    ) {
+        if self
+            .last_active
+            .get(user_id)
+            .map(|last_active| last_active.0 >= timestamp.0)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        self.last_active.insert(user_id.to_owned(), timestamp);
+    }
+
+    fn should_smart_filter(
+        &self,
+        user_id: &UserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+    ) -> bool {
+        let Some(last_active) = self.last_active.get(user_id) else {
+            return true;
+        };
+
+        timestamp.0.saturating_sub(last_active.0) > uint!(300000)
+    }
+
     pub async fn handle_membership_event(
         &self,
         event: &SyncStateEvent<RoomMemberEventContent>,
@@ -311,7 +342,7 @@ impl Members {
             let target = self.get(&target_id).await;
 
             // Display the event message
-            let message = match (&sender, &target) {
+            let line = match (&sender, &target) {
                 (Some(sender), Some(target)) => {
                     render_membership(event, sender, target)
                 }
@@ -329,13 +360,23 @@ impl Members {
                             target_id);
                     }
 
-                    "ERROR: cannot render event since sender or target are not a room member".into()
+                    crate::render::RenderedLine {
+                        tags: vec!["matrix_membership".to_owned()],
+                        message: "ERROR: cannot render event since sender or target are not a room member".into(),
+                    }
                 }
             };
 
             let timestamp: i64 =
                 (event.origin_server_ts.0 / uint!(1000)).into();
-            buffer.print_date_tags(timestamp as isize, &[], &message);
+            let mut tags = line.tags;
+
+            if self.should_smart_filter(&target_id, event.origin_server_ts) {
+                tags.push("matrix_smart_filter".to_owned());
+            }
+
+            let tags: Vec<&str> = tags.iter().map(|t| t.as_str()).collect();
+            buffer.print_date_tags(timestamp as isize, &tags, &line.message);
         }
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -909,6 +909,9 @@ impl MatrixRoom {
         // If the event has a transaction id it's an event that we sent out
         // ourselves, the content will be in the outgoing message queue and it
         // may have been printed out as a local echo.
+        self.members
+            .mark_active(event.sender(), event.origin_server_ts());
+
         if let Some(id) = event.transaction_id() {
             self.handle_outgoing_message(id, event.event_id()).await;
             return;
@@ -959,8 +962,16 @@ impl MatrixRoom {
         state_event: bool,
         ambiguity_change: Option<&AmbiguityChange>,
     ) {
+        let smart_filter_delay_ms =
+            self.config.borrow().look().smart_filter_delay();
+
         self.members
-            .handle_membership_event(event, state_event, ambiguity_change)
+            .handle_membership_event(
+                event,
+                state_event,
+                ambiguity_change,
+                smart_filter_delay_ms,
+            )
             .await
     }
 
@@ -1034,6 +1045,9 @@ impl MatrixRoom {
         event: &AnySyncStateEvent,
         _state_event: bool,
     ) {
+        self.members
+            .mark_active(event.sender(), event.origin_server_ts());
+
         match event {
             AnySyncStateEvent::RoomName(_) => self.buffer.update_buffer_name(),
             AnySyncStateEvent::RoomTopic(_) => self.buffer.set_topic(),

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -560,6 +560,8 @@ impl MatrixRoom {
         use AnyMessageLikeEventContent::{RoomEncrypted, RoomMessage};
         use MessageType::*;
 
+        self.members.mark_active(sender.user_id(), send_time);
+
         let rendered = match content {
             RoomEncrypted(c) => {
                 c.render_with_prefix(send_time, event_id, sender, &())


### PR DESCRIPTION
Adds smart-filter tags to membership events when the affected member has not been active recently, and documents the filter command.

Activity is now updated from message-like and state events, not just rendered message bodies, and the inactivity delay is configurable with `matrix-rust.look.smart_filter_delay` (default five minutes).

The final filter decision still uses the affected member, matching #22's join/leave-noise case; sender activity is tracked but does not decide whether another member's kick/ban line is hidden.

Fixes #22.

Fix requested by @strk.
