### PR TITLE
feat: expose room parent spaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4635,6 +4635,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
+ "futures-util",
  "image",
  "matrix-sdk",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 uuid = { version = "1.1.2", features = ["v4"] }
 unicode-segmentation = "1.10.0"
+futures-util = "0.3"
 
 # Auto-select version from matrix-sdk
 qrcode = { version = "*", default-features = false }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ The inactivity delay defaults to five minutes and can be changed with:
 
        /set matrix-rust.look.smart_filter_delay 300000
 
+# Matrix Spaces
+
+Room buffers expose Matrix parent Spaces as WeeChat local variables. Switch to a
+room buffer that belongs to a Space and run:
+
+       /buffer listvar
+
+Look for `space`, `space_id`, `spaces`, and `space_ids`. The singular variables
+hold the first parent Space name and room id; the plural variables contain all
+known parent Spaces as comma-separated lists.
+
+The buflist plugin will not reorganize Matrix rooms under Spaces by itself.
+These variables are available to scripts and custom buflist formats. For
+example, to prefix Matrix room names with their first parent Space:
+
+       /set buflist.format.name "${if:${space}?${space}/${name}:${name}}"
+       /buflist refresh
+
+Remove that prefix again with:
+
+       /unset buflist.format.name
+
 # Storage
 
 The plugin keeps Matrix state and encryption data in

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -1,11 +1,16 @@
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
+use futures_util::StreamExt;
 use matrix_sdk::{
+    room::ParentSpace,
     ruma::{EventId, OwnedRoomAliasId, TransactionId, UserId},
-    Room,
+    Error, Room,
 };
 use tokio::runtime::Handle;
-use weechat::buffer::{Buffer, BufferHandle, BufferLine, LineData};
+use weechat::{
+    buffer::{Buffer, BufferHandle, BufferLine, LineData},
+    Prefix, Weechat,
+};
 
 use crate::{render::RenderedEvent, utils::ToTag};
 
@@ -193,6 +198,45 @@ impl RoomBuffer {
         }
     }
 
+    pub fn update_parent_spaces(&self) {
+        let spaces = self.runtime.block_on(parent_spaces(self.room.clone()));
+
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            match spaces {
+                Ok(spaces) => {
+                    let ids = spaces
+                        .iter()
+                        .map(|s| s.id.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let names = spaces
+                        .iter()
+                        .map(|s| s.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",");
+
+                    buffer.set_localvar("space_ids", &ids);
+                    buffer.set_localvar("spaces", &names);
+
+                    if let Some(space) = spaces.first() {
+                        buffer.set_localvar("space_id", space.id.as_str());
+                        buffer.set_localvar("space", &space.name);
+                    } else {
+                        buffer.set_localvar("space_id", "");
+                        buffer.set_localvar("space", "");
+                    }
+                }
+                Err(e) => {
+                    Weechat::print(&format!(
+                        "{}: Error fetching parent spaces from the store: {}",
+                        Weechat::prefix(Prefix::Error),
+                        e,
+                    ));
+                }
+            }
+        }
+    }
+
     fn alias(&self) -> Option<OwnedRoomAliasId> {
         self.room.canonical_alias()
     }
@@ -322,4 +366,40 @@ mod tests {
             "!roomid:matrix.osgeo.org"
         );
     }
+}
+
+struct ParentSpaceInfo {
+    id: String,
+    name: String,
+}
+
+async fn parent_spaces(room: Room) -> Result<Vec<ParentSpaceInfo>, Error> {
+    let mut stream = room.parent_spaces().await?;
+    let mut spaces = Vec::new();
+
+    while let Some(parent) = stream.next().await {
+        match parent? {
+            ParentSpace::Reciprocal(room)
+            | ParentSpace::WithPowerlevel(room)
+            | ParentSpace::Illegitimate(room) => {
+                let id = room.room_id().to_string();
+                let name = room
+                    .display_name()
+                    .await
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|_| id.clone());
+
+                spaces.push(ParentSpaceInfo { id, name });
+            }
+            ParentSpace::Unverifiable(room_id) => {
+                let id = room_id.to_string();
+                spaces.push(ParentSpaceInfo {
+                    id: id.clone(),
+                    name: id,
+                });
+            }
+        }
+    }
+
+    Ok(spaces)
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -348,6 +348,7 @@ impl RoomHandle {
         }
 
         *room.buffer.inner.borrow_mut() = Some(buffer_handle.clone());
+        room.buffer.update_parent_spaces();
 
         Self { inner: room }
     }
@@ -392,6 +393,7 @@ impl RoomHandle {
 
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();
+        room_buffer.buffer.update_parent_spaces();
 
         Ok(room_buffer)
     }
@@ -451,6 +453,10 @@ impl MatrixRoom {
 
     pub fn buffer_handle(&self) -> BufferHandle {
         self.buffer.buffer_handle()
+    }
+
+    pub fn update_parent_spaces(&self) {
+        self.buffer.update_parent_spaces();
     }
 
     pub fn accept_verification(&self) {
@@ -1166,6 +1172,9 @@ impl MatrixRoom {
             AnySyncStateEvent::RoomCanonicalAlias(_) => {
                 self.buffer.set_alias();
                 self.buffer.update_buffer_name();
+            }
+            AnySyncStateEvent::SpaceParent(_) => {
+                self.buffer.update_parent_spaces()
             }
             _ => (),
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -928,8 +928,16 @@ impl InnerServer {
         room_id: &RoomId,
         event: AnySyncStateEvent,
     ) {
+        let refresh_parent_spaces =
+            matches!(&event, AnySyncStateEvent::RoomName(_));
         let room = self.get_or_create_room(room_id);
-        room.handle_sync_state_event(&event, true).await
+        room.handle_sync_state_event(&event, true).await;
+
+        if refresh_parent_spaces {
+            for room in self.rooms() {
+                room.update_parent_spaces();
+            }
+        }
     }
 
     pub async fn receive_joined_timeline_event(


### PR DESCRIPTION
Exposes Matrix parent Spaces on room buffers as localvars.

Room buffers now get `space`, `space_id`, `spaces`, and `space_ids`, refreshed when the room is created/restored and when `m.space.parent` state changes. This gives WeeChat scripts and buflist rules a concrete way to group rooms by Space without pretending a single buffer can appear under multiple server trees.

References #48.

Fix requested by @strk.