### PR TITLE
docs: document relay limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ over the Matrix protocol. This is a Rust rewrite of the
 This project is a work in progress and doesn't do much yet. It can connect
 to a Matrix server and send messages.
 
+It is not an IRC relay or bridge: IRC clients connected through WeeChat's relay
+plugin cannot use Matrix rooms as IRC channels. Remote WeeChat interfaces using
+WeeChat relay protocols can access plugin buffers, but Matrix features that
+rewrite already-printed lines, such as message edits and redactions, depend on
+the remote client supporting WeeChat relay line-update events.
+
 If you are interested in helping out take a look at the issue tracker.
 
 # Build


### PR DESCRIPTION
Documents the current relay status from poljar/weechat-matrix-rs#40 with the IRC-relay and remote-interface cases separated.

The README now says:

- WeeChat relay's IRC proxy is not a Matrix bridge, so IRC clients connected through relay cannot use Matrix rooms as IRC channels.
- Remote WeeChat/API relay interfaces can access plugin buffers.
- Matrix features that rewrite already printed lines, such as edits and redactions, depend on the remote client supporting WeeChat relay line-update events.

Research points:

- WeeChat's user guide documents the relay IRC proxy as an IRC-server simulation for IRC clients: https://weechat.org/files/doc/stable/weechat_user.en.html#relay_irc_proxy
- The same guide documents API and WeeChat relay protocols for remote interfaces: https://weechat.org/files/doc/stable/weechat_user.en.html#relay_api_protocol
- The WeeChat relay protocol includes buffer line update events such as `_buffer_line_data_changed`: https://weechat.org/files/doc/weechat/stable/weechat_relay_weechat.en.html

Fixes poljar/weechat-matrix-rs#40.

Fix requested by @strk.
