### PR TITLE
feat: support SSO login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1519,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2051,6 +2105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrix-pickle"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2145,7 @@ dependencies = [
  "async-channel",
  "async-stream",
  "async-trait",
+ "axum",
  "backon",
  "bytes",
  "bytesize",
@@ -2112,6 +2173,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rand 0.8.5",
  "reqwest",
  "ruma",
  "serde",
@@ -2123,6 +2185,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
  "tracing",
  "url",
  "urlencoding",
@@ -4191,6 +4254,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4234,6 +4298,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ git = "https://github.com/poljar/rust-weechat"
 version = "0.14.0"
 # git = "https://github.com/matrix-org/matrix-rust-sdk.git"
 # rev = "92192c549b3f53889c23954386743867a73b31b1"
-features = ["markdown", "socks", "qrcode"]
+features = ["markdown", "socks", "qrcode", "sso-login"]
 
 [profile.dev.package]
 sha2 = { opt-level = 2 }

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ _(replace the placeholders in brackets [] with your own details)_:
        /set matrix-rust.server.[server-name].username [username]
        /set matrix-rust.server.[server-name].password [password]
 
-   To use single sign-on instead of password login, leave the password empty.
-   WeeChat will print a login URL when you connect.
+   If the homeserver advertises single sign-on, leave the password empty to use
+   it. WeeChat will print a login URL when you connect.
 
 3. Now try to connect. The first connection can take a few minutes while the
    client syncs the account:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ _(replace the placeholders in brackets [] with your own details)_:
    If the homeserver advertises single sign-on, leave the password empty to use
    it. WeeChat will print a login URL when you connect.
 
+   The SSO callback listens on `127.0.0.1:29325` on the WeeChat host. When
+   WeeChat runs on another machine, create an SSH tunnel before connecting so
+   the browser's localhost callback reaches it:
+
+       ssh -L 29325:127.0.0.1:29325 user@weechat-host
+
 3. Now try to connect. The first connection can take a few minutes while the
    client syncs the account:
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ _(replace the placeholders in brackets [] with your own details)_:
        /set matrix-rust.server.[server-name].username [username]
        /set matrix-rust.server.[server-name].password [password]
 
+   To use single sign-on instead of password login, leave the password empty.
+   WeeChat will print a login URL when you connect.
+
 3. Now try to connect. The first connection can take a few minutes while the
    client syncs the account:
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -27,7 +27,10 @@ use matrix_sdk::{
                 FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter,
             },
             message::send_message_event::v3::Response as RoomSendResponse,
-            session::login::v3::Response as LoginResponse,
+            session::{
+                get_login_types::v3::LoginType,
+                login::v3::Response as LoginResponse,
+            },
             sync::sync_events::v3::Filter,
             uiaa::{AuthData, Password, UserIdentifier},
         },
