### PR TITLE
fix: save server config options deterministically

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,8 +182,11 @@ impl ConfigHandle {
                 |_weechat: &Weechat,
                  config: &Conf,
                  section: &mut ConfigSection| {
+                    let mut options = section.options();
+                    options.sort_by(|a, b| a.name().cmp(&b.name()));
+
                     config.write_section(section.name());
-                    for option in section.options() {
+                    for option in options {
                         config.write_option(option);
                     }
                 },


### PR DESCRIPTION
Fixes #165.

The server config writer was iterating options from the section's internal map, which can serialize `matrix-rust.conf` in a different order across `/save` cycles. Sort server section options by name before writing them, so repeated saves stay stable.

Validation:
- `cargo fmt --check`
- `git diff --check upstream/main..komzpa/stable-config-save-order`
