### PR TITLE
deb: include git describe output in deb package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Install cargo-deb
         run: cargo install cargo-deb
-      - name: Build release binary
-        run: cargo build --release
       - name: Build .deb package
-        run: cargo deb --no-build
+        run: make deb
+      - name: Find .deb artifact
+        id: deb_artifact
+        run: |
+          deb_file=$(ls target/debian/weechat-matrix_*.deb)
+          echo "path=$deb_file" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$deb_file" .deb)" >> "$GITHUB_OUTPUT"
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4
         with:
-          name: weechat-matrix-debian-13.deb
-          path: target/debian/*.deb
+          name: ${{ steps.deb_artifact.outputs.name }}
+          path: ${{ steps.deb_artifact.outputs.path }}

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,28 @@ install-dir: ## Create plugins directory
 lint: ## Lint issues with clippy
 	cargo clippy
 
-deb: ## Build a .deb package
-	cargo deb
+# Get the base package version from Cargo.toml (fallback when no git tags are found)
+CARGO_VERSION := $(shell grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+
+deb: target/$(PROFILE)/libmatrix.so ## Build a .deb package with version from git describe
+	DEB_VERSION=$$( \
+	  desc=$$(git describe --tags --always --dirty --match '[0-9]*' 2>/dev/null); \
+	  if [ -z "$$desc" ]; then \
+	    echo "$(CARGO_VERSION)+unknown"; \
+	  else \
+	    case "$$desc" in \
+	      *-dirty) dirty=".dirty"; desc="$${desc%-dirty}" ;; \
+	      *) dirty="" ;; \
+	    esac; \
+	    case "$$desc" in \
+	      *.*) ;; \
+	      *) desc="$(CARGO_VERSION)+git.$$desc" ;; \
+	    esac; \
+	    desc=$$(echo "$$desc" | sed 's/-\([0-9][0-9]*\)-g\([0-9a-f][0-9a-f]*\)/+\1.\2/'); \
+	    echo "$$desc$$dirty"; \
+	  fi \
+	); \
+	cargo deb --no-build --deb-version "$$DEB_VERSION"
 	@echo ""
-	@echo "Package built: target/debian/weechat-matrix_*.deb"
-	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix_*.deb"
+	@echo "Package built: target/debian/weechat-matrix_$${DEB_VERSION}*.deb"
+	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix_$${DEB_VERSION}*.deb"


### PR DESCRIPTION
The `deb` Makefile target now computes a Debian-compatible version from `git describe --tags` and passes it to `cargo deb --deb-version`, so the resulting .deb package has a version that reflects the exact git state.

**Version computation logic:**
- On a tag (e.g. `0.4.0`) → `0.4.0`
- N commits after a tag (e.g. `0.4.0-3-gabcdef1`) → `0.4.0+3.abcdef1`
- No tag reachable (bare hash) → `<cargo-version>+git.<hash>` (e.g. `0.1.0+git.2ec691e`)
- Dirty working tree → appends `.dirty`
- git not available → `<cargo-version>+unknown`

The base version from `Cargo.toml` (`0.1.0`) is used as the fallback when no git tags are reachable.

The same logic is mirrored in the GitHub release workflow for the `publish-deb` job.