### PR TITLE
feat: improve media download UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,10 @@ The inactivity delay defaults to five minutes and can be changed with:
 Room buffers accept normal message input after `/matrix connect [server-name]`
 has completed.
 
-`/matrix media download <mxc-uri> <file>` downloads Matrix media through the logged-in client, including homeservers that require authenticated media. It refuses to overwrite an existing file.
+`/matrix media download <mxc-uri> [file]` downloads Matrix media through the logged-in client, including homeservers that require authenticated media. It refuses to overwrite an existing file. When `[file]` is omitted, the media id is saved with the configured prefix, which defaults to `matrix-media-`:
+
+       /set matrix-rust.media.download_prefix matrix-media-
+
+The prefix may include a directory and supports `~`, `$XDG_STATE_HOME`, and `${XDG_STATE_HOME}`. Parent directories are created automatically:
+
+       /set matrix-rust.media.download_prefix "$XDG_STATE_HOME/weechat-matrix/media/matrix-media-"

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -34,7 +34,7 @@ impl MatrixCommand {
             .add_argument("connect <server-name>")
             .add_argument("devices delete|list|set-name")
             .add_argument("keys import|export <file> <passphrase>")
-            .add_argument("media download <mxc-uri> <file>")
+            .add_argument("media download <mxc-uri> [file]")
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")

--- a/src/commands/media.rs
+++ b/src/commands/media.rs
@@ -7,7 +7,7 @@ use clap::{
 use matrix_sdk::ruma::MxcUri;
 use weechat::{buffer::Buffer, Weechat};
 
-use crate::Servers;
+use crate::{BufferOwner, Servers};
 
 pub struct MediaCommand;
 
@@ -16,9 +16,18 @@ impl MediaCommand {
     pub const COMPLETION: &'static str = "download %(matrix-media)";
 
     pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
-        let server = match servers.find_server(buffer) {
-            Some(server) => server,
-            None => {
+        let (server, output_buffer) = match servers.buffer_owner(buffer) {
+            BufferOwner::Room(server, room) => {
+                (server, Some(room.buffer_handle()))
+            }
+            BufferOwner::Server(server) => {
+                let output_buffer = server.server_buffer().as_ref().cloned();
+                (server, output_buffer)
+            }
+            BufferOwner::Verification(server, verification) => {
+                (server, Some(verification.buffer()))
+            }
+            BufferOwner::None => {
                 Weechat::print("Must be executed on Matrix buffer");
                 return;
             }
@@ -51,7 +60,9 @@ impl MediaCommand {
                 };
 
                 Weechat::spawn(async move {
-                    server.download_media(uri.into(), file).await;
+                    server
+                        .download_media(uri.into(), file, output_buffer)
+                        .await;
                 })
                 .detach();
             }

--- a/src/commands/media.rs
+++ b/src/commands/media.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{ffi::OsString, path::PathBuf};
 
 use clap::{
     App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches,
@@ -45,10 +45,13 @@ impl MediaCommand {
                     return;
                 }
 
+                let download_prefix =
+                    server.config().borrow().media().download_prefix();
+
                 let file = args
                     .value_of("file")
                     .map(|file| PathBuf::from(Weechat::expand_home(file)))
-                    .or_else(|| default_download_file(&uri));
+                    .or_else(|| default_download_file(&uri, &download_prefix));
                 let file = match file {
                     Some(file) => file,
                     None => {
@@ -93,13 +96,76 @@ impl MediaCommand {
     ];
 }
 
-fn default_download_file(uri: &MxcUri) -> Option<PathBuf> {
+fn default_download_file(uri: &MxcUri, prefix: &str) -> Option<PathBuf> {
     uri.as_str()
         .trim_end_matches('/')
         .rsplit('/')
         .next()
         .filter(|name| !name.is_empty())
+        .map(|name| prefixed_download_path(prefix, name))
+}
+
+fn prefixed_download_path(prefix: &str, name: &str) -> PathBuf {
+    let prefix = expand_download_prefix(
+        prefix,
+        std::env::var_os("XDG_STATE_HOME"),
+        std::env::var_os("HOME"),
+    );
+    PathBuf::from(format!("{}{}", prefix, name))
+}
+
+fn expand_download_prefix(
+    prefix: &str,
+    xdg_state_home: Option<OsString>,
+    home: Option<OsString>,
+) -> String {
+    let prefix = expand_home_prefix(prefix, home.clone());
+
+    if prefix.starts_with("${XDG_STATE_HOME}") {
+        return format!(
+            "{}{}",
+            xdg_state_home_path(xdg_state_home, home).display(),
+            &prefix["${XDG_STATE_HOME}".len()..]
+        );
+    }
+
+    if prefix == "$XDG_STATE_HOME" || prefix.starts_with("$XDG_STATE_HOME/") {
+        return format!(
+            "{}{}",
+            xdg_state_home_path(xdg_state_home, home).display(),
+            &prefix["$XDG_STATE_HOME".len()..]
+        );
+    }
+
+    prefix
+}
+
+fn expand_home_prefix(prefix: &str, home: Option<OsString>) -> String {
+    if prefix == "~" || prefix.starts_with("~/") {
+        if let Some(home) = home.filter(|home| !home.is_empty()) {
+            return format!(
+                "{}{}",
+                PathBuf::from(home).display(),
+                &prefix["~".len()..]
+            );
+        }
+    }
+
+    prefix.to_owned()
+}
+
+fn xdg_state_home_path(
+    xdg_state_home: Option<OsString>,
+    home: Option<OsString>,
+) -> PathBuf {
+    xdg_state_home
+        .filter(|path| !path.is_empty())
         .map(PathBuf::from)
+        .or_else(|| {
+            home.filter(|home| !home.is_empty())
+                .map(|home| PathBuf::from(home).join(".local/state"))
+        })
+        .unwrap_or_else(|| PathBuf::from("."))
 }
 
 #[cfg(test)]
@@ -111,8 +177,63 @@ mod tests {
         let uri = Box::<MxcUri>::from("mxc://matrix.org/some-media-id");
 
         assert_eq!(
-            Some(PathBuf::from("some-media-id")),
-            default_download_file(&uri)
+            Some(PathBuf::from("matrix-media-some-media-id")),
+            default_download_file(&uri, "matrix-media-")
+        );
+    }
+
+    #[test]
+    fn default_download_prefix_can_include_directory() {
+        let uri = Box::<MxcUri>::from("mxc://matrix.org/some-media-id");
+
+        assert_eq!(
+            Some(PathBuf::from("/tmp/matrix/matrix-media-some-media-id")),
+            default_download_file(&uri, "/tmp/matrix/matrix-media-")
+        );
+    }
+
+    #[test]
+    fn expands_xdg_state_home_in_download_prefix() {
+        assert_eq!(
+            "/tmp/state/weechat-matrix/matrix-media-",
+            expand_download_prefix(
+                "$XDG_STATE_HOME/weechat-matrix/matrix-media-",
+                Some("/tmp/state".into()),
+                Some("/home/user".into())
+            )
+        );
+
+        assert_eq!(
+            "/tmp/state/weechat-matrix/matrix-media-",
+            expand_download_prefix(
+                "${XDG_STATE_HOME}/weechat-matrix/matrix-media-",
+                Some("/tmp/state".into()),
+                Some("/home/user".into())
+            )
+        );
+    }
+
+    #[test]
+    fn expands_xdg_state_home_fallback() {
+        assert_eq!(
+            "/home/user/.local/state/weechat-matrix/matrix-media-",
+            expand_download_prefix(
+                "$XDG_STATE_HOME/weechat-matrix/matrix-media-",
+                None,
+                Some("/home/user".into())
+            )
+        );
+    }
+
+    #[test]
+    fn expands_home_in_download_prefix() {
+        assert_eq!(
+            "/home/user/media/matrix-media-",
+            expand_download_prefix(
+                "~/media/matrix-media-",
+                Some("/tmp/state".into()),
+                Some("/home/user".into())
+            )
         );
     }
 }

--- a/src/commands/media.rs
+++ b/src/commands/media.rs
@@ -13,7 +13,7 @@ pub struct MediaCommand;
 
 impl MediaCommand {
     pub const DESCRIPTION: &'static str = "Download Matrix media.";
-    pub const COMPLETION: &'static str = "download";
+    pub const COMPLETION: &'static str = "download %(matrix-media)";
 
     pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
         let server = match servers.find_server(buffer) {
@@ -38,8 +38,17 @@ impl MediaCommand {
 
                 let file = args
                     .value_of("file")
-                    .expect("File not set but was required");
-                let file = PathBuf::from(Weechat::expand_home(file));
+                    .map(|file| PathBuf::from(Weechat::expand_home(file)))
+                    .or_else(|| default_download_file(&uri));
+                let file = match file {
+                    Some(file) => file,
+                    None => {
+                        Weechat::print(
+                            "Could not derive a filename from MXC URI",
+                        );
+                        return;
+                    }
+                };
 
                 Weechat::spawn(async move {
                     server.download_media(uri.into(), file).await;
@@ -62,7 +71,7 @@ impl MediaCommand {
                     Err("The given URI is not a valid MXC URI".to_owned())
                 }
             }))
-            .arg(Arg::with_name("file").required(true))]
+            .arg(Arg::with_name("file").required(false))]
     }
 
     pub const SETTINGS: &'static [ArgParseSettings] = &[
@@ -71,4 +80,28 @@ impl MediaCommand {
         ArgParseSettings::VersionlessSubcommands,
         ArgParseSettings::SubcommandRequiredElseHelp,
     ];
+}
+
+fn default_download_file(uri: &MxcUri) -> Option<PathBuf> {
+    uri.as_str()
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_download_file_to_media_id() {
+        let uri = Box::<MxcUri>::from("mxc://matrix.org/some-media-id");
+
+        assert_eq!(
+            Some(PathBuf::from("some-media-id")),
+            default_download_file(&uri)
+        );
+    }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,4 +1,6 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeSet};
+
+use matrix_sdk::ruma::MxcUri;
 
 use weechat::{
     buffer::Buffer,
@@ -14,13 +16,15 @@ use crate::Servers;
 pub struct Completions {
     servers: CompletionHook,
     users: CompletionHook,
+    media: CompletionHook,
 }
 
 impl Completions {
     pub fn hook_all(servers: Servers) -> Result<Self, ()> {
         Ok(Self {
             servers: ServersCompletion::create(servers.clone())?,
-            users: UsersCompletion::create(servers)?,
+            users: UsersCompletion::create(servers.clone())?,
+            media: MediaCompletion::create(servers)?,
         })
     }
 }
@@ -106,5 +110,98 @@ impl CompletionCallback for UsersCompletion {
         }
 
         Ok(())
+    }
+}
+
+struct MediaCompletion {
+    servers: Servers,
+}
+
+impl MediaCompletion {
+    fn create(servers: Servers) -> Result<CompletionHook, ()> {
+        let comp = MediaCompletion { servers };
+
+        CompletionHook::new(
+            "matrix-media",
+            "Completion for Matrix media URIs in the current buffer",
+            comp,
+        )
+    }
+}
+
+impl CompletionCallback for MediaCompletion {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        _: Cow<str>,
+        completion: &Completion,
+    ) -> Result<(), ()> {
+        if self.servers.find_server(buffer).is_none() {
+            return Ok(());
+        }
+
+        let mut media = BTreeSet::new();
+
+        for line in buffer.lines().rev().take(200) {
+            let message = Weechat::remove_color(&line.message());
+            media.extend(extract_mxc_uris(&message));
+        }
+
+        for uri in media {
+            completion.add_with_options(
+                &uri,
+                false,
+                CompletionPosition::Sorted,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+fn extract_mxc_uris(message: &str) -> Vec<String> {
+    message
+        .match_indices("mxc://")
+        .filter_map(|(start, _)| {
+            let uri = message[start..]
+                .split(|c: char| {
+                    c.is_whitespace()
+                        || matches!(
+                            c,
+                            '<' | '>' | '[' | ']' | '(' | ')' | '"' | '\''
+                        )
+                })
+                .next()
+                .unwrap_or_default();
+            let uri = Box::<MxcUri>::from(uri);
+
+            if uri.is_valid() {
+                Some(uri.as_str().to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_valid_mxc_uris() {
+        assert_eq!(
+            vec!["mxc://matrix.org/some-media-id".to_owned()],
+            extract_mxc_uris(
+                "authenticated download: /matrix media download \
+                 mxc://matrix.org/some-media-id [file]"
+            )
+        );
+    }
+
+    #[test]
+    fn ignores_invalid_mxc_uris() {
+        assert!(extract_mxc_uris("download mxc://").is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,7 +154,18 @@ config!(
             // Default value.
             true,
         },
-    }
+    },
+
+    Section media {
+        download_prefix: String {
+            // Description.
+            "Prefix prepended to default media download filenames. The value \
+             may include a directory, and supports ~, $XDG_STATE_HOME, and \
+             ${XDG_STATE_HOME}",
+            // Default value.
+            "matrix-media-",
+        },
+    },
 );
 
 /// A wrapper for our config struct that can be cloned around.

--- a/src/render.rs
+++ b/src/render.rs
@@ -418,7 +418,7 @@ fn mxc_to_emxc(
 fn media_download_command(source: &MediaSource) -> Option<String> {
     match source {
         MediaSource::Plain(url) => {
-            Some(format!("/matrix media download {} <file>", url.as_str()))
+            Some(format!("/matrix media download {} [file]", url.as_str()))
         }
         MediaSource::Encrypted(_) => None,
     }
@@ -456,7 +456,11 @@ impl<C: HasUrlOrFile> Render for C {
 
         if let Some(command) = media_download_command(self.source()) {
             lines.push(RenderedLine {
-                message: format!("authenticated download: {}", command),
+                message: format!(
+                    "{}authenticated download: {}",
+                    Weechat::prefix(Prefix::Network),
+                    command
+                ),
                 tags: self.tags(),
             });
         }
@@ -1052,7 +1056,7 @@ mod tests {
 
         assert_eq!(
             Some(
-                "/matrix media download mxc://matrix.org/some-media-id <file>"
+                "/matrix media download mxc://matrix.org/some-media-id [file]"
                     .to_owned()
             ),
             media_download_command(&source)

--- a/src/server.rs
+++ b/src/server.rs
@@ -1073,6 +1073,23 @@ impl InnerServer {
             .await
         {
             Ok(content) => {
+                if let Some(parent) = file.parent() {
+                    if !parent.as_os_str().is_empty() {
+                        if let Err(e) = std::fs::create_dir_all(parent) {
+                            self.print_with_prefix_to(
+                                output_buffer.as_ref(),
+                                &Weechat::prefix(Prefix::Error),
+                                &format!(
+                                    "Error creating media directory {}: {:#?}",
+                                    parent.display(),
+                                    e
+                                ),
+                            );
+                            return;
+                        }
+                    }
+                }
+
                 if let Err(e) = std::fs::OpenOptions::new()
                     .write(true)
                     .create_new(true)

--- a/src/server.rs
+++ b/src/server.rs
@@ -60,7 +60,7 @@ use std::{
     cmp::Reverse,
     collections::HashMap,
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::{Rc, Weak},
 };
 use tracing::error;
@@ -669,6 +669,21 @@ impl InnerServer {
         self.print(&format!("{}{}: {}", prefix, PLUGIN_NAME, message));
     }
 
+    /// Print a message to a Matrix buffer, falling back to the server buffer if
+    /// the original command buffer disappeared.
+    fn print_with_prefix_to(
+        &self,
+        buffer: Option<&BufferHandle>,
+        prefix: &str,
+        message: &str,
+    ) {
+        if let Some(Ok(buffer)) = buffer.map(|buffer| buffer.upgrade()) {
+            buffer.print(&format!("{}{}: {}", prefix, PLUGIN_NAME, message));
+        } else {
+            self.print_with_prefix(prefix, message);
+        }
+    }
+
     /// Print an network message to the server buffer.
     pub fn print_network(&self, message: &str) {
         self.print_with_prefix(&Weechat::prefix(Prefix::Network), message);
@@ -1020,11 +1035,20 @@ impl InnerServer {
         };
     }
 
-    pub async fn download_media(&self, uri: OwnedMxcUri, file: PathBuf) {
+    pub async fn download_media(
+        &self,
+        uri: OwnedMxcUri,
+        file: PathBuf,
+        output_buffer: Option<BufferHandle>,
+    ) {
         let connection = if let Some(c) = self.connection() {
             c
         } else {
-            self.print_error("You must be connected to execute this command");
+            self.print_with_prefix_to(
+                output_buffer.as_ref(),
+                &Weechat::prefix(Prefix::Error),
+                "You must be connected to execute this command",
+            );
             return;
         };
 
@@ -1033,9 +1057,14 @@ impl InnerServer {
             source: MediaSource::Plain(uri),
             format: MediaFormat::File,
         };
-        let display_file = file.display().to_string();
+        let display_file =
+            Self::display_download_path(&file).display().to_string();
 
-        self.print_network(&format!("Downloading media to {}", display_file));
+        self.print_with_prefix_to(
+            output_buffer.as_ref(),
+            &Weechat::prefix(Prefix::Network),
+            &format!("Downloading media to {}", display_file),
+        );
 
         match connection
             .spawn(async move {
@@ -1050,20 +1079,42 @@ impl InnerServer {
                     .open(&file)
                     .and_then(|mut file| file.write_all(&content))
                 {
-                    self.print_error(&format!(
-                        "Error writing media to {}: {:#?}",
-                        display_file, e
-                    ));
+                    self.print_with_prefix_to(
+                        output_buffer.as_ref(),
+                        &Weechat::prefix(Prefix::Error),
+                        &format!(
+                            "Error writing media to {}: {:#?}",
+                            display_file, e
+                        ),
+                    );
                 } else {
-                    self.print_network(&format!(
-                        "Successfully downloaded media to {}",
-                        display_file
-                    ));
+                    self.print_with_prefix_to(
+                        output_buffer.as_ref(),
+                        &Weechat::prefix(Prefix::Network),
+                        &format!(
+                            "Successfully downloaded media to {}",
+                            display_file
+                        ),
+                    );
                 }
             }
             Err(e) => {
-                self.print_error(&format!("Error downloading media {:#?}", e));
+                self.print_with_prefix_to(
+                    output_buffer.as_ref(),
+                    &Weechat::prefix(Prefix::Error),
+                    &format!("Error downloading media {:#?}", e),
+                );
             }
+        }
+    }
+
+    fn display_download_path(file: &Path) -> PathBuf {
+        if file.is_absolute() {
+            file.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(file))
+                .unwrap_or_else(|_| file.to_path_buf())
         }
     }
 
@@ -1414,5 +1465,35 @@ impl InnerServer {
             indent = 8
         ));
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InnerServer;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn keeps_absolute_download_path_for_display() {
+        let path = Path::new("/tmp/matrix-media");
+
+        assert_eq!(InnerServer::display_download_path(path), path);
+    }
+
+    #[test]
+    fn expands_relative_download_path_for_display() {
+        let path = Path::new("matrix-media");
+        let expected = std::env::current_dir()
+            .expect("current working directory")
+            .join(path);
+
+        assert_eq!(InnerServer::display_download_path(path), expected);
+    }
+
+    #[test]
+    fn preserves_absolute_pathbuf_for_display() {
+        let path = PathBuf::from("/tmp/matrix-media");
+
+        assert_eq!(InnerServer::display_download_path(&path), path);
     }
 }


### PR DESCRIPTION
Fixes #168.

Improves the authenticated media download flow:

- `/matrix media download <mxc-uri>` now defaults the output filename to the MXC media id.
- `/matrix media download <TAB>` completes MXC URIs seen in the current Matrix buffer.
- The rendered helper line now uses WeeChat's network prefix, so it reads as a local hint rather than another user message.
- Existing download start/success/error feedback is kept.

Validation:
- `cargo fmt --check`
- `git diff --check`
- Docker: `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo test --locked media --lib`
- Docker: `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo test --locked extract --lib`
