### PR TITLE
fix: refresh room verification status

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -392,6 +392,10 @@ impl BufferInputCallbackAsync for MatrixRoom {
 }
 
 impl MatrixRoom {
+    fn update_status_bar(&self) {
+        Weechat::bar_item_update("buffer_modes");
+    }
+
     pub fn is_encrypted(&self) -> bool {
         self.members
             .runtime
@@ -972,7 +976,9 @@ impl MatrixRoom {
                 ambiguity_change,
                 smart_filter_delay_ms,
             )
-            .await
+            .await;
+
+        self.update_status_bar();
     }
 
     fn set_prev_batch(&self) {
@@ -1054,5 +1060,7 @@ impl MatrixRoom {
             AnySyncStateEvent::RoomCanonicalAlias(_) => self.buffer.set_alias(),
             _ => (),
         }
+
+        self.update_status_bar();
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -417,10 +417,6 @@ impl BufferInputCallbackAsync for MatrixRoom {
 }
 
 impl MatrixRoom {
-    fn update_status_bar(&self) {
-        Weechat::bar_item_update("buffer_modes");
-    }
-
     pub fn is_encrypted(&self) -> bool {
         self.members
             .runtime
@@ -1096,7 +1092,7 @@ impl MatrixRoom {
             )
             .await;
 
-        self.update_status_bar();
+        Weechat::bar_item_update("buffer_modes");
     }
 
     fn set_prev_batch(&self) {
@@ -1182,9 +1178,11 @@ impl MatrixRoom {
             AnySyncStateEvent::SpaceParent(_) => {
                 self.buffer.update_parent_spaces()
             }
-            _ => (),
+            AnySyncStateEvent::RoomEncryption(_)
+            | AnySyncStateEvent::RoomJoinRules(_) => {
+                Weechat::bar_item_update("buffer_modes");
+            }
+            _ => {}
         }
-
-        self.update_status_bar();
     }
 }

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -10,6 +10,7 @@ use matrix_sdk::{
         UserId,
     },
 };
+use weechat::Weechat;
 
 use crate::{
     connection::Connection,
@@ -222,5 +223,7 @@ impl Verification {
             }
             _ => {}
         }
+
+        Weechat::bar_item_update("buffer_modes");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -912,6 +912,10 @@ impl InnerServer {
                 refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string()).await
             }
+            AnyToDeviceEvent::KeyVerificationDone(e) => {
+                refresh_status_bar = true;
+                handle_event(&event, e.content.transaction_id.to_string()).await
+            }
             _ => {}
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -693,10 +693,13 @@ impl InnerServer {
             }
         };
 
+        let mut refresh_status_bar = false;
+
         match &event {
             AnyToDeviceEvent::RoomKey(_) => {}
             AnyToDeviceEvent::RoomKeyRequest(_) => {}
             AnyToDeviceEvent::KeyVerificationRequest(e) => {
+                refresh_status_bar = true;
                 if let Some(client) = self.get_client() {
                     if let Some(request) = client
                         .encryption()
@@ -721,6 +724,7 @@ impl InnerServer {
                 }
             }
             AnyToDeviceEvent::KeyVerificationStart(e) => {
+                refresh_status_bar = true;
                 if let Some(client) = self.get_client() {
                     use matrix_sdk::encryption::verification::Verification;
                     match client
@@ -777,19 +781,27 @@ impl InnerServer {
                 }
             }
             AnyToDeviceEvent::KeyVerificationCancel(e) => {
+                refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string())
                     .await;
             }
             AnyToDeviceEvent::KeyVerificationAccept(e) => {
+                refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string()).await
             }
             AnyToDeviceEvent::KeyVerificationKey(e) => {
+                refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string()).await
             }
             AnyToDeviceEvent::KeyVerificationMac(e) => {
+                refresh_status_bar = true;
                 handle_event(&event, e.content.transaction_id.to_string()).await
             }
             _ => {}
+        }
+
+        if refresh_status_bar {
+            Weechat::bar_item_update("buffer_modes");
         }
     }
 


### PR DESCRIPTION
Refreshes the room status bar when room state, membership, or verification events can change the signs shown in `buffer_modes`.

The status item already renders encrypted rooms and the unverified-device warning. This makes the item repaint when the state behind those signs changes instead of waiting for an unrelated refresh.

References #31.

Fix requested by @strk.