### PR TITLE
docs: clarify macOS plugin loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ extension enabled before it loads the plugin:
 
     /set weechat.plugin.extension ".so,.dll,.dylib"
 
+Rename `target/release/libmatrix.dylib` to `matrix.dylib` before copying it to
+your WeeChat plugin directory.
+
 # Loading the plugin
 
 Restart WeeChat after installing the plugin, or load it manually:


### PR DESCRIPTION
Adds the missing macOS step after copying `matrix.dylib`: WeeChat may need `.dylib` in `weechat.plugin.extension`, and the plugin loads as `matrix`.

Fixes #66.

Fix requested by @strk.