### PR TITLE
Change plugin install path in debian package to match weechat-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ section = "net"
 priority = "optional"
 depends = "$auto, weechat-plugins"
 assets = [
-    ["target/release/libmatrix.so", "usr/lib/weechat/plugins/matrix.so", "755"],
+    ["target/release/libmatrix.so",
+     "/usr/lib/x86_64-linux-gnu/weechat/plugins/matrix-rs.so",
+     "755"],
 ]
 
 [lib]


### PR DESCRIPTION
The weechat-core debian package installs plugins under

  /usr/lib/x86_64-linux-gnu/weechat/plugins/

This commit makes weechat-matrix-rs debian package do to same
