### PR TITLE
feat: add Matrix /names command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod keys;
 mod matrix;
 mod me;
 mod media;
+mod names;
 mod page_up;
 mod part;
 mod upload;
@@ -26,6 +27,7 @@ use keys::KeysCommand;
 use matrix::MatrixCommand;
 use me::MeCommand;
 use media::MediaCommand;
+use names::NamesCommand;
 use page_up::PageUpCommand;
 use part::PartCommand;
 use upload::UploadCommand;
@@ -41,6 +43,7 @@ pub struct Commands {
     _me: CommandRun,
     _upload: CommandRun,
     _part: CommandRun,
+    _names: CommandRun,
 }
 
 impl Commands {
@@ -59,6 +62,7 @@ impl Commands {
             _me: MeCommand::create(servers)?,
             _upload: UploadCommand::create(servers)?,
             _part: PartCommand::create(servers)?,
+            _names: NamesCommand::create(servers)?,
         })
     }
 }

--- a/src/commands/names.rs
+++ b/src/commands/names.rs
@@ -1,0 +1,47 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::Servers;
+
+pub struct NamesCommand {
+    servers: Servers,
+}
+
+impl NamesCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "2000|/names",
+            NamesCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for NamesCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        _: Cow<str>,
+    ) -> ReturnCode {
+        if let Some(room) = self.servers.find_room(buffer) {
+            let names = room.names();
+            let message = if names.is_empty() {
+                "No Matrix room members are known yet.".to_owned()
+            } else {
+                format!("Matrix room members: {}", names.join(", "))
+            };
+
+            buffer.print(&message);
+            ReturnCode::OkEat
+        } else {
+            ReturnCode::Ok
+        }
+    }
+}

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -259,6 +259,16 @@ impl Members {
         self.last_active.insert(user_id.to_owned(), timestamp);
     }
 
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<_> = self
+            .nicks
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
     fn should_smart_filter(
         &self,
         user_id: &UserId,

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -451,6 +451,10 @@ impl MatrixRoom {
         &self.room_id
     }
 
+    pub fn names(&self) -> Vec<String> {
+        self.members.names()
+    }
+
     pub fn buffer_handle(&self) -> BufferHandle {
         self.buffer.buffer_handle()
     }


### PR DESCRIPTION
Fixes #164.

Adds a Matrix-aware `/names` command for room buffers. The command prints the room nicklist sorted by display name, and lets WeeChat handle `/names` normally outside Matrix buffers.

Validation:
- `git diff --check upstream/main..komzpa/names-command`
