### PR TITLE
docs: mention first connect may take time

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ _(replace the placeholders in brackets [] with your own details)_:
        /set matrix-rust.server.[server-name].username [username]
        /set matrix-rust.server.[server-name].password [password]
 
-3. Now try to connect:
+3. Now try to connect. The first connection can take a few minutes while the
+   client syncs the account:
 
        /matrix connect [server-name]
 


### PR DESCRIPTION
Adds one setup note: the first `/matrix connect` can take a few minutes while the Matrix client syncs the account.

This carries over the remaining useful first-use guidance from #50 without reviving that old conflicting README branch.

References #50.

Fix requested by @strk.