### PR TITLE
feat: add room moderation commands

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod keys;
 mod matrix;
 mod me;
 mod media;
+mod moderation;
 mod names;
 mod page_up;
 mod part;
@@ -30,6 +31,7 @@ use keys::KeysCommand;
 use matrix::MatrixCommand;
 use me::MeCommand;
 use media::MediaCommand;
+use moderation::ModerationCommand;
 use names::NamesCommand;
 use page_up::PageUpCommand;
 use part::PartCommand;
@@ -41,6 +43,8 @@ pub struct Commands {
     _keys: Command,
     _devices: Command,
     _invite: Command,
+    _ban: Command,
+    _kick: Command,
     _page_up: CommandRun,
     _redact: Command,
     _verification: Command,
@@ -50,6 +54,7 @@ pub struct Commands {
     _upload: CommandRun,
     _part: CommandRun,
     _names: CommandRun,
+    _unban: Command,
 }
 
 impl Commands {
@@ -61,6 +66,8 @@ impl Commands {
             _matrix: MatrixCommand::create(servers, config)?,
             _devices: DevicesCommand::create(servers)?,
             _invite: InviteCommand::create(servers)?,
+            _ban: ModerationCommand::ban(servers)?,
+            _kick: ModerationCommand::kick(servers)?,
             _keys: KeysCommand::create(servers)?,
             _page_up: PageUpCommand::create(servers)?,
             _redact: RedactCommand::create(servers)?,
@@ -71,6 +78,7 @@ impl Commands {
             _upload: UploadCommand::create(servers)?,
             _part: PartCommand::create(servers)?,
             _names: NamesCommand::create(servers)?,
+            _unban: ModerationCommand::unban(servers)?,
         })
     }
 }

--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -111,8 +111,8 @@ impl ModerationCommand {
         let room = room.room().clone();
         let action = self.action;
         let error_user_id = user_id.clone();
-        let result = self.servers.runtime().block_on(async move {
-            match action {
+        Weechat::spawn(async move {
+            let result = match action {
                 ModerationAction::Ban => {
                     room.ban_user(&user_id, reason.as_deref()).await
                 }
@@ -122,19 +122,20 @@ impl ModerationCommand {
                 ModerationAction::Unban => {
                     room.unban_user(&user_id, reason.as_deref()).await
                 }
-            }
-        });
+            };
 
-        if let Err(error) = result {
-            Weechat::print(&format!(
-                "{}{}: Failed to {} {}: {}",
-                Weechat::prefix(Prefix::Error),
-                PLUGIN_NAME,
-                self.action.verb(),
-                error_user_id,
-                error
-            ));
-        }
+            if let Err(error) = result {
+                Weechat::print(&format!(
+                    "{}{}: Failed to {} {}: {}",
+                    Weechat::prefix(Prefix::Error),
+                    PLUGIN_NAME,
+                    action.verb(),
+                    error_user_id,
+                    error
+                ));
+            }
+        })
+        .detach();
     }
 }
 

--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -108,32 +108,15 @@ impl ModerationCommand {
             return;
         };
 
-        let room = room.room().clone();
         let action = self.action;
-        let error_user_id = user_id.clone();
         Weechat::spawn(async move {
-            let result = match action {
-                ModerationAction::Ban => {
-                    room.ban_user(&user_id, reason.as_deref()).await
-                }
-                ModerationAction::Kick => {
-                    room.kick_user(&user_id, reason.as_deref()).await
-                }
+            match action {
+                ModerationAction::Ban => room.ban_user(user_id, reason).await,
+                ModerationAction::Kick => room.kick_user(user_id, reason).await,
                 ModerationAction::Unban => {
-                    room.unban_user(&user_id, reason.as_deref()).await
+                    room.unban_user(user_id, reason).await
                 }
             };
-
-            if let Err(error) = result {
-                Weechat::print(&format!(
-                    "{}{}: Failed to {} {}: {}",
-                    Weechat::prefix(Prefix::Error),
-                    PLUGIN_NAME,
-                    action.verb(),
-                    error_user_id,
-                    error
-                ));
-            }
         })
         .detach();
     }