@@ -68,6 +71,7 @@ impl InteractiveAuthInfo {
 
 pub enum ClientMessage {
     LoginMessage(LoginResponse),
+    SsoLoginUrl(String),
     SyncState(OwnedRoomId, AnySyncStateEvent),
     SyncEvent(OwnedRoomId, AnySyncTimelineEvent),
     ToDeviceEvent(AnyToDeviceEvent),
@@ -284,6 +288,9 @@ impl Connection {
             match message {
                 Ok(message) => match message {
                     ClientMessage::LoginMessage(r) => server.receive_login(r),
+                    ClientMessage::SsoLoginUrl(url) => {
+                        server.receive_sso_url(&url)
+                    }
                     ClientMessage::SyncEvent(r, e) => {
                         server.receive_joined_timeline_event(&r, e).await
                     }
@@ -341,8 +348,14 @@ impl Connection {
         server_path: PathBuf,
     ) {
         if !client.matrix_auth().logged_in() {
+            let device_id_key = if username.is_empty() {
+                server_name.as_str()
+            } else {
+                username.as_str()
+            };
+
             let device_id =
-                Connection::load_device_id(&username, server_path.clone());
+                Connection::load_device_id(device_id_key, server_path.clone());
 
             let device_id = match device_id {
                 Err(e) => {
@@ -360,20 +373,71 @@ impl Connection {
             };
 
             let first_login = device_id.is_none();
+            let matrix_auth = client.matrix_auth();
 
-            let mut builder = client
-                .matrix_auth()
-                .login_username(&username, &password)
-                .initial_device_display_name("WeeChat-Matrix-rs");
+            let login_response = if password.is_empty() {
+                let login_types = match matrix_auth.get_login_types().await {
+                    Ok(response) => response,
+                    Err(e) => {
+                        let _ = channel
+                            .send(Err(format!(
+                                "Failed to get login types: {}",
+                                e
+                            )))
+                            .await;
+                        return;
+                    }
+                };
 
-            if let Some(device_id) = device_id.as_ref() {
-                builder = builder.device_id(device_id);
+                let has_sso = login_types
+                    .flows
+                    .iter()
+                    .any(|flow| matches!(flow, LoginType::Sso(_)));
+
+                if !has_sso {
+                    let _ = channel
+                        .send(Err(
+                            "No password configured and homeserver does not advertise SSO login"
+                                .to_owned(),
+                        ))
+                        .await;
+                    return;
+                }
+
+                let sso_channel = channel.clone();
+                let mut builder = matrix_auth
+                    .login_sso(move |sso_url| {
+                        let sso_channel = sso_channel.clone();
+                        async move {
+                            let _ = sso_channel
+                                .send(Ok(ClientMessage::SsoLoginUrl(sso_url)))
+                                .await;
+                            Ok(())
+                        }
+                    })
+                    .initial_device_display_name("WeeChat-Matrix-rs");
+
+                if let Some(device_id) = device_id.as_ref() {
+                    builder = builder.device_id(device_id);
+                };
+
+                builder.send().await
+            } else {
+                let mut builder = matrix_auth
+                    .login_username(&username, &password)
+                    .initial_device_display_name("WeeChat-Matrix-rs");
+
+                if let Some(device_id) = device_id.as_ref() {
+                    builder = builder.device_id(device_id);
+                };
+
+                builder.send().await
             };
 
-            match builder.send().await {
+            match login_response {
                 Ok(response) => {
                     if let Err(e) = Connection::save_device_id(
-                        &username,
+                        device_id_key,
                         server_path.clone(),
                         &response,
                     ) {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -42,6 +42,7 @@ use matrix_sdk::{
         OwnedDeviceId, OwnedRoomId, OwnedTransactionId,
     },
     sync::State,
+    utils::local_server::LocalServerBuilder,
     Client, LoopCtrl, Result as MatrixResult, RoomMemberships,
 };
 
@@ -53,6 +54,7 @@ use crate::{
 };
 
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+const SSO_CALLBACK_PORT: u16 = 29_325;
 
 pub struct InteractiveAuthInfo {
     pub user: String,
@@ -416,7 +418,12 @@ impl Connection {
                             Ok(())
                         }
                     })
-                    .initial_device_display_name("WeeChat-Matrix-rs");
+                    .initial_device_display_name("WeeChat-Matrix-rs")
+                    .server_builder(
+                        LocalServerBuilder::new().port_range(
+                            SSO_CALLBACK_PORT..SSO_CALLBACK_PORT + 1,
+                        ),
+                    );
 
                 if let Some(device_id) = device_id.as_ref() {
                     builder = builder.device_id(device_id);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -404,14 +404,15 @@ impl Connection {
                     return;
                 }
 
-                let sso_channel = channel.clone();
+                let url_sender = channel.clone();
                 let mut builder = matrix_auth
                     .login_sso(move |sso_url| {
-                        let sso_channel = sso_channel.clone();
                         async move {
-                            let _ = sso_channel
+                            let _ = url_sender
                                 .send(Ok(ClientMessage::SsoLoginUrl(sso_url)))
                                 .await;
+                            // Handing the URL to WeeChat successfully completes
+                            // our callback; returning an error would abort SSO.
                             Ok(())
                         }
                     })

--- a/src/server.rs
+++ b/src/server.rs
@@ -979,6 +979,16 @@ impl InnerServer {
         *self.login_state.borrow_mut() = Some(login_state);
     }
 
+    pub fn receive_sso_url(&self, url: &str) {
+        self.print_network(&format!(
+            "Open this URL to finish SSO login for {}{}{}: {}",
+            Weechat::color("chat_server"),
+            self.name(),
+            Weechat::color("reset"),
+            url,
+        ));
+    }
+
     fn create_server_dir(&self) -> std::io::Result<()> {
         let path = self.get_server_path();
         std::fs::create_dir_all(path)


### PR DESCRIPTION
Adds first-login SSO support using the Matrix SDK's built-in `sso-login` flow.

If the server password option is empty, `/matrix connect` checks whether the homeserver advertises SSO, prints the browser login URL in WeeChat, and lets the SDK's local callback server finish the login. Normal username/password login is unchanged when a password is configured.

The branch is split into two commits: first enabling the Matrix SDK `sso-login` feature and lockfile changes, then the weechat-matrix-rs login flow and README note.

This keeps the scope smaller than poljar/weechat-matrix-rs#119: no manual token command, no extra config switch, and no custom callback server in this plugin. Manual token entry is tracked separately in poljar/weechat-matrix-rs#172.

Fixes poljar/weechat-matrix-rs#28.
Fixes poljar/weechat-matrix-rs#108.
References poljar/weechat-matrix-rs#119.

Checked with `cargo fmt --check`, `git diff --check`, and Docker `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo check --locked`.

Fix requested by @strk.
