### PR TITLE
feat: add authenticated media download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,5 @@ _(replace the placeholders in brackets [] with your own details)_:
 
 Room buffers accept normal message input after `/matrix connect [server-name]`
 has completed.
+
+`/matrix media download <mxc-uri> <file>` downloads Matrix media through the logged-in client, including homeservers that require authenticated media. It refuses to overwrite an existing file.

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -12,7 +12,7 @@ use weechat::{
 
 use super::{parse_and_run, verification::VerificationCommand};
 use crate::{
-    commands::{DevicesCommand, KeysCommand},
+    commands::{DevicesCommand, KeysCommand, MediaCommand},
     config::ConfigHandle,
     MatrixServer, Servers, PLUGIN_NAME,
 };
@@ -34,6 +34,7 @@ impl MatrixCommand {
             .add_argument("connect <server-name>")
             .add_argument("devices delete|list|set-name")
             .add_argument("keys import|export <file> <passphrase>")
+            .add_argument("media download <mxc-uri> <file>")
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
@@ -44,16 +45,19 @@ impl MatrixCommand {
    reconnect: Reconnect to server(s).
      devices: {}
         keys: {}
+       media: {}
 verification: {}
         help: Show detailed command help.\n
 Use /matrix [command] help to find out more.\n",
                 DevicesCommand::DESCRIPTION,
                 KeysCommand::DESCRIPTION,
+                MediaCommand::DESCRIPTION,
                 VerificationCommand::DESCRIPTION,
             ))
             .add_completion("server add|delete|list|listfull")
             .add_completion("devices list|delete|set-name %(matrix-users)")
             .add_completion(format!("keys {}", KeysCommand::COMPLETION))
+            .add_completion(format!("media {}", MediaCommand::COMPLETION))
             .add_completion(format!(
                 "verification {}",
                 VerificationCommand::COMPLETION
@@ -62,7 +66,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|keys|devices",
+                "help server|connect|disconnect|reconnect|keys|devices|media",
             );
 
         Command::new(
@@ -230,6 +234,9 @@ Use /matrix [command] help to find out more.\n",
             ("keys", Some(subargs)) => {
                 KeysCommand::run(buffer, &self.servers, subargs)
             }
+            ("media", Some(subargs)) => {
+                MediaCommand::run(buffer, &self.servers, subargs)
+            }
             ("verification", Some(subargs)) => {
                 VerificationCommand::run(buffer, &self.servers, subargs)
             }
@@ -299,6 +306,12 @@ impl CommandCallback for MatrixCommand {
                     .about(KeysCommand::DESCRIPTION)
                     .settings(KeysCommand::SETTINGS)
                     .subcommands(KeysCommand::subcommands()),
+            )
+            .subcommand(
+                SubCommand::with_name("media")
+                    .about(MediaCommand::DESCRIPTION)
+                    .settings(MediaCommand::SETTINGS)
+                    .subcommands(MediaCommand::subcommands()),
             )
             .subcommand(
                 SubCommand::with_name("verification")

--- a/src/commands/media.rs
+++ b/src/commands/media.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+use clap::{
+    App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches,
+    SubCommand,
+};
+use matrix_sdk::ruma::MxcUri;
+use weechat::{buffer::Buffer, Weechat};
+
+use crate::Servers;
+
+pub struct MediaCommand;
+
+impl MediaCommand {
+    pub const DESCRIPTION: &'static str = "Download Matrix media.";
+    pub const COMPLETION: &'static str = "download";
+
+    pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
+        let server = match servers.find_server(buffer) {
+            Some(server) => server,
+            None => {
+                Weechat::print("Must be executed on Matrix buffer");
+                return;
+            }
+        };
+
+        match args.subcommand() {
+            ("download", Some(args)) => {
+                let uri = args
+                    .value_of("mxc-uri")
+                    .expect("MXC URI not set but was required");
+                let uri = Box::<MxcUri>::from(uri);
+
+                if !uri.is_valid() {
+                    Weechat::print("Invalid MXC URI");
+                    return;
+                }
+
+                let file = args
+                    .value_of("file")
+                    .expect("File not set but was required");
+                let file = PathBuf::from(Weechat::expand_home(file));
+
+                Weechat::spawn(async move {
+                    server.download_media(uri.into(), file).await;
+                })
+                .detach();
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn subcommands() -> Vec<Argparse<'static, 'static>> {
+        vec![SubCommand::with_name("download")
+            .about("Download the MXC URI through the logged-in Matrix client")
+            .arg(Arg::with_name("mxc-uri").required(true).validator(|uri| {
+                let uri = Box::<MxcUri>::from(uri.as_str());
+
+                if uri.is_valid() {
+                    Ok(())
+                } else {
+                    Err("The given URI is not a valid MXC URI".to_owned())
+                }
+            }))
+            .arg(Arg::with_name("file").required(true))]
+    }
+
+    pub const SETTINGS: &'static [ArgParseSettings] = &[
+        ArgParseSettings::DisableHelpFlags,
+        ArgParseSettings::DisableVersion,
+        ArgParseSettings::VersionlessSubcommands,
+        ArgParseSettings::SubcommandRequiredElseHelp,
+    ];
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod devices;
 mod keys;
 mod matrix;
 mod me;
+mod media;
 mod page_up;
 mod verification;
 
@@ -20,6 +21,7 @@ use devices::DevicesCommand;
 use keys::KeysCommand;
 use matrix::MatrixCommand;
 use me::MeCommand;
+use media::MediaCommand;
 use page_up::PageUpCommand;
 
 pub struct Commands {

--- a/src/render.rs
+++ b/src/render.rs
@@ -415,6 +415,15 @@ fn mxc_to_emxc(
     Ok(emxc_url.to_string())
 }
 
+fn media_download_command(source: &MediaSource) -> Option<String> {
+    match source {
+        MediaSource::Plain(url) => {
+            Some(format!("/matrix media download {} <file>", url.as_str()))
+        }
+        MediaSource::Encrypted(_) => None,
+    }
+}
+
 impl<C: HasUrlOrFile> Render for C {
     type RenderContext = Url;
     const TAGS: &'static [&'static str] = &["matrix_media"];
@@ -443,7 +452,16 @@ impl<C: HasUrlOrFile> Render for C {
             tags: self.tags(),
         };
 
-        RenderedContent { lines: vec![line] }
+        let mut lines = vec![line];
+
+        if let Some(command) = media_download_command(self.source()) {
+            lines.push(RenderedLine {
+                message: format!("authenticated download: {}", command),
+                tags: self.tags(),
+            });
+        }
+
+        RenderedContent { lines }
     }
 }
 
@@ -1021,5 +1039,46 @@ mod tests {
             expected,
             mxc_to_emxc(&mxc_url, &homeserver, &encrypt_info).unwrap()
         );
+    }
+
+    #[test]
+    fn test_plain_media_download_command() {
+        let source = MediaSource::Plain(OwnedMxcUri::from(
+            "mxc://matrix.org/some-media-id",
+        ));
+
+        assert_eq!(
+            Some(
+                "/matrix media download mxc://matrix.org/some-media-id <file>"
+                    .to_owned()
+            ),
+            media_download_command(&source)
+        );
+    }
+
+    #[test]
+    fn test_encrypted_media_has_no_plain_download_command() {
+        use std::collections::BTreeMap;
+
+        let mut hashes: BTreeMap<String, Base64> = BTreeMap::new();
+        hashes.insert("sha256".to_string(), Base64::parse("aGFzaA").unwrap());
+        let encrypt_info = EncryptedFileInit {
+            key: JsonWebKeyInit {
+                k: Base64::parse("dGVzdA").unwrap(),
+                kty: "oct".to_string(),
+                key_ops: vec![],
+                ext: true,
+                alg: "A256CTR".to_string(),
+            }
+            .into(),
+            iv: Base64::parse("aXY").unwrap(),
+            v: "v2".to_string(),
+            url: OwnedMxcUri::from("mxc://some-url"),
+            hashes,
+        }
+        .into();
+        let source = MediaSource::Encrypted(Box::new(encrypt_info));
+
+        assert_eq!(None, media_download_command(&source));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,6 +59,7 @@ use std::{
     cell::{Ref, RefCell, RefMut},
     cmp::Reverse,
     collections::HashMap,
+    io::Write,
     path::PathBuf,
     rc::{Rc, Weak},
 };
@@ -69,15 +70,17 @@ use matrix_sdk::{
     self,
     deserialized_responses::AmbiguityChange,
     encryption::RoomKeyImportResult,
+    media::{MediaFormat, MediaRequestParameters},
     room::Room,
     ruma::{
         api::client::session::login::v3::Response as LoginResponse,
         events::{
-            room::member::RoomMemberEventContent, AnySyncStateEvent,
-            AnySyncTimelineEvent, AnyToDeviceEvent, SyncStateEvent,
+            room::{member::RoomMemberEventContent, MediaSource},
+            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
+            SyncStateEvent,
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
-        OwnedDeviceId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+        OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, UserId,
     },
     Client, Error,
 };
@@ -1015,6 +1018,53 @@ impl InnerServer {
                 }
             }
         };
+    }
+
+    pub async fn download_media(&self, uri: OwnedMxcUri, file: PathBuf) {
+        let connection = if let Some(c) = self.connection() {
+            c
+        } else {
+            self.print_error("You must be connected to execute this command");
+            return;
+        };
+
+        let client = connection.client().clone();
+        let request = MediaRequestParameters {
+            source: MediaSource::Plain(uri),
+            format: MediaFormat::File,
+        };
+        let display_file = file.display().to_string();
+
+        self.print_network(&format!("Downloading media to {}", display_file));
+
+        match connection
+            .spawn(async move {
+                client.media().get_media_content(&request, true).await
+            })
+            .await
+        {
+            Ok(content) => {
+                if let Err(e) = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&file)
+                    .and_then(|mut file| file.write_all(&content))
+                {
+                    self.print_error(&format!(
+                        "Error writing media to {}: {:#?}",
+                        display_file, e
+                    ));
+                } else {
+                    self.print_network(&format!(
+                        "Successfully downloaded media to {}",
+                        display_file
+                    ));
+                }
+            }
+            Err(e) => {
+                self.print_error(&format!("Error downloading media {:#?}", e));
+            }
+        }
     }
 
     async fn list_own_devices(


### PR DESCRIPTION
Adds a plain Matrix media download path through the logged-in Matrix client.

`/matrix media download <mxc-uri> <file>` asks matrix-sdk to fetch the MXC URI, so homeservers that require authenticated media can still be used for plain media. The command refuses to overwrite an existing file.

Plain media messages also print the exact `/matrix media download ... <file>` command as a hint. Encrypted media keeps the existing `emxc://` rendering; supporting authenticated encrypted downloads needs the event's encrypted-file metadata and is intentionally outside this small batch.

References #95.

Checked with:

- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`
- Ubuntu 24.04 Docker with Rust 1.96.0, `WEECHAT_BUNDLED=1`, and `CARGO_TARGET_DIR=/tmp/weechat-pr156-test cargo test --locked media_download_command --lib`

Fix requested by @strk.
