### PR TITLE
fix: fetch restored backlog backwards

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -95,10 +95,32 @@ pub struct RoomHandle {
     inner: MatrixRoom,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PrevBatch {
     Forward(String),
     Backwards(String),
+}
+
+fn restored_prev_batch(prev_batch: Option<String>) -> Option<PrevBatch> {
+    prev_batch.map(PrevBatch::Backwards)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{restored_prev_batch, PrevBatch};
+
+    #[test]
+    fn restored_rooms_fetch_history_backwards_from_prev_batch() {
+        assert_eq!(
+            restored_prev_batch(Some("token".to_owned())),
+            Some(PrevBatch::Backwards("token".to_owned()))
+        );
+    }
+
+    #[test]
+    fn restored_rooms_without_prev_batch_have_no_history_request() {
+        assert_eq!(restored_prev_batch(None), None);
+    }
 }
 
 impl Deref for RoomHandle {
@@ -366,8 +388,7 @@ impl RoomHandle {
             room_buffer.members.restore_member(user_id).await;
         }
 
-        *room_buffer.prev_batch.borrow_mut() =
-            prev_batch.map(PrevBatch::Forward);
+        *room_buffer.prev_batch.borrow_mut() = restored_prev_batch(prev_batch);
 
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();


### PR DESCRIPTION
Restored rooms should use the saved `last_prev_batch` token as a backwards history cursor.

Using it as a forward cursor can make the first backlog fetch after restart ask for already-known timeline edges and render duplicate lines.

Fixes #185.

Checked with Docker `WEECHAT_BUNDLED=1 cargo test --locked restored_rooms --lib`, Docker `WEECHAT_BUNDLED=1 cargo check --locked`, `cargo fmt --check`, and `git diff --check`.

Fix requested by @strk.
