### PR TITLE
build: split system and user install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 # See https://weechat.org/files/doc/weechat/stable/weechat_user.en.html#xdg_directories
 XDG_DATA_HOME ?= $(HOME)/.local/share
 WEECHAT_DATA_DIR ?= $(XDG_DATA_HOME)/weechat
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null)
+ifeq ($(DEB_HOST_MULTIARCH),)
+WEECHAT_PLUGIN_DIR ?= /usr/lib/weechat/plugins
+else
+WEECHAT_PLUGIN_DIR ?= /usr/lib/$(DEB_HOST_MULTIARCH)/weechat/plugins
+endif
 
 SOURCES := $(wildcard src/*.rs src/bar_items/*.rs src/commands/*.rs src/room/*.rs Cargo.lock)
 
 PROFILE ?= release
 
-.PHONY: install install-dir lint all help deb
+.PHONY: install install-user uninstall uninstall-user install-dir install-user-dir lint all help deb
 
 all: help
 
@@ -19,10 +25,22 @@ target/debug/libmatrix.so: $(SOURCES) ## Build plugin in dev profile
 target/release/libmatrix.so: $(SOURCES) ## Build plugin release profile
 	cargo build --release
 
-install: install-dir target/$(PROFILE)/libmatrix.so ## Install plugin to weechat dir
+install: install-dir target/$(PROFILE)/libmatrix.so ## Install plugin systemwide
+	install -m644  target/$(PROFILE)/libmatrix.so $(DESTDIR)$(WEECHAT_PLUGIN_DIR)/matrix.so
+
+install-user: install-user-dir target/$(PROFILE)/libmatrix.so ## Install plugin to user WeeChat dir
 	install -m644  target/$(PROFILE)/libmatrix.so $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins/matrix.so
 
-install-dir: ## Create plugins directory
+uninstall: ## Remove systemwide plugin
+	rm -f $(DESTDIR)$(WEECHAT_PLUGIN_DIR)/matrix.so
+
+uninstall-user: ## Remove plugin from user WeeChat dir
+	rm -f $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins/matrix.so
+
+install-dir:
+	install -d $(DESTDIR)$(WEECHAT_PLUGIN_DIR)
+
+install-user-dir:
 	install -d $(DESTDIR)$(WEECHAT_DATA_DIR)/plugins
 
 lint: ## Lint issues with clippy

--- a/README.md
+++ b/README.md
@@ -55,9 +55,26 @@ On Linux this creates a `libmatrix.so` file in the `target/release/`
 (`target/debug` for dev builds) folder. Rename it to `matrix.so` and copy it to
 your WeeChat plugin directory.
 
-`make install` uses WeeChat's XDG data directory by default:
+`make install` installs the plugin systemwide:
 
-    make install
+    sudo make install
+
+On Debian-like multiarch systems this installs the release build to:
+
+    /usr/lib/${DEB_HOST_MULTIARCH}/weechat/plugins/matrix.so
+
+On other systems it defaults to:
+
+    /usr/lib/weechat/plugins/matrix.so
+
+Set `WEECHAT_PLUGIN_DIR` if your distribution uses another system plugin
+directory:
+
+    sudo make install WEECHAT_PLUGIN_DIR=/path/to/weechat/plugins
+
+To install only for the current user, use:
+
+    make install-user
 
 This installs the release build to:
 
@@ -65,7 +82,12 @@ This installs the release build to:
 
 Use `PROFILE=debug` for a debug build:
 
-    make install PROFILE=debug
+    make install-user PROFILE=debug
+
+The matching uninstall targets are:
+
+    sudo make uninstall
+    make uninstall-user
 
 On older WeeChat setups the plugin directory may instead live under
 `$WEECHAT_HOME/plugins`, commonly `~/.weechat/plugins/`. Create the directory if


### PR DESCRIPTION
Makes `make install` install systemwide, adds `make install-user` for the XDG user plugin directory, and adds matching `uninstall` / `uninstall-user` targets.

The internal directory targets stay out of `make help`, and README now documents the new target names and plugin directory override.

Fixes #180.

Fix requested by @strk.