### PR TITLE
fix: enable room nick highlights

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -302,6 +302,9 @@ impl RoomHandle {
 
         buffer.set_localvar("server", server_name);
         buffer.set_localvar("nick", &own_nick);
+        buffer
+            .run_command("/buffer set highlight_words $nick")
+            .expect("Can't set room buffer highlight words");
         buffer.set_localvar(
             "domain",
             room.room_id()


### PR DESCRIPTION
Sets Matrix room buffers to highlight `$nick`, using the room buffer nick localvar already set during buffer creation.

Fixes #57.

Fix requested by @strk.