### PR TITLE
fix: rename Debian package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Find .deb artifact
         id: deb_artifact
         run: |
-          deb_file=$(ls target/debian/weechat-matrix_*.deb)
+          deb_file=$(ls target/debian/weechat-matrix-rs_*.deb)
           echo "path=$deb_file" >> "$GITHUB_OUTPUT"
           echo "name=$(basename "$deb_file" .deb)" >> "$GITHUB_OUTPUT"
       - name: Upload .deb artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 description = "WeeChat plugin for the Matrix protocol"
 
 [package.metadata.deb]
+name = "weechat-matrix-rs"
 maintainer = "Damir Jelić <poljar@termina.org.uk>"
 copyright = "2019-2024, Damir Jelić <poljar@termina.org.uk>"
 extended-description = """\

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,5 @@ deb: target/$(PROFILE)/libmatrix.so ## Build a .deb package with version from gi
 	); \
 	cargo deb --no-build --deb-version "$$DEB_VERSION"
 	@echo ""
-	@echo "Package built: target/debian/weechat-matrix_$${DEB_VERSION}*.deb"
-	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix_$${DEB_VERSION}*.deb"
+	@echo "Package built: target/debian/weechat-matrix-rs_$${DEB_VERSION}*.deb"
+	@echo "Install with: sudo dpkg -i target/debian/weechat-matrix-rs_$${DEB_VERSION}*.deb"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then build the package with:
 
 The resulting `.deb` package is placed in `target/debian/`. Install it with:
 
-    sudo dpkg -i target/debian/weechat-matrix_*.deb
+    sudo dpkg -i target/debian/weechat-matrix-rs_*.deb
 
 # Loading the plugin
 


### PR DESCRIPTION
Fixes #175.

Renames only the generated Debian package to `weechat-matrix-rs` so it does not collide with Debian's existing `weechat-matrix` package for the Python script. The Rust crate name and WeeChat plugin file remain unchanged.

Validation:
- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`
- `/tmp/cargo-deb-validate/bin/cargo-deb --no-build --no-strip --deb-version 0.0.0-test` with a dummy `target/release/libmatrix.so`; `dpkg-deb -f` reported `Package: weechat-matrix-rs`

Fix requested by @strk.