### PR TITLE
fix: split Matrix SDK event cache storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ The inactivity delay defaults to five minutes and can be changed with:
 
        /set matrix-rust.look.smart_filter_delay 300000
 
+# Storage
+
+The plugin keeps Matrix state and encryption data in
+`$WEECHAT_HOME/matrix-rust/<server>/`. It keeps the Matrix SDK event cache in
+`$WEECHAT_HOME/matrix-rust/<server>-cache/`.
+
+If the cache grows or causes too much disk I/O, disconnect WeeChat and remove
+only the `-cache` directory. Do not remove the main server directory unless you
+want to reset stored Matrix state.
 
 # Helpful Commands
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -854,6 +854,15 @@ impl InnerServer {
         path
     }
 
+    fn get_server_cache_path(&self) -> PathBuf {
+        let mut path = Weechat::home_dir();
+        let server_name: &str = &self.server_name;
+        path.push("matrix-rust");
+        path.push(format!("{}-cache", server_name));
+
+        path
+    }
+
     pub fn connection(&self) -> Option<Connection> {
         self.connection.borrow().clone()
     }
@@ -878,7 +887,11 @@ impl InnerServer {
 
         let mut client_builder = Client::builder()
             .homeserver_url(homeserver)
-            .sqlite_store(self.get_server_path(), Some("DEFAULT_PASSPHRASE"));
+            .sqlite_store_with_cache_path(
+                self.get_server_path(),
+                self.get_server_cache_path(),
+                Some("DEFAULT_PASSPHRASE"),
+            );
 
         if let Some(proxy) = settings.proxy.as_ref() {
             client_builder = client_builder.proxy(proxy);


### PR DESCRIPTION
Separates the Matrix SDK event cache from the state and crypto stores.

The existing per-server directory keeps Matrix state and encryption data. The event cache now goes into a sibling `<server>-cache` directory, so cache cleanup no longer requires deleting the important state directory.

The README documents which directory is safe to remove when cache churn or disk I/O becomes a problem.

This is a narrow mitigation for the disk-I/O report, not a claim that every possible write source is gone.

Fixes #70.

Checked with `cargo fmt --check`, `git diff --check`, and Docker `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/tmp/weechat-cache-split-check cargo check --locked`.

Fix requested by @strk.