### PR TITLE
fix: refresh room names from state updates

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -448,38 +448,40 @@ impl Connection {
                 }
 
                 for (room_id, room) in response.rooms.joined {
-                    if let State::Before(state) = room.state {
-                        for event in
-                            state.iter().filter_map(|e| e.deserialize().ok())
-                        {
-                            if let AnySyncStateEvent::RoomMember(m) = event {
-                                let change = room
-                                    .ambiguity_changes
-                                    .get(m.event_id())
-                                    .cloned();
+                    let state_events = match &room.state {
+                        State::Before(state) | State::After(state) => state,
+                    };
 
-                                if sync_channel
-                                    .send(Ok(ClientMessage::MemberEvent(
-                                        room_id.clone(),
-                                        m,
-                                        true,
-                                        change,
-                                    )))
-                                    .await
-                                    .is_err()
-                                {
-                                    return LoopCtrl::Break;
-                                }
-                            } else if sync_channel
-                                .send(Ok(ClientMessage::SyncState(
+                    for event in
+                        state_events.iter().filter_map(|e| e.deserialize().ok())
+                    {
+                        if let AnySyncStateEvent::RoomMember(m) = event {
+                            let change = room
+                                .ambiguity_changes
+                                .get(m.event_id())
+                                .cloned();
+
+                            if sync_channel
+                                .send(Ok(ClientMessage::MemberEvent(
                                     room_id.clone(),
-                                    event,
+                                    m,
+                                    true,
+                                    change,
                                 )))
                                 .await
                                 .is_err()
                             {
                                 return LoopCtrl::Break;
                             }
+                        } else if sync_channel
+                            .send(Ok(ClientMessage::SyncState(
+                                room_id.clone(),
+                                event,
+                            )))
+                            .await
+                            .is_err()
+                        {
+                            return LoopCtrl::Break;
                         }
                     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1051,7 +1051,10 @@ impl MatrixRoom {
         match event {
             AnySyncStateEvent::RoomName(_) => self.buffer.update_buffer_name(),
             AnySyncStateEvent::RoomTopic(_) => self.buffer.set_topic(),
-            AnySyncStateEvent::RoomCanonicalAlias(_) => self.buffer.set_alias(),
+            AnySyncStateEvent::RoomCanonicalAlias(_) => {
+                self.buffer.set_alias();
+                self.buffer.update_buffer_name();
+            }
             _ => (),
         }
     }


### PR DESCRIPTION
Fixes #176.

Follow-up from #174 / https://github.com/poljar/weechat-matrix-rs/pull/174#issuecomment-4876579044.

Room buffer names already refreshed on `m.room.name`, but two update paths were incomplete:

- `m.room.canonical_alias` updated only the `alias` localvar, even though the buffer name can fall back to the canonical alias.
- the sync loop forwarded only Matrix SDK `State::Before` room state batches; `State::After` batches also contain state deltas that should reach the room handlers.

This refreshes the buffer short name after canonical alias changes and forwards both SDK state batch shapes into the existing state handlers.

Validation:
- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`
- Docker: `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target-room-name-refresh cargo check --locked`