--- a/src/commands/moderation.rs
+++ b/src/commands/moderation.rs
@@ -1,0 +1,173 @@
+use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches};
+use matrix_sdk::ruma::{OwnedUserId, UserId};
+use weechat::{
+    buffer::Buffer,
+    hooks::{Command, CommandCallback, CommandSettings},
+    Args, Prefix, Weechat,
+};
+
+use super::parse_and_run;
+use crate::{Servers, PLUGIN_NAME};
+
+#[derive(Clone, Copy)]
+enum ModerationAction {
+    Ban,
+    Kick,
+    Unban,
+}
+
+impl ModerationAction {
+    fn command(&self) -> &'static str {
+        match self {
+            ModerationAction::Ban => "ban",
+            ModerationAction::Kick => "kick",
+            ModerationAction::Unban => "unban",
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            ModerationAction::Ban => "Ban a Matrix user from the current room.",
+            ModerationAction::Kick => {
+                "Kick a Matrix user from the current room."
+            }
+            ModerationAction::Unban => {
+                "Unban a Matrix user from the current room."
+            }
+        }
+    }
+
+    fn verb(&self) -> &'static str {
+        match self {
+            ModerationAction::Ban => "ban",
+            ModerationAction::Kick => "kick",
+            ModerationAction::Unban => "unban",
+        }
+    }
+}
+
+pub struct ModerationCommand {
+    servers: Servers,
+    action: ModerationAction,
+}
+
+impl ModerationCommand {
+    fn create(
+        servers: &Servers,
+        action: ModerationAction,
+    ) -> Result<Command, ()> {
+        let settings = CommandSettings::new(action.command())
+            .description(action.description())
+            .add_argument("<user-id> [reason]")
+            .arguments_description(format!(
+                "user-id: The Matrix user ID to {}.\nreason: Optional reason.",
+                action.verb()
+            ))
+            .add_completion("%(matrix-users) %-");
+
+        Command::new(
+            settings,
+            ModerationCommand {
+                servers: servers.clone(),
+                action,
+            },
+        )
+    }
+
+    pub fn ban(servers: &Servers) -> Result<Command, ()> {
+        Self::create(servers, ModerationAction::Ban)
+    }
+
+    pub fn kick(servers: &Servers) -> Result<Command, ()> {
+        Self::create(servers, ModerationAction::Kick)
+    }
+
+    pub fn unban(servers: &Servers) -> Result<Command, ()> {
+        Self::create(servers, ModerationAction::Unban)
+    }
+
+    fn parse_reason(args: &ArgMatches) -> Option<String> {
+        args.values_of("reason")
+            .map(|values| values.collect::<Vec<_>>().join(" "))
+            .filter(|reason| !reason.is_empty())
+    }
+
+    fn run(
+        &self,
+        buffer: &Buffer,
+        user_id: OwnedUserId,
+        reason: Option<String>,
+    ) {
+        let Some(room) = self.servers.find_room(buffer) else {
+            Weechat::print(&format!(
+                "{}{}: /{} needs to be run in a Matrix room buffer.",
+                Weechat::prefix(Prefix::Error),
+                PLUGIN_NAME,
+                self.action.command()
+            ));
+            return;
+        };
+
+        let room = room.room().clone();
+        let action = self.action;
+        let error_user_id = user_id.clone();
+        let result = self.servers.runtime().block_on(async move {
+            match action {
+                ModerationAction::Ban => {
+                    room.ban_user(&user_id, reason.as_deref()).await
+                }
+                ModerationAction::Kick => {
+                    room.kick_user(&user_id, reason.as_deref()).await
+                }
+                ModerationAction::Unban => {
+                    room.unban_user(&user_id, reason.as_deref()).await
+                }
+            }
+        });
+
+        if let Err(error) = result {
+            Weechat::print(&format!(
+                "{}{}: Failed to {} {}: {}",
+                Weechat::prefix(Prefix::Error),
+                PLUGIN_NAME,
+                self.action.verb(),
+                error_user_id,
+                error
+            ));
+        }
+    }
+}
+
+impl CommandCallback for ModerationCommand {
+    fn callback(&mut self, _: &Weechat, buffer: &Buffer, arguments: Args) {
+        let parser = Argparse::new(self.action.command())
+            .about(self.action.description())
+            .settings(&[
+                ArgParseSettings::DisableHelpFlags,
+                ArgParseSettings::DisableVersion,
+            ])
+            .arg(Arg::with_name("user-id").required(true).validator(|u| {
+                UserId::parse(u).map(|_| ()).map_err(|_| {
+                    "The given user is not a valid user ID".to_owned()
+                })
+            }))
+            .arg(
+                Arg::with_name("reason")
+                    .multiple(true)
+                    .allow_hyphen_values(true),
+            );
+
+        parse_and_run(parser, arguments, |matches| {
+            let user_id = matches
+                .value_of("user-id")
+                .map(|u| {
+                    UserId::parse(u)
+                        .expect("Argument was already validated as a user ID")
+                })
+                .expect("User ID not set but was required");
+            let reason = Self::parse_reason(matches);
+
+            self.run(buffer, user_id, reason);
+        });
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1053,6 +1053,79 @@ impl MatrixRoom {
         }
     }
 
+    pub async fn ban_user(&self, user_id: OwnedUserId, reason: Option<String>) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        let room = self.room().clone();
+        let error_user_id = user_id.clone();
+
+        match connection
+            .spawn(
+                async move { room.ban_user(&user_id, reason.as_deref()).await },
+            )
+            .await
+        {
+            Ok(_) => (),
+            Err(error) => self.print_error(&format!(
+                "Failed to ban {}: {}",
+                error_user_id, error
+            )),
+        }
+    }
+
+    pub async fn kick_user(
+        &self,
+        user_id: OwnedUserId,
+        reason: Option<String>,
+    ) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        let room = self.room().clone();
+        let error_user_id = user_id.clone();
+
+        match connection
+            .spawn(async move { room.kick_user(&user_id, reason.as_deref()).await })
+            .await
+        {
+            Ok(_) => (),
+            Err(error) => self.print_error(&format!(
+                "Failed to kick {}: {}",
+                error_user_id, error
+            )),
+        }
+    }
+
+    pub async fn unban_user(
+        &self,
+        user_id: OwnedUserId,
+        reason: Option<String>,
+    ) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        let room = self.room().clone();
+        let error_user_id = user_id.clone();
+
+        match connection
+            .spawn(async move { room.unban_user(&user_id, reason.as_deref()).await })
+            .await
+        {
+            Ok(_) => (),
+            Err(error) => self.print_error(&format!(
+                "Failed to unban {}: {}",
+                error_user_id, error
+            )),
+        }
+    }
+
     pub async fn send_attachment(&self, path: PathBuf) {
         let Some(filename) = path
             .file_name()


### PR DESCRIPTION
Adds small room-buffer moderation commands:

- `/ban <user-id> [reason]`
- `/kick <user-id> [reason]`
- `/unban <user-id> [reason]`

The moderation requests run asynchronously, so a slow homeserver does not block WeeChat's command callback.

This extracts the useful moderation-command slice from #106 by panekj without the broad clap upgrade or unfinished room/create scaffolding.

References #106.

Validation on current head `f2430e6775e6a2c6de3b693317554cc597803664`:

- `cargo fmt --check`
- `git diff --check`
- `cargo test --locked --lib` in a Rust 1.96 container
- all four hosted build/package jobs pass

Fix requested by @strk.
