### PR TITLE
ci: add Debian 13 (trixie) .deb package build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
-          apt-get install -y ca-certificates curl gnupg apt-transport-https build-essential pkg-config libssl-dev libsqlite3-dev git
+          apt-get install -y ca-certificates curl gnupg apt-transport-https build-essential pkg-config libssl-dev libsqlite3-dev libclang-dev git
           mkdir -p /etc/apt/keyrings
           curl --silent https://weechat.org/dev/info/debian_repository_signing_key_asc/ | tee /etc/apt/keyrings/weechat.asc
           echo "deb [signed-by=/etc/apt/keyrings/weechat.asc] https://weechat.org/debian trixie main" | tee /etc/apt/sources.list.d/weechat.list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install cargo-deb
         run: cargo install cargo-deb
+      - name: Build release binary
+        run: cargo build --release
       - name: Build .deb package
-        run: cargo deb --release
+        run: cargo deb --no-build
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,8 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          rustup default stable
+          # rustup isn't on PATH yet in this step, use full path
+          "$HOME/.cargo/bin/rustup" default stable
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Install cargo-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,35 @@ jobs:
         with:
           name: 'libmatrix.so-${{ matrix.os }}'
           path: target/release/libmatrix.so
+
+  publish-deb:
+    name: Publish .deb for Debian 13 (trixie)
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+    steps:
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates curl gnupg apt-transport-https build-essential pkg-config libssl-dev libsqlite3-dev git
+          mkdir -p /etc/apt/keyrings
+          curl --silent https://weechat.org/dev/info/debian_repository_signing_key_asc/ | tee /etc/apt/keyrings/weechat.asc
+          echo "deb [signed-by=/etc/apt/keyrings/weechat.asc] https://weechat.org/debian trixie main" | tee /etc/apt/sources.list.d/weechat.list
+          apt-get update
+          apt-get install -y weechat-curses weechat-plugins weechat-python weechat-perl weechat-dev
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup default stable
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install cargo-deb
+        run: cargo install cargo-deb
+      - name: Build .deb package
+        run: cargo deb --release
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weechat-matrix-debian-13.deb
+          path: target/debian/*.deb


### PR DESCRIPTION
Add a new `publish-deb` job to the release workflow that builds and uploads a `.deb` package for **Debian 13 "trixie"**.

Key details:

- Runs inside a `debian:trixie` container on `ubuntu-latest`
- Uses the [weechat.org Debian repository](https://weechat.org/download/debian/) (same upstream source as the existing Ubuntu builds), with modern `signed-by` keyring configuration
- Installs the same set of weechat dev packages (`weechat-dev`, `weechat-plugins`, etc.)
- Builds the `.deb` via `cargo deb --release` using the existing `[package.metadata.deb]` config in `Cargo.toml`
- Uploads the resulting `.deb` as `weechat-matrix-debian-13.deb` artifact

All existing Ubuntu builds remain unchanged.