### PR TITLE
fix: avoid noisy disconnect during unload

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -99,13 +99,15 @@ pub enum ClientMessage {
 pub struct Connection {
     #[allow(dead_code)]
     receiver_task: Rc<Task<()>>,
-    client: Client,
+    client: Option<Client>,
     pub runtime: Rc<Runtime>,
 }
 
 impl Connection {
     pub fn client(&self) -> &Client {
-        &self.client
+        self.client
+            .as_ref()
+            .expect("Connection client was already dropped")
     }
 
     pub async fn spawn<F>(&self, future: F) -> F::Output
@@ -141,7 +143,7 @@ impl Connection {
         ));
 
         Self {
-            client: client.clone(),
+            client: Some(client.clone()),
             runtime: runtime.into(),
             receiver_task: receiver_task.into(),
         }
@@ -180,7 +182,7 @@ impl Connection {
         devices: Vec<OwnedDeviceId>,
         auth_info: Option<InteractiveAuthInfo>,
     ) -> MatrixResult<DeleteDevicesResponse> {
-        let client = self.client.clone();
+        let client = self.client().clone();
         Ok(self
             .spawn(async move {
                 if let Some(info) = auth_info {
@@ -216,7 +218,7 @@ impl Connection {
 
     /// Get the list of our own devices.
     pub async fn devices(&self) -> MatrixResult<DevicesResponse> {
-        let client = self.client.clone();
+        let client = self.client().clone();
         Ok(self.spawn(async move { client.devices().await }).await?)
     }
 
@@ -657,6 +659,15 @@ impl Connection {
             } else {
                 break;
             }
+        }
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        if let Some(client) = self.client.take() {
+            let _guard = self.runtime.enter();
+            drop(client);
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     future::Future,
     path::PathBuf,
     rc::{Rc, Weak},
@@ -8,6 +9,7 @@ use std::{
 use tokio::{
     runtime::Runtime,
     sync::mpsc::{channel, Receiver, Sender},
+    task::JoinHandle,
 };
 
 use tracing::error;
@@ -83,7 +85,7 @@ pub enum ClientMessage {
         bool,
         Option<AmbiguityChange>,
     ),
-    RestoredRoom(Room),
+    RestoredRoom(OwnedRoomId),
 }
 
 /// Struct representing an active connection to the homeserver.
@@ -97,8 +99,8 @@ pub enum ClientMessage {
 /// loop drop the object.
 #[derive(Debug, Clone)]
 pub struct Connection {
-    #[allow(dead_code)]
-    receiver_task: Rc<Task<()>>,
+    receiver_task: Rc<RefCell<Option<Task<()>>>>,
+    sync_task: Rc<RefCell<Option<JoinHandle<()>>>>,
     client: Option<Client>,
     runtime: Option<Rc<Runtime>>,
 }
@@ -128,6 +130,31 @@ impl Connection {
             .expect("Tokio error while sending a message")
     }
 
+    pub fn shutdown(&self) {
+        let runtime = self.runtime();
+
+        self.stop_sync_task(&runtime);
+        self.stop_receiver_task(&runtime);
+    }
+
+    fn stop_sync_task(&self, runtime: &Runtime) {
+        let Some(task) = self.sync_task.borrow_mut().take() else {
+            return;
+        };
+
+        task.abort();
+        let _ = runtime.block_on(async { task.await });
+    }
+
+    fn stop_receiver_task(&self, runtime: &Runtime) {
+        let Some(task) = self.receiver_task.borrow_mut().take() else {
+            return;
+        };
+
+        let _guard = runtime.enter();
+        drop(task);
+    }
+
     pub fn new(server: &MatrixServer, client: &Client) -> Self {
         let (tx, rx) = channel(10_000);
 
@@ -140,7 +167,7 @@ impl Connection {
 
         let runtime = Runtime::new().unwrap();
 
-        runtime.spawn(Connection::sync_loop(
+        let sync_task = runtime.spawn(Connection::sync_loop(
             client.clone(),
             tx,
             server.user_name(),
@@ -150,9 +177,10 @@ impl Connection {
         ));
 
         Self {
+            receiver_task: Rc::new(RefCell::new(Some(receiver_task))),
+            sync_task: Rc::new(RefCell::new(Some(sync_task))),
             client: Some(client.clone()),
             runtime: Some(runtime.into()),
-            receiver_task: receiver_task.into(),
         }
     }
 
@@ -327,8 +355,8 @@ impl Connection {
                     ClientMessage::SyncState(r, e) => {
                         server.receive_joined_state_event(&r, e).await
                     }
-                    ClientMessage::RestoredRoom(room) => {
-                        server.restore_room(room).await
+                    ClientMessage::RestoredRoom(room_id) => {
+                        server.restore_room_by_id(room_id).await
                     }
                     ClientMessage::ToDeviceEvent(e) => {
                         server.receive_to_device_event(e).await
@@ -504,7 +532,9 @@ impl Connection {
             if !first_login {
                 for room in client.joined_rooms() {
                     if channel
-                        .send(Ok(ClientMessage::RestoredRoom(room)))
+                        .send(Ok(ClientMessage::RestoredRoom(
+                            room.room_id().to_owned(),
+                        )))
                         .await
                         .is_err()
                     {
@@ -672,20 +702,21 @@ impl Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        {
-            let runtime = self.runtime();
-
-            if let Some(client) = self.client.take() {
-                let _guard = runtime.enter();
-                drop(client);
-            }
-        }
-
-        let Some(runtime) = self.runtime.as_ref() else {
+        let Some(runtime) = self.runtime.as_ref().cloned() else {
             return;
         };
 
-        if Rc::strong_count(runtime) == 1 {
+        if Rc::strong_count(&runtime) == 1 {
+            self.stop_sync_task(&runtime);
+            self.stop_receiver_task(&runtime);
+        }
+
+        if let Some(client) = self.client.take() {
+            let _guard = runtime.enter();
+            drop(client);
+        }
+
+        if Rc::strong_count(&runtime) == 1 {
             let runtime = self.runtime.take().expect("runtime disappeared");
             let handle = runtime.handle().clone();
             let _guard = handle.enter();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -100,10 +100,17 @@ pub struct Connection {
     #[allow(dead_code)]
     receiver_task: Rc<Task<()>>,
     client: Option<Client>,
-    pub runtime: Rc<Runtime>,
+    runtime: Option<Rc<Runtime>>,
 }
 
 impl Connection {
+    pub fn runtime(&self) -> Rc<Runtime> {
+        self.runtime
+            .as_ref()
+            .expect("Connection runtime was already dropped")
+            .clone()
+    }
+
     pub fn client(&self) -> &Client {
         self.client
             .as_ref()
@@ -115,7 +122,7 @@ impl Connection {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        self.runtime
+        self.runtime()
             .spawn(future)
             .await
             .expect("Tokio error while sending a message")
@@ -144,7 +151,7 @@ impl Connection {
 
         Self {
             client: Some(client.clone()),
-            runtime: runtime.into(),
+            runtime: Some(runtime.into()),
             receiver_task: receiver_task.into(),
         }
     }
@@ -665,9 +672,24 @@ impl Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        if let Some(client) = self.client.take() {
-            let _guard = self.runtime.enter();
-            drop(client);
+        {
+            let runtime = self.runtime();
+
+            if let Some(client) = self.client.take() {
+                let _guard = runtime.enter();
+                drop(client);
+            }
+        }
+
+        let Some(runtime) = self.runtime.as_ref() else {
+            return;
+        };
+
+        if Rc::strong_count(runtime) == 1 {
+            let runtime = self.runtime.take().expect("runtime disappeared");
+            let handle = runtime.handle().clone();
+            let _guard = handle.enter();
+            drop(runtime);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,14 +308,14 @@ impl Drop for Matrix {
     fn drop(&mut self) {
         let servers = self.servers.borrow();
 
-        // Buffer close callbacks get called after this, so disconnect here so
-        // we don't leave all our rooms.
+        // Buffer close callbacks get called after this, so drop active
+        // connections here so we don't leave all our rooms.
         //
         // TODO set a flag on the server as well so we don't even try to leave
         // the rooms, once leaving the rooms is implemented when the buffer gets
         // closed.
         for server in servers.values() {
-            server.disconnect();
+            server.shutdown();
         }
 
         drop(servers);

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -17,16 +17,18 @@ use weechat::{
 
 use crate::{render::RenderedEvent, utils::ToTag};
 
+use super::{active_room, SharedRoom};
+
 #[derive(Clone)]
 pub struct RoomBuffer {
-    room: Room,
+    room: SharedRoom,
     runtime: Handle,
     pub(super) inner: Rc<RefCell<Option<BufferHandle>>>,
     thread_buffers: Rc<RefCell<HashMap<OwnedEventId, BufferHandle>>>,
 }
 
 impl RoomBuffer {
-    pub fn new(room: Room, runtime: Handle) -> Self {
+    pub fn new(room: SharedRoom, runtime: Handle) -> Self {
         Self {
             room,
             runtime,
@@ -280,7 +282,9 @@ impl RoomBuffer {
 
     pub fn set_topic(&self) {
         if let Ok(buffer) = self.buffer_handle().upgrade() {
-            buffer.set_title(&self.room.topic().unwrap_or_default());
+            buffer.set_title(
+                &active_room(&self.room).topic().unwrap_or_default(),
+            );
         }
     }
 
@@ -293,7 +297,9 @@ impl RoomBuffer {
     }
 
     pub fn update_parent_spaces(&self) {
-        let spaces = self.runtime.block_on(parent_spaces(self.room.clone()));
+        let spaces = self
+            .runtime
+            .block_on(parent_spaces(active_room(&self.room)));
 
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             match spaces {
@@ -332,11 +338,12 @@ impl RoomBuffer {
     }
 
     fn alias(&self) -> Option<OwnedRoomAliasId> {
-        self.room.canonical_alias()
+        active_room(&self.room).canonical_alias()
     }
 
     pub fn calculate_buffer_name(&self) -> String {
         let room = self.room.clone();
+        let room = active_room(&self.room);
         let is_direct =
             self.runtime.block_on(room.is_direct()).unwrap_or(false);
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -17,7 +17,7 @@ use weechat::{
 
 use crate::{render::RenderedEvent, utils::ToTag};
 
-use super::{active_room, SharedRoom};
+use super::{maybe_active_room, SharedRoom};
 
 #[derive(Clone)]
 pub struct RoomBuffer {
@@ -281,10 +281,12 @@ impl RoomBuffer {
     }
 
     pub fn set_topic(&self) {
+        let Some(room) = maybe_active_room(&self.room) else {
+            return;
+        };
+
         if let Ok(buffer) = self.buffer_handle().upgrade() {
-            buffer.set_title(
-                &active_room(&self.room).topic().unwrap_or_default(),
-            );
+            buffer.set_title(&room.topic().unwrap_or_default());
         }
     }
 
@@ -297,9 +299,11 @@ impl RoomBuffer {
     }
 
     pub fn update_parent_spaces(&self) {
-        let spaces = self
-            .runtime
-            .block_on(parent_spaces(active_room(&self.room)));
+        let Some(room) = maybe_active_room(&self.room) else {
+            return;
+        };
+
+        let spaces = self.runtime.block_on(parent_spaces(room));
 
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             match spaces {
@@ -338,11 +342,13 @@ impl RoomBuffer {
     }
 
     fn alias(&self) -> Option<OwnedRoomAliasId> {
-        active_room(&self.room).canonical_alias()
+        maybe_active_room(&self.room).and_then(|room| room.canonical_alias())
     }
 
     pub fn calculate_buffer_name(&self) -> String {
-        let room = active_room(&self.room);
+        let Some(room) = maybe_active_room(&self.room) else {
+            return self.short_name();
+        };
         let is_direct =
             self.runtime.block_on(room.is_direct()).unwrap_or(false);
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -342,7 +342,6 @@ impl RoomBuffer {
     }
 
     pub fn calculate_buffer_name(&self) -> String {
-        let room = self.room.clone();
         let room = active_room(&self.room);
         let is_direct =
             self.runtime.block_on(room.is_direct()).unwrap_or(false);

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -274,10 +274,6 @@ impl Members {
         }
     }
 
-    fn room(&self) -> Room {
-        active_room(&self.room)
-    }
-
     pub fn mark_active(
         &self,
         user_id: &UserId,

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info};
 
 use matrix_sdk::{
     deserialized_responses::AmbiguityChange,
-    room::{Room, RoomMember},
+    room::RoomMember,
     ruma::{
         events::{
             room::{

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -25,12 +25,14 @@ use weechat::{
 };
 
 use crate::{
-    config::Config, render::render_membership, room::buffer::RoomBuffer,
+    config::Config,
+    render::render_membership,
+    room::{active_room, buffer::RoomBuffer, SharedRoom},
 };
 
 #[derive(Clone)]
 pub struct Members {
-    room: Room,
+    room: SharedRoom,
     pub(super) runtime: Handle,
     ambiguity_map: Rc<DashMap<OwnedUserId, bool>>,
     nicks: Rc<DashMap<OwnedUserId, String>>,
@@ -55,7 +57,7 @@ impl PartialEq for WeechatRoomMember {
 
 impl Members {
     pub fn new(
-        room: Room,
+        room: SharedRoom,
         runtime: Handle,
         config: Rc<RefCell<Config>>,
         buffer: RoomBuffer,
@@ -98,7 +100,7 @@ impl Members {
     }
 
     pub async fn restore_member(&self, user_id: OwnedUserId) {
-        let room = self.room.clone();
+        let room = active_room(&self.room);
         let user = user_id.to_owned();
 
         match self
@@ -215,14 +217,15 @@ impl Members {
 
     /// Retrieve a reference to a Weechat room member by user ID.
     pub async fn get(&self, user_id: &UserId) -> Option<WeechatRoomMember> {
-        let color = if self.room.own_user_id() == user_id {
+        let sdk_room = active_room(&self.room);
+        let color = if sdk_room.own_user_id() == user_id {
             "weechat.color.chat_nick_self".into()
         } else {
             Weechat::info_get("nick_color_name", user_id.as_str())
                 .expect("Couldn't get the nick color name")
         };
 
-        let room = self.room.clone();
+        let room = sdk_room.clone();
         let user = user_id.to_owned();
 
         match self
@@ -269,6 +272,10 @@ impl Members {
             p if p > Int::from(0) => color.nick_prefix_power(),
             _ => "default".to_owned(),
         }
+    }
+
+    fn room(&self) -> Room {
+        active_room(&self.room)
     }
 
     pub fn mark_active(

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -523,6 +523,7 @@ impl MatrixRoom {
     }
 
     pub fn release_sdk_state(&self) {
+        self.verification.release_sdk_state();
         self.room.borrow_mut().take();
     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -98,11 +98,12 @@ pub struct RoomHandle {
 
 pub(super) type SharedRoom = Rc<RefCell<Option<Room>>>;
 
+pub(super) fn maybe_active_room(room: &SharedRoom) -> Option<Room> {
+    room.borrow().as_ref().cloned()
+}
+
 pub(super) fn active_room(room: &SharedRoom) -> Room {
-    room.borrow()
-        .as_ref()
-        .expect("Matrix room was already shut down")
-        .clone()
+    maybe_active_room(room).expect("Matrix room was already shut down")
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -528,33 +529,47 @@ impl MatrixRoom {
     }
 
     pub fn is_encrypted(&self) -> bool {
+        let Some(room) = maybe_active_room(&self.room) else {
+            return false;
+        };
+
         self.members
             .runtime
-            .block_on(self.room().latest_encryption_state())
+            .block_on(room.latest_encryption_state())
             .map(|s| s.is_encrypted())
             .unwrap_or_default()
     }
 
     pub fn contains_only_verified_devices(&self) -> bool {
+        let Some(room) = maybe_active_room(&self.room) else {
+            return false;
+        };
+
         self.members
             .runtime
-            .block_on(self.room().contains_only_verified_devices())
+            .block_on(room.contains_only_verified_devices())
             .unwrap_or_default()
     }
 
     pub fn is_public(&self) -> bool {
-        self.room().is_public().unwrap_or_default()
+        maybe_active_room(&self.room)
+            .and_then(|room| room.is_public())
+            .unwrap_or_default()
     }
 
     pub fn is_direct(&self) -> bool {
+        let Some(room) = maybe_active_room(&self.room) else {
+            return false;
+        };
+
         self.members
             .runtime
-            .block_on(self.room().is_direct())
+            .block_on(room.is_direct())
             .unwrap_or_default()
     }
 
     pub fn alias(&self) -> Option<OwnedRoomAliasId> {
-        self.room().canonical_alias()
+        maybe_active_room(&self.room).and_then(|room| room.canonical_alias())
     }
 
     pub fn room_id(&self) -> &RoomId {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -96,6 +96,15 @@ pub struct RoomHandle {
     inner: MatrixRoom,
 }
 
+pub(super) type SharedRoom = Rc<RefCell<Option<Room>>>;
+
+pub(super) fn active_room(room: &SharedRoom) -> Room {
+    room.borrow()
+        .as_ref()
+        .expect("Matrix room was already shut down")
+        .clone()
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PrevBatch {
     Forward(String),
@@ -159,7 +168,7 @@ pub struct MatrixRoom {
     homeserver: Rc<Url>,
     room_id: Rc<RoomId>,
     own_user_id: Rc<UserId>,
-    room: Room,
+    room: SharedRoom,
     buffer: RoomBuffer,
 
     config: Rc<RefCell<Config>>,
@@ -315,6 +324,8 @@ impl RoomHandle {
         room_id: &RoomId,
         own_user_id: &UserId,
     ) -> Self {
+        let room = Rc::new(RefCell::new(Some(room)));
+        let sdk_room = active_room(&room);
         let buffer = RoomBuffer::new(room.clone(), runtime.clone());
         let members = Members::new(
             room.clone(),
@@ -324,7 +335,7 @@ impl RoomHandle {
         );
 
         let own_nick = runtime
-            .block_on(room.get_member_no_sync(own_user_id))
+            .block_on(sdk_room.get_member_no_sync(own_user_id))
             .ok()
             .flatten()
             .map(|m| m.name().to_owned())
@@ -343,7 +354,7 @@ impl RoomHandle {
             connection: connection.clone(),
             config,
             prev_batch: Rc::new(RefCell::new(
-                room.last_prev_batch().map(PrevBatch::Backwards),
+                sdk_room.last_prev_batch().map(PrevBatch::Backwards),
             )),
             latest_event_id: Rc::new(RefCell::new(None)),
             latest_read_event_id: Rc::new(RefCell::new(None)),
@@ -511,10 +522,14 @@ impl MatrixRoom {
         self.buffer.owns_buffer(buffer)
     }
 
+    pub fn release_sdk_state(&self) {
+        self.room.borrow_mut().take();
+    }
+
     pub fn is_encrypted(&self) -> bool {
         self.members
             .runtime
-            .block_on(self.room.latest_encryption_state())
+            .block_on(self.room().latest_encryption_state())
             .map(|s| s.is_encrypted())
             .unwrap_or_default()
     }
@@ -522,23 +537,23 @@ impl MatrixRoom {
     pub fn contains_only_verified_devices(&self) -> bool {
         self.members
             .runtime
-            .block_on(self.room.contains_only_verified_devices())
+            .block_on(self.room().contains_only_verified_devices())
             .unwrap_or_default()
     }
 
     pub fn is_public(&self) -> bool {
-        self.room.is_public().unwrap_or_default()
+        self.room().is_public().unwrap_or_default()
     }
 
     pub fn is_direct(&self) -> bool {
         self.members
             .runtime
-            .block_on(self.room.is_direct())
+            .block_on(self.room().is_direct())
             .unwrap_or_default()
     }
 
     pub fn alias(&self) -> Option<OwnedRoomAliasId> {
-        self.room.canonical_alias()
+        self.room().canonical_alias()
     }
 
     pub fn room_id(&self) -> &RoomId {
@@ -950,7 +965,7 @@ impl MatrixRoom {
             self.queue_outgoing_message(&transaction_id, &content).await;
             match c
                 .send_message(
-                    self.room().clone(),
+                    self.room(),
                     AnyMessageLikeEventContent::RoomMessage(content),
                     Some(transaction_id.clone()),
                 )
@@ -1087,7 +1102,7 @@ impl MatrixRoom {
 
         match connection
             .spawn({
-                let room = self.room().clone();
+                let room = self.room();
                 async move {
                     room.send_attachment(filename, &content_type, data, config)
                         .await
@@ -1133,7 +1148,7 @@ impl MatrixRoom {
         }
 
         let connection = self.connection.clone();
-        let room = self.room().clone();
+        let room = self.room();
 
         let send = |typing: bool| async move {
             let connection = connection.borrow().clone();
@@ -1249,7 +1264,7 @@ impl MatrixRoom {
         Weechat::bar_item_update("matrix_modes");
 
         if let Some(connection) = connection {
-            let room = self.room().clone();
+            let room = self.room();
             let room_id = room.room_id().to_owned();
 
             if let Ok(r) = connection.room_messages(room, prev_batch).await {
@@ -1488,7 +1503,7 @@ impl MatrixRoom {
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             if buffer.num_lines() == 0 {
                 *self.prev_batch.borrow_mut() =
-                    self.room.last_prev_batch().map(PrevBatch::Backwards);
+                    self.room().last_prev_batch().map(PrevBatch::Backwards);
             }
         }
     }
@@ -1565,8 +1580,8 @@ impl MatrixRoom {
         }
     }
 
-    pub fn room(&self) -> &Room {
-        &self.room
+    pub fn room(&self) -> Room {
+        active_room(&self.room)
     }
 
     pub async fn handle_sync_state_event(

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -71,6 +71,10 @@ impl Verification {
         }
     }
 
+    pub fn release_sdk_state(&self) {
+        self.inner.borrow_mut().take();
+    }
+
     pub async fn confirm(&self) {
         let connection = self.connection.borrow().clone();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1622,8 +1622,6 @@ impl InnerServer {
     }
 
     pub fn shutdown(&self) {
-        let _runtime_guard = self.servers.runtime().enter();
-
         let mut connection = self.connection.borrow_mut();
         connection.take();
         drop(connection);

--- a/src/server.rs
+++ b/src/server.rs
@@ -103,6 +103,32 @@ use crate::{
     ConfigHandle, Servers, PLUGIN_NAME,
 };
 
+fn with_entered_runtime_until_final_drop<F>(
+    runtime: Rc<tokio::runtime::Runtime>,
+    f: F,
+) where
+    F: FnOnce(),
+{
+    with_entered_runtime_until_drop(runtime, f, drop);
+}
+
+fn with_entered_runtime_until_drop<F, D>(
+    runtime: Rc<tokio::runtime::Runtime>,
+    f: F,
+    drop_runtime: D,
+) where
+    F: FnOnce(),
+    D: FnOnce(Rc<tokio::runtime::Runtime>),
+{
+    let handle = runtime.handle().clone();
+    let guard = handle.enter();
+
+    f();
+
+    drop_runtime(runtime);
+    drop(guard);
+}
+
 #[derive(Debug)]
 pub enum ServerError {
     StartError(String),
@@ -1649,9 +1675,10 @@ impl InnerServer {
         });
 
         if let Some(runtime) = runtime {
-            let _guard = runtime.enter();
-            self.shutdown_sdk_state();
-            drop(connection);
+            with_entered_runtime_until_final_drop(runtime, || {
+                self.shutdown_sdk_state();
+                drop(connection);
+            });
         } else {
             let runtime = self.servers.runtime().to_owned();
             let _guard = runtime.enter();
@@ -1711,8 +1738,32 @@ impl InnerServer {
 
 #[cfg(test)]
 mod tests {
-    use super::InnerServer;
+    use super::{with_entered_runtime_until_drop, InnerServer};
     use std::path::{Path, PathBuf};
+    use std::rc::Rc;
+    use std::sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    };
+    use tokio::runtime::{Handle, Runtime};
+
+    const NOT_DROPPED: u8 = 0;
+    const DROPPED_OUTSIDE_RUNTIME: u8 = 1;
+    const DROPPED_INSIDE_RUNTIME: u8 = 2;
+
+    struct DropProbe(Arc<AtomicU8>);
+
+    impl Drop for DropProbe {
+        fn drop(&mut self) {
+            let context = if Handle::try_current().is_ok() {
+                DROPPED_INSIDE_RUNTIME
+            } else {
+                DROPPED_OUTSIDE_RUNTIME
+            };
+
+            self.0.store(context, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn keeps_absolute_download_path_for_display() {
@@ -1736,5 +1787,24 @@ mod tests {
         let path = PathBuf::from("/tmp/matrix-media");
 
         assert_eq!(InnerServer::display_download_path(&path), path);
+    }
+
+    #[test]
+    fn final_runtime_drop_happens_while_handle_is_entered() {
+        let runtime = Rc::new(Runtime::new().expect("runtime"));
+        let drop_context = Arc::new(AtomicU8::new(NOT_DROPPED));
+        let final_drop_context = Arc::clone(&drop_context);
+
+        with_entered_runtime_until_drop(
+            runtime,
+            || {},
+            |runtime| {
+                let probe = DropProbe(final_drop_context);
+                drop(runtime);
+                drop(probe);
+            },
+        );
+
+        assert_eq!(drop_context.load(Ordering::SeqCst), DROPPED_INSIDE_RUNTIME);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1622,11 +1622,26 @@ impl InnerServer {
     }
 
     pub fn shutdown(&self) {
-        let mut connection = self.connection.borrow_mut();
-        connection.take();
-        drop(connection);
+        let connection = self.connection.borrow_mut().take();
+        let runtime = connection.as_ref().map(|c| c.runtime.clone());
 
+        if let Some(runtime) = runtime {
+            let _guard = runtime.enter();
+            self.shutdown_sdk_state();
+            drop(connection);
+        } else {
+            let runtime = self.servers.runtime().to_owned();
+            let _guard = runtime.enter();
+            self.shutdown_sdk_state();
+        }
+    }
+
+    fn shutdown_sdk_state(&self) {
         self.verification_buffers.borrow_mut().clear();
+
+        for room in self.rooms.borrow().values() {
+            room.release_sdk_state();
+        }
         self.rooms.borrow_mut().clear();
 
         let mut client = self.client.borrow_mut();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1623,7 +1623,7 @@ impl InnerServer {
 
     pub fn shutdown(&self) {
         let connection = self.connection.borrow_mut().take();
-        let runtime = connection.as_ref().map(|c| c.runtime.clone());
+        let runtime = connection.as_ref().map(|c| c.runtime());
 
         if let Some(runtime) = runtime {
             let _guard = runtime.enter();

--- a/src/server.rs
+++ b/src/server.rs
@@ -526,9 +526,14 @@ impl Drop for MatrixServer {
             let config = &self.config;
             let mut config_borrow = config.borrow_mut();
 
-            let mut section = config_borrow
-                .search_section_mut("server")
-                .expect("Can't get server section");
+            let Some(mut section) = config_borrow.search_section_mut("server")
+            else {
+                error!(
+                    "Can't get server section while dropping Matrix server {}",
+                    self.server_name
+                );
+                return;
+            };
 
             for option_name in &[
                 "autoconnect",
@@ -540,9 +545,9 @@ impl Drop for MatrixServer {
             ] {
                 let option_name =
                     &format!("{}.{}", self.server_name, option_name);
-                section.free_option(option_name).unwrap_or_else(|_| {
-                    panic!("Can't free option {}", option_name)
-                });
+                if section.free_option(option_name).is_err() {
+                    error!("Can't free option {}", option_name);
+                }
             }
         }
     }
@@ -1614,6 +1619,20 @@ impl InnerServer {
             self.name(),
             Weechat::color("reset")
         ));
+    }
+
+    pub fn shutdown(&self) {
+        let _runtime_guard = self.servers.runtime().enter();
+
+        let mut connection = self.connection.borrow_mut();
+        connection.take();
+        drop(connection);
+
+        self.verification_buffers.borrow_mut().clear();
+        self.rooms.borrow_mut().clear();
+
+        let mut client = self.client.borrow_mut();
+        client.take();
     }
 
     pub fn get_info_str(&self, details: bool) -> String {

--- a/src/server.rs
+++ b/src/server.rs
@@ -622,6 +622,23 @@ impl InnerServer {
         self.settings.borrow().password.clone()
     }
 
+    pub async fn restore_room_by_id(&self, room_id: OwnedRoomId) {
+        if self.rooms.borrow().contains_key(&room_id) {
+            return;
+        }
+
+        let Some(client) = self.get_client() else {
+            return;
+        };
+
+        let Some(room) = client.get_room(&room_id) else {
+            error!("Can't restore room {}, room not found", room_id);
+            return;
+        };
+
+        self.restore_room(room).await;
+    }
+
     pub async fn restore_room(&self, room: Room) {
         let homeserver = self
             .settings
@@ -1609,8 +1626,11 @@ impl InnerServer {
         }
 
         {
-            let mut connection = self.connection.borrow_mut();
-            connection.take();
+            let connection = self.connection.borrow_mut().take();
+            if let Some(connection) = connection.as_ref() {
+                connection.shutdown();
+            }
+            drop(connection);
         }
 
         self.print_network(&format!(
@@ -1623,7 +1643,10 @@ impl InnerServer {
 
     pub fn shutdown(&self) {
         let connection = self.connection.borrow_mut().take();
-        let runtime = connection.as_ref().map(|c| c.runtime());
+        let runtime = connection.as_ref().map(|c| {
+            c.shutdown();
+            c.runtime()
+        });
 
         if let Some(runtime) = runtime {
             let _guard = runtime.enter();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1687,6 +1687,9 @@ impl InnerServer {
     }
 
     fn shutdown_sdk_state(&self) {
+        for verification in self.verification_buffers.borrow().values() {
+            verification.release_sdk_state();
+        }
         self.verification_buffers.borrow_mut().clear();
 
         for room in self.rooms.borrow().values() {

--- a/src/verification_buffer.rs
+++ b/src/verification_buffer.rs
@@ -98,11 +98,19 @@ impl Verification {
 
 #[derive(Clone)]
 struct InnerVerificationBuffer {
-    verification: Rc<RefCell<Verification>>,
+    verification: Rc<RefCell<Option<Verification>>>,
     connection: Rc<RefCell<Option<Connection>>>,
 }
 
 impl InnerVerificationBuffer {
+    fn verification(&self) -> Option<Verification> {
+        self.verification.borrow().clone()
+    }
+
+    fn release_sdk_state(&self) {
+        self.verification.borrow_mut().take();
+    }
+
     fn print_message(buffer: BufferHandle, message: &str) {
         if let Ok(buffer) = buffer.upgrade() {
             buffer.print(message);
@@ -115,7 +123,9 @@ impl InnerVerificationBuffer {
 
     pub async fn accept(&self, buffer: BufferHandle) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
-            let verification = self.verification.borrow().clone();
+            let Some(verification) = self.verification() else {
+                return Ok(());
+            };
             let verification_clone = verification.clone();
 
             c.spawn(async move { verification_clone.accept().await })
@@ -142,7 +152,7 @@ impl InnerVerificationBuffer {
                 } else if let Some(sas) =
                     c.spawn(async move { request.start_sas().await }).await?
                 {
-                    *self.verification.borrow_mut() = sas.into();
+                    *self.verification.borrow_mut() = Some(sas.into());
                 }
             }
         }
@@ -152,16 +162,14 @@ impl InnerVerificationBuffer {
 
     pub async fn confirm(&self, buffer: BufferHandle) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
-            if let Verification::Sas(s) = self.verification.borrow().clone() {
+            if let Some(Verification::Sas(s)) = self.verification() {
                 let sas = s.clone();
                 c.spawn(async move { s.confirm().await }).await?;
 
                 if sas.is_done() {
                     self.print_done(buffer);
                 }
-            } else if let Verification::Qr(qr) =
-                self.verification.borrow().clone()
-            {
+            } else if let Some(Verification::Qr(qr)) = self.verification() {
                 c.spawn(async move { qr.confirm().await }).await?;
 
                 // if qr.is_done() {
@@ -177,7 +185,10 @@ impl InnerVerificationBuffer {
 
     pub async fn cancel(&self) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
-            let verification = self.verification.borrow().clone();
+            let Some(verification) = self.verification() else {
+                return Ok(());
+            };
+
             c.spawn(async move { verification.cancel().await }).await?;
         }
 
@@ -232,7 +243,7 @@ impl VerificationBuffer {
         connection: Rc<RefCell<Option<Connection>>>,
     ) -> Self {
         let inner = InnerVerificationBuffer {
-            verification: Rc::new(RefCell::new(verification.into())),
+            verification: Rc::new(RefCell::new(Some(verification.into()))),
             connection,
         };
 
@@ -268,6 +279,10 @@ impl VerificationBuffer {
         self.buffer.clone()
     }
 
+    pub fn release_sdk_state(&self) {
+        self.inner.release_sdk_state();
+    }
+
     pub fn accept(&self) {
         let buffer = self.buffer();
         let inner = self.inner.clone();
@@ -286,12 +301,14 @@ impl VerificationBuffer {
     }
 
     pub async fn update_qr(&mut self, qr: QrVerification) {
-        *self.inner.verification.borrow_mut() = qr.into();
+        *self.inner.verification.borrow_mut() = Some(qr.into());
     }
 
     pub async fn update(&mut self, sas: SasVerification) -> Result<(), Error> {
-        *self.inner.verification.borrow_mut() = sas.into();
-        let verification = self.inner.verification.borrow().clone();
+        *self.inner.verification.borrow_mut() = Some(sas.into());
+        let Some(verification) = self.inner.verification() else {
+            return Ok(());
+        };
 
         if let Some(c) = self.inner.connection.borrow().clone() {
             c.spawn(async move { verification.accept().await }).await?;
@@ -305,8 +322,8 @@ impl VerificationBuffer {
     pub async fn handle_event(&self, event: &AnyToDeviceEvent) {
         match event {
             AnyToDeviceEvent::KeyVerificationRequest(e) => {
-                if let Verification::Request(_) =
-                    self.inner.verification.borrow().clone()
+                if let Some(Verification::Request(_)) =
+                    self.inner.verification()
                 {
                     let content =
                         e.content.render(&VerificationContext::ToDevice);
@@ -315,7 +332,9 @@ impl VerificationBuffer {
                 }
             }
             AnyToDeviceEvent::KeyVerificationStart(e) => {
-                let verification = self.inner.verification.borrow().clone();
+                let Some(verification) = self.inner.verification() else {
+                    return;
+                };
 
                 if let Ok(verification) = verification.try_into() {
                     let content =
@@ -337,8 +356,7 @@ impl VerificationBuffer {
                 self.print_sas(&e.content);
             }
             AnyToDeviceEvent::KeyVerificationMac(_) => {
-                if let Verification::Sas(sas) =
-                    self.inner.verification.borrow().clone()
+                if let Some(Verification::Sas(sas)) = self.inner.verification()
                 {
                     if sas.is_done() {
                         self.inner.print_done(self.buffer.clone());
@@ -363,8 +381,7 @@ impl VerificationBuffer {
     }
 
     fn print_sas(&self, content: &ToDeviceKeyVerificationKeyEventContent) {
-        if let Verification::Sas(sas) = self.inner.verification.borrow().clone()
-        {
+        if let Some(Verification::Sas(sas)) = self.inner.verification() {
             let message = content.render(&sas);
             self.print(&message);
         }


### PR DESCRIPTION
Avoids the hard abort/core-dump path during WeeChat plugin unload.

The Debian 13 backtraces in poljar/weechat-matrix-rs#116 show Matrix SDK sqlite/deadpool state being dropped without a current Tokio runtime: `deadpool_sync::SyncWrapper<rusqlite::Connection>::drop` calls `tokio::task::spawn_blocking`, which then panics at `tokio::runtime::Handle::current()`.

This keeps the normal `/matrix disconnect` command unchanged. During plugin unload, the plugin now:

- uses a small shutdown path instead of the interactive disconnect command;
- stops sync and response-receiver tasks before SDK teardown;
- clears verification buffers, rooms, and client state while a Tokio runtime is entered;
- keeps the entered runtime guard alive through the final per-connection runtime drop;
- avoids panicking when WeeChat config options are already gone during `/quit`.

Fixes poljar/weechat-matrix-rs#116.

Validation on current head `e9d675401c0407d51650d8f931b8526c11a34da4`:

- regression test `final_runtime_drop_happens_while_handle_is_entered`
- `cargo fmt --check`
- `git diff --check`
- all four hosted build/package jobs pass
- the four-PR current-head composite passes `cargo test --locked --lib` (44 tests)

The remaining behavioral proof is a connected-account Debian 13 `/quit` retest; that exact environment is not reproduced locally.

Fix requested by @strk.
