### PR TITLE
fix: finish verification cancel lifecycle

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -470,7 +470,8 @@ impl MatrixRoom {
     }
 
     pub fn cancel_verification(&self) {
-        todo!()
+        let verification = self.verification.clone();
+        Weechat::spawn(async move { verification.cancel().await }).detach();
     }
 
     async fn redact_event(&self, event: &SyncRoomRedactionEvent) {

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -32,7 +32,10 @@ pub struct Verification {
 #[derive(Clone, Debug)]
 enum ActiveVerification {
     Request(VerificationRequest),
-    Sas(SasVerification),
+    Sas {
+        flow_id: String,
+        verification: SasVerification,
+    },
 }
 
 impl From<VerificationRequest> for ActiveVerification {
@@ -41,17 +44,13 @@ impl From<VerificationRequest> for ActiveVerification {
     }
 }
 
-impl From<SasVerification> for ActiveVerification {
-    fn from(v: SasVerification) -> Self {
-        Self::Sas(v)
-    }
-}
-
 impl ActiveVerification {
     async fn cancel(self) -> Result<(), Error> {
         match self {
             ActiveVerification::Request(request) => request.cancel().await,
-            ActiveVerification::Sas(sas) => sas.cancel().await,
+            ActiveVerification::Sas { verification, .. } => {
+                verification.cancel().await
+            }
         }
     }
 }
@@ -76,7 +75,7 @@ impl Verification {
         let connection = self.connection.borrow().clone();
 
         if let Some(c) = connection {
-            if let Some(ActiveVerification::Sas(verification)) =
+            if let Some(ActiveVerification::Sas { verification, .. }) =
                 self.inner.borrow().clone()
             {
                 if let Err(e) =
@@ -112,6 +111,7 @@ impl Verification {
             if let Some(ActiveVerification::Request(verification)) =
                 verification
             {
+                let flow_id = verification.flow_id().to_owned();
                 let verification_clone = verification.clone();
 
                 if let Err(e) = c
@@ -135,7 +135,11 @@ impl Verification {
                     .await
                 {
                     Ok(Some(sas)) => {
-                        *self.inner.borrow_mut() = Some(sas.into());
+                        *self.inner.borrow_mut() =
+                            Some(ActiveVerification::Sas {
+                                flow_id,
+                                verification: sas,
+                            });
                     }
                     Ok(None) => {
                         self.print("Could not start emoji verification");
@@ -207,7 +211,11 @@ impl Verification {
                         );
                         self.buffer
                             .replace_verification_event(flow_id, rendered);
-                        *self.inner.borrow_mut() = Some(sas.clone().into());
+                        *self.inner.borrow_mut() =
+                            Some(ActiveVerification::Sas {
+                                flow_id: flow_id.to_string(),
+                                verification: sas.clone(),
+                            });
 
                         // We accept here automatically since the only method
                         // we're supporting is SAS verification
@@ -240,8 +248,9 @@ impl Verification {
                     return;
                 };
                 let flow_id = &e.content.relates_to.event_id;
-                if let Some(ActiveVerification::Sas(sas)) =
-                    self.inner.borrow().clone()
+                if let Some(ActiveVerification::Sas {
+                    verification: sas, ..
+                }) = self.inner.borrow().clone()
                 {
                     if sas.can_be_presented() {
                         let rendered = e.content.render_with_prefix(
@@ -256,9 +265,29 @@ impl Verification {
                 }
             }
             AnySyncMessageLikeEvent::KeyVerificationMac(_) => {}
-            AnySyncMessageLikeEvent::KeyVerificationDone(_) => {
-                self.inner.borrow_mut().take();
-                self.print("Verification done");
+            AnySyncMessageLikeEvent::KeyVerificationDone(e) => {
+                let Some(e) = e.as_original() else {
+                    return;
+                };
+                let completed_flow = e.content.relates_to.event_id.as_str();
+                let matches_active = self
+                    .inner
+                    .borrow()
+                    .as_ref()
+                    .map(|active| match active {
+                        ActiveVerification::Request(request) => {
+                            request.flow_id() == completed_flow
+                        }
+                        ActiveVerification::Sas { flow_id, .. } => {
+                            flow_id == completed_flow
+                        }
+                    })
+                    .unwrap_or(false);
+
+                if matches_active {
+                    self.inner.borrow_mut().take();
+                    self.print("Verification done");
+                }
             }
             AnySyncMessageLikeEvent::RoomMessage(e) => {
                 let Some(e) = e.as_original() else {

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -9,8 +9,9 @@ use matrix_sdk::{
         },
         UserId,
     },
+    Error,
 };
-use weechat::Weechat;
+use weechat::{Prefix, Weechat};
 
 use crate::{
     connection::Connection,
@@ -46,6 +47,15 @@ impl From<SasVerification> for ActiveVerification {
     }
 }
 
+impl ActiveVerification {
+    async fn cancel(self) -> Result<(), Error> {
+        match self {
+            ActiveVerification::Request(request) => request.cancel().await,
+            ActiveVerification::Sas(sas) => sas.cancel().await,
+        }
+    }
+}
+
 impl Verification {
     pub fn new(
         own_user_id: Rc<UserId>,
@@ -69,9 +79,28 @@ impl Verification {
             if let Some(ActiveVerification::Sas(verification)) =
                 self.inner.borrow().clone()
             {
-                let _ret =
-                    c.spawn(async move { verification.confirm().await }).await;
+                if let Err(e) =
+                    c.spawn(async move { verification.confirm().await }).await
+                {
+                    self.print(&format!("Error confirming verification: {e}"));
+                }
             }
+        }
+    }
+
+    pub async fn cancel(&self) {
+        let connection = self.connection.borrow().clone();
+        let verification = self.inner.borrow_mut().take();
+
+        if let (Some(c), Some(verification)) = (connection, verification) {
+            match c.spawn(async move { verification.cancel().await }).await {
+                Ok(()) => self.print("Verification canceled"),
+                Err(e) => {
+                    self.print(&format!("Error canceling verification: {e}"))
+                }
+            }
+        } else {
+            self.print("No active verification to cancel");
         }
     }
 
@@ -85,7 +114,7 @@ impl Verification {
             {
                 let verification_clone = verification.clone();
 
-                let _ret = c
+                if let Err(e) = c
                     .spawn(async move {
                         verification
                             .accept_with_methods(vec![
@@ -93,18 +122,41 @@ impl Verification {
                             ])
                             .await
                     })
-                    .await;
+                    .await
+                {
+                    self.print(&format!("Error accepting verification: {e}"));
+                    return;
+                }
 
                 // We automatically start SAS verification here since it's the
                 // only method we support.
-                if let Some(sas) = c
+                match c
                     .spawn(async move { verification_clone.start_sas().await })
                     .await
-                    .unwrap()
                 {
-                    *self.inner.borrow_mut() = Some(sas.into());
+                    Ok(Some(sas)) => {
+                        *self.inner.borrow_mut() = Some(sas.into());
+                    }
+                    Ok(None) => {
+                        self.print("Could not start emoji verification");
+                    }
+                    Err(e) => {
+                        self.print(&format!(
+                            "Error starting emoji verification: {e}"
+                        ));
+                    }
                 }
             }
+        }
+    }
+
+    fn print(&self, message: &str) {
+        if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
+            buffer.print(&format!(
+                "{}{}",
+                Weechat::prefix(Prefix::Network),
+                message
+            ));
         }
     }
 
@@ -159,14 +211,27 @@ impl Verification {
 
                         // We accept here automatically since the only method
                         // we're supporting is SAS verification
-                        let _ret = connection
+                        if let Err(e) = connection
                             .spawn(async move { sas.accept().await })
-                            .await;
+                            .await
+                        {
+                            self.print(&format!(
+                                "Error accepting verification: {e}"
+                            ));
+                        }
                     }
                 }
             }
-            AnySyncMessageLikeEvent::KeyVerificationCancel(_) => {
+            AnySyncMessageLikeEvent::KeyVerificationCancel(e) => {
                 self.inner.borrow_mut().take();
+                let Some(e) = e.as_original() else {
+                    self.print("Verification canceled");
+                    return;
+                };
+                self.print(&format!(
+                    "Verification canceled: {} ({})",
+                    e.content.reason, e.content.code
+                ));
             }
             AnySyncMessageLikeEvent::KeyVerificationAccept(_) => {}
             AnySyncMessageLikeEvent::KeyVerificationKey(e) => {
@@ -191,7 +256,10 @@ impl Verification {
                 }
             }
             AnySyncMessageLikeEvent::KeyVerificationMac(_) => {}
-            AnySyncMessageLikeEvent::KeyVerificationDone(_) => {}
+            AnySyncMessageLikeEvent::KeyVerificationDone(_) => {
+                self.inner.borrow_mut().take();
+                self.print("Verification done");
+            }
             AnySyncMessageLikeEvent::RoomMessage(e) => {
                 let Some(e) = e.as_original() else {
                     // Unhandled redacted event

--- a/src/server.rs
+++ b/src/server.rs
@@ -916,6 +916,9 @@ impl InnerServer {
                 refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string()).await
             }
+            AnyToDeviceEvent::KeyVerificationDone(e) => {
+                handle_event(&event, e.content.transaction_id.to_string()).await
+            }
             _ => {}
         }
 

--- a/src/verification_buffer.rs
+++ b/src/verification_buffer.rs
@@ -103,7 +103,15 @@ struct InnerVerificationBuffer {
 }
 
 impl InnerVerificationBuffer {
-    fn print_done(&self, _buffer: BufferHandle) {}
+    fn print_message(buffer: BufferHandle, message: &str) {
+        if let Ok(buffer) = buffer.upgrade() {
+            buffer.print(message);
+        }
+    }
+
+    fn print_done(&self, buffer: BufferHandle) {
+        Self::print_message(buffer, "Verification done");
+    }
 
     pub async fn accept(&self, buffer: BufferHandle) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
@@ -320,9 +328,10 @@ impl VerificationBuffer {
                 }
             }
             AnyToDeviceEvent::KeyVerificationCancel(_) => {
-                // let message =
-                //     format!("The verification flow has been canceled");
-                // self.print(&message);
+                InnerVerificationBuffer::print_message(
+                    self.buffer.clone(),
+                    "Verification canceled",
+                );
             }
             AnyToDeviceEvent::KeyVerificationKey(e) => {
                 self.print_sas(&e.content);
@@ -336,7 +345,9 @@ impl VerificationBuffer {
                     }
                 }
             }
-            AnyToDeviceEvent::KeyVerificationDone(_) => {}
+            AnyToDeviceEvent::KeyVerificationDone(_) => {
+                self.inner.print_done(self.buffer.clone());
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
Finishes a few room and verification-buffer lifecycle edges for emoji verification.

The room `/matrix verification cancel` path no longer panics, cancel/done events now print a short status message, and accept/confirm failures are reported instead of being silently ignored. This keeps the existing SAS flow intact.

References #32.

Fix requested by @strk.