### PR TITLE
feat: add file upload command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,6 +2362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf6f36070878c42c5233846cd3de24cf9016828fd47bc22957a687298bb21fc"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4627,6 +4637,7 @@ dependencies = [
  "dashmap",
  "image",
  "matrix-sdk",
+ "mime_guess",
  "qrcode",
  "serde_json",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ unicode-segmentation = "1.10.0"
 # Auto-select version from matrix-sdk
 qrcode = { version = "*", default-features = false }
 image = { version = "*", default-features = false, features = ["jpeg"] }
+mime_guess = "2.0"
 
 [dependencies.weechat]
 git = "https://github.com/poljar/rust-weechat"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod matrix;
 mod me;
 mod media;
 mod page_up;
+mod upload;
 mod verification;
 
 use buffer_clear::BufferClearCommand;
@@ -23,6 +24,7 @@ use matrix::MatrixCommand;
 use me::MeCommand;
 use media::MediaCommand;
 use page_up::PageUpCommand;
+use upload::UploadCommand;
 
 pub struct Commands {
     _matrix: Command,
@@ -32,6 +34,7 @@ pub struct Commands {
     _verification: Command,
     _buffer_clear: CommandRun,
     _me: CommandRun,
+    _upload: CommandRun,
 }
 
 impl Commands {
@@ -47,6 +50,7 @@ impl Commands {
             _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,
             _me: MeCommand::create(servers)?,
+            _upload: UploadCommand::create(servers)?,
         })
     }
 }

--- a/src/commands/upload.rs
+++ b/src/commands/upload.rs
@@ -1,0 +1,55 @@
+use std::{borrow::Cow, path::PathBuf};
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::Servers;
+
+pub struct UploadCommand {
+    servers: Servers,
+}
+
+impl UploadCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/upload",
+            UploadCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for UploadCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        cmd: Cow<str>,
+    ) -> ReturnCode {
+        let Some(room) = self.servers.find_room(buffer) else {
+            Weechat::print(
+                "The upload command needs to be executed in a room buffer",
+            );
+            return ReturnCode::Ok;
+        };
+
+        let Some(path) = cmd.strip_prefix("/upload").map(str::trim) else {
+            return ReturnCode::Ok;
+        };
+
+        if path.is_empty() {
+            Weechat::print("Usage: /upload <file>");
+            return ReturnCode::Ok;
+        }
+
+        let path = PathBuf::from(Weechat::expand_home(path));
+        Weechat::spawn(async move { room.send_attachment(path).await })
+            .detach();
+
+        ReturnCode::Ok
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -38,6 +38,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     ops::Deref,
+    path::PathBuf,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -50,6 +51,7 @@ use url::Url;
 
 use matrix_sdk::{
     async_trait,
+    attachment::{AttachmentConfig, AttachmentInfo, BaseFileInfo},
     deserialized_responses::AmbiguityChange,
     room::Room,
     ruma::{
@@ -67,7 +69,7 @@ use matrix_sdk::{
             OriginalSyncMessageLikeEvent, SyncMessageLikeEvent, SyncStateEvent,
         },
         EventId, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId,
-        OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
+        OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UInt, UserId,
     },
     StoreError,
 };
@@ -77,7 +79,7 @@ use weechat::{
         Buffer, BufferBuilderAsync, BufferHandle, BufferInputCallbackAsync,
         BufferLine,
     },
-    Weechat,
+    Prefix, Weechat,
 };
 
 use crate::{
@@ -722,6 +724,69 @@ impl MatrixRoom {
             }
         } else if let Ok(buffer) = self.buffer_handle().upgrade() {
             buffer.print("Error not connected");
+        }
+    }
+
+    fn print_error(&self, message: &str) {
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            buffer.print(&format!(
+                "{}{}",
+                Weechat::prefix(Prefix::Error),
+                message
+            ));
+        }
+    }
+
+    pub async fn send_attachment(&self, path: PathBuf) {
+        let Some(filename) = path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .map(ToOwned::to_owned)
+        else {
+            self.print_error("Invalid file name");
+            return;
+        };
+
+        let data = match std::fs::read(&path) {
+            Ok(data) => data,
+            Err(e) => {
+                self.print_error(&format!(
+                    "Failed to read attachment {}: {}",
+                    path.display(),
+                    e
+                ));
+                return;
+            }
+        };
+
+        let content_type = mime_guess::from_path(&path).first_or_octet_stream();
+        let size = UInt::new(data.len() as u64);
+        let config = AttachmentConfig::new()
+            .info(AttachmentInfo::File(BaseFileInfo { size }));
+
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        match connection
+            .spawn({
+                let room = self.room().clone();
+                async move {
+                    room.send_attachment(filename, &content_type, data, config)
+                        .await
+                }
+            })
+            .await
+        {
+            Ok(_) => (),
+            Err(e) => {
+                self.print_error(&format!(
+                    "Failed to upload attachment {}: {}",
+                    path.display(),
+                    e
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
Adds `/upload <file>` for Matrix room buffers.

The command reads the local file, guesses its MIME type, and sends it through the Matrix SDK attachment API. This is the first plain file-upload path; progress, previews, streaming, completion, and richer local echo can be follow-ups.

Fixes #27.

Fix requested by @strk.