### PR TITLE
Add 'deb' Makefile target using cargo-deb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,21 @@ authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2018"
 license = "ISC"
 resolver = "2"
+description = "WeeChat plugin for the Matrix protocol"
+
+[package.metadata.deb]
+maintainer = "Damir Jelić <poljar@termina.org.uk>"
+copyright = "2019-2024, Damir Jelić <poljar@termina.org.uk>"
+extended-description = """\
+WeeChat plugin for the Matrix protocol built with the Matrix Rust SDK.
+Provides native Matrix support within WeeChat, allowing you to chat
+on Matrix from your favourite IRC client."""
+section = "net"
+priority = "optional"
+depends = "$auto, weechat-plugins"
+assets = [
+    ["target/release/libmatrix.so", "usr/lib/weechat/plugins/matrix.so", "755"],
+]
 
 [lib]
 name = "matrix"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SOURCES := $(wildcard src/*.rs src/bar_items/*.rs src/commands/*.rs src/room/*.r
 
 PROFILE ?= release
 
-.PHONY: install install-dir lint all help
+.PHONY: install install-dir lint all help deb
 
 all: help
 
@@ -27,3 +27,9 @@ install-dir: ## Create plugins directory
 
 lint: ## Lint issues with clippy
 	cargo clippy
+
+deb: ## Build a .deb package
+	cargo deb
+	@echo ""
+	@echo "Package built: target/debian/weechat-matrix_*.deb"
+	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix_*.deb"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ extension enabled before it loads the plugin:
 Rename `target/release/libmatrix.dylib` to `matrix.dylib` before copying it to
 your WeeChat plugin directory.
 
+# Debian / Ubuntu package
+
+A `.deb` package can be built using `cargo-deb`. This requires
+[Rust installed](https://rustup.rs/) (via rustup, the recommended method).
+
+First ensure `cargo-deb` is available:
+
+    cargo install cargo-deb
+
+Then build the package with:
+
+    make deb
+
+The resulting `.deb` package is placed in `target/debian/`. Install it with:
+
+    sudo dpkg -i target/debian/weechat-matrix_*.deb
+
 # Loading the plugin
 
 Restart WeeChat after installing the plugin, or load it manually:


### PR DESCRIPTION
### Summary

Add a `deb` Makefile target that builds a `.deb` package using `cargo-deb`, configured via `[package.metadata.deb]` in `Cargo.toml`.

### Changes

- **Cargo.toml**: Added `description` and `[package.metadata.deb]` with proper section (`net`), dependencies (`$auto, weechat-plugins`), and asset mapping (plugin `.so` → `/usr/lib/weechat/plugins/matrix.so`).
- **Makefile**: Added `deb` target running `cargo deb`.
- **README.md**: Added 'Debian / Ubuntu package' section.

### Usage

```bash
cargo install cargo-deb
make deb
sudo dpkg -i target/debian/weechat-matrix_*.deb
```