### PR TITLE
feat: mark rooms as read

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -42,13 +42,15 @@ impl MatrixCommand {
             .add_argument("media download <mxc-uri> [file]")
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
+            .add_argument("read")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(format!(
                 "      server: List, add, or remove Matrix servers.
      connect: Connect to Matrix servers.
   disconnect: Disconnect from one or all Matrix servers.
    reconnect: Reconnect to server(s).
-        join: Join a Matrix room by ID or alias.
+       join: Join a Matrix room by ID or alias.
+       read: Mark the current room as read.
      devices: {}
         keys: {}
        media: {}
@@ -72,7 +74,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|read|keys|devices|media",
             );
 
         Command::new(
@@ -263,6 +265,11 @@ Use /matrix [command] help to find out more.\n",
             ("verification", Some(subargs)) => {
                 VerificationCommand::run(buffer, &self.servers, subargs)
             }
+            ("read", _) => {
+                if let Some(room) = self.servers.find_room(buffer) {
+                    room.mark_as_read();
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -369,6 +376,10 @@ impl CommandCallback for MatrixCommand {
                             .value_name("room-id-or-alias")
                             .required(true),
                     ),
+            )
+            .subcommand(
+                SubCommand::with_name("read")
+                    .about("Mark the current room as read."),
             );
 
         parse_and_run(argparse, arguments, |args| self.run(buffer, args));

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,13 @@ config!(
             // Default value.
             false,
         },
+
+        send_read_receipts: bool {
+            // Description
+            "Send public read receipts when marking a room as read",
+            // Default value.
+            true,
+        },
     },
 
     Section input {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -16,7 +16,7 @@ use matrix_sdk::{
     self,
     config::SyncSettings,
     deserialized_responses::AmbiguityChange,
-    room::{Messages, MessagesOptions, Room},
+    room::{Messages, MessagesOptions, Receipts, Room},
     ruma::{
         api::client::{
             device::{
@@ -36,7 +36,7 @@ use matrix_sdk::{
             AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
             SyncStateEvent,
         },
-        OwnedDeviceId, OwnedRoomId, OwnedTransactionId,
+        OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId,
     },
     sync::State,
     Client, LoopCtrl, Result as MatrixResult, RoomMemberships,
@@ -229,6 +229,25 @@ impl Connection {
     ) -> MatrixResult<()> {
         self.spawn(async move { room.typing_notice(typing).await })
             .await
+    }
+
+    pub async fn mark_room_as_read(
+        &self,
+        room: Room,
+        event_id: OwnedEventId,
+        public_receipt: bool,
+    ) -> MatrixResult<()> {
+        self.spawn(async move {
+            let receipts = Receipts::new().fully_read_marker(event_id.clone());
+            let receipts = if public_receipt {
+                receipts.public_read_receipt(event_id)
+            } else {
+                receipts.private_read_receipt(event_id)
+            };
+
+            room.send_multiple_receipts(receipts).await
+        })
+        .await
     }
 
     fn save_device_id(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ impl SignalCallback for Servers {
             if let Some(room) = self.find_room(&buffer) {
                 match signal_name {
                     "buffer_switch" => {
+                        room.mark_as_read_silent();
                         Weechat::spawn(async move {
                             room.get_messages_if_empty().await
                         })
@@ -201,6 +202,8 @@ struct Matrix {
     typing_notice_signal: SignalHook,
     #[allow(dead_code)]
     history_fetch_signal: SignalHook,
+    #[allow(dead_code)]
+    read_marker_signal: SignalHook,
     #[allow(dead_code)]
     completions: Completions,
     debug_buffer: RefCell<Option<BufferHandle>>,
@@ -279,6 +282,8 @@ impl Plugin for Matrix {
             .expect("Can't create signal hook for the typing notice cb");
         let history_fetch = SignalHook::new("buffer_switch", servers.clone())
             .expect("Can't create signal hook for the history fetch cb");
+        let read_marker = SignalHook::new("buffer_switch", servers.clone())
+            .expect("Can't create signal hook for the read marker cb");
 
         let plugin = Matrix {
             global_runtime,
@@ -290,6 +295,7 @@ impl Plugin for Matrix {
             debug_buffer: RefCell::new(None),
             typing_notice_signal: typing,
             history_fetch_signal: history_fetch,
+            read_marker_signal: read_marker,
         };
 
         Weechat::spawn(async move {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -986,10 +986,19 @@ impl MatrixRoom {
                 for event in
                     r.chunk.iter().filter_map(|e| e.raw().deserialize().ok())
                 {
-                    self.handle_room_event(
-                        &event.into_full_event(room_id.clone()),
-                    )
-                    .await;
+                    let event = event.into_full_event(room_id.clone());
+                    if self.latest_event_id.borrow().is_none() {
+                        let event_id = match &event {
+                            AnyTimelineEvent::MessageLike(event) => {
+                                event.event_id().to_owned()
+                            }
+                            AnyTimelineEvent::State(event) => {
+                                event.event_id().to_owned()
+                            }
+                        };
+                        *self.latest_event_id.borrow_mut() = Some(event_id);
+                    }
+                    self.handle_room_event(&event).await;
                 }
 
                 let mut prev_batch = self.prev_batch.borrow_mut();
@@ -1190,6 +1199,19 @@ impl MatrixRoom {
             AnySyncTimelineEvent::State(event) => {
                 self.handle_sync_state_event(event, false).await
             }
+        }
+
+        let is_current = self
+            .buffer_handle()
+            .upgrade()
+            .map(|buffer| {
+                // Sync callbacks run on WeeChat's main thread, so the global
+                // context is valid for this immediate buffer comparison.
+                buffer == unsafe { Weechat::weechat() }.current_buffer()
+            })
+            .unwrap_or(false);
+        if is_current {
+            self.mark_as_read_silent();
         }
     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -68,7 +68,7 @@ use matrix_sdk::{
             AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
             OriginalSyncMessageLikeEvent, SyncMessageLikeEvent, SyncStateEvent,
         },
-        EventId, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId,
+        EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomAliasId,
         OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
     },
     StoreError,
@@ -184,6 +184,8 @@ pub struct MatrixRoom {
 
     messages_in_flight: IntMutex,
     prev_batch: Rc<RefCell<Option<PrevBatch>>>,
+    latest_event_id: Rc<RefCell<Option<OwnedEventId>>>,
+    latest_read_event_id: Rc<RefCell<Option<OwnedEventId>>>,
 
     outgoing_messages: MessageQueue,
 
@@ -262,6 +264,8 @@ impl RoomHandle {
             prev_batch: Rc::new(RefCell::new(
                 room.last_prev_batch().map(PrevBatch::Backwards),
             )),
+            latest_event_id: Rc::new(RefCell::new(None)),
+            latest_read_event_id: Rc::new(RefCell::new(None)),
             own_user_id: own_user_id.into(),
             members,
             buffer,
@@ -890,6 +894,69 @@ impl MatrixRoom {
         *self.prev_batch.borrow_mut() = None;
     }
 
+    fn mark_event_as_read(&self, event_id: OwnedEventId, verbose: bool) {
+        if self.latest_read_event_id.borrow().as_ref() == Some(&event_id) {
+            return;
+        }
+
+        let connection = self.connection.borrow().clone();
+        let room = self.room().clone();
+        let public_receipt =
+            self.config.borrow().network().send_read_receipts();
+        let latest_read_event_id = self.latest_read_event_id.clone();
+
+        let mark_read = async move {
+            if let Some(connection) = connection {
+                match connection
+                    .mark_room_as_read(room, event_id.clone(), public_receipt)
+                    .await
+                {
+                    Ok(()) => {
+                        *latest_read_event_id.borrow_mut() = Some(event_id);
+                    }
+                    Err(e) => {
+                        Weechat::print(&format!(
+                            "{}: Failed to mark room as read: {}",
+                            PLUGIN_NAME, e
+                        ));
+                    }
+                }
+            } else if verbose {
+                Weechat::print(&format!(
+                    "{}: Room is not connected.",
+                    PLUGIN_NAME
+                ));
+            }
+        };
+
+        Weechat::spawn(mark_read).detach();
+    }
+
+    fn mark_latest_event_as_read(&self, verbose: bool) {
+        let event_id =
+            if let Some(event_id) = self.latest_event_id.borrow().clone() {
+                event_id
+            } else if verbose {
+                Weechat::print(&format!(
+                    "{}: No event has been received for this room yet.",
+                    PLUGIN_NAME
+                ));
+                return;
+            } else {
+                return;
+            };
+
+        self.mark_event_as_read(event_id, verbose);
+    }
+
+    pub fn mark_as_read(&self) {
+        self.mark_latest_event_as_read(true);
+    }
+
+    pub fn mark_as_read_silent(&self) {
+        self.mark_latest_event_as_read(false);
+    }
+
     pub async fn get_messages(&self) {
         let messages_lock = self.messages_in_flight.clone();
 
@@ -987,6 +1054,8 @@ impl MatrixRoom {
                 self.buffer.print_rendered_event(rendered);
             }
         }
+
+        self.mark_event_as_read(event_id.to_owned(), false);
     }
 
     async fn handle_edits(&self, event: &AnySyncMessageLikeEvent) {
@@ -1106,6 +1175,13 @@ impl MatrixRoom {
 
     pub async fn handle_sync_room_event(&self, event: AnySyncTimelineEvent) {
         self.set_prev_batch();
+
+        *self.latest_event_id.borrow_mut() = Some(match &event {
+            AnySyncTimelineEvent::MessageLike(event) => {
+                event.event_id().to_owned()
+            }
+            AnySyncTimelineEvent::State(event) => event.event_id().to_owned(),
+        });
 
         match &event {
             AnySyncTimelineEvent::MessageLike(message) => {


### PR DESCRIPTION
Adds `/matrix read` and marks the current room read when switching to its buffer or when our own sent message comes back from sync.

Public read receipts stay enabled by default, with `network.send_read_receipts` to use private read markers instead.

Fixes #37.

Fix requested by @strk.