### PR TITLE
build: run cargo before installing plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,17 @@ SOURCES := $(wildcard src/*.rs src/bar_items/*.rs src/commands/*.rs src/room/*.r
 
 PROFILE ?= release
 
-.PHONY: install install-dir lint all help deb
+.PHONY: install install-dir lint all help deb FORCE
 
 all: help
 
 help: ## Print this help message
 	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-target/debug/libmatrix.so: $(SOURCES) ## Build plugin in dev profile
+target/debug/libmatrix.so: FORCE $(SOURCES) ## Build plugin in dev profile
 	cargo build
 
-target/release/libmatrix.so: $(SOURCES) ## Build plugin release profile
+target/release/libmatrix.so: FORCE $(SOURCES) ## Build plugin release profile
 	cargo build --release
 
 install: install-dir target/$(PROFILE)/libmatrix.so ## Install plugin to weechat dir
@@ -53,3 +53,5 @@ deb: target/$(PROFILE)/libmatrix.so ## Build a .deb package with version from gi
 	@echo ""
 	@echo "Package built: target/debian/weechat-matrix_$${DEB_VERSION}*.deb"
 	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix_$${DEB_VERSION}*.deb"
+
+FORCE:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ that the `clang` command-line tools, C/C++ compiler headers, and matching
 `libclang` package are installed. On minimal distributions the library package
 alone may not provide the compiler include paths that `bindgen` needs.
 
+`WEECHAT_PLUGIN_FILE` is only used while building. After changing it, rerun
+`cargo build` or `make install`; `make clean` is not needed.
+
 After the dependencies are installed the plugin can be compiled with:
 
     cargo build --release


### PR DESCRIPTION
`make install` now always runs the Cargo build target before copying the plugin, so a plain install does not skip Cargo's build-script dependency tracking.

The README notes that `WEECHAT_PLUGIN_FILE` is only used while building, and that rerunning `cargo build` or `make install` is enough after changing it.

The rust-weechat-side header input tracking is in poljar/rust-weechat#47.

Fix requested by @strk.
