### PR TITLE
Run cargo fix --lib -p weechat-matrix

### DIFF
--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -68,7 +68,7 @@ impl Verification {
             if let Some(ActiveVerification::Sas(verification)) =
                 self.inner.borrow().clone()
             {
-                let ret =
+                let _ret =
                     c.spawn(async move { verification.confirm().await }).await;
             }
         }
@@ -84,7 +84,7 @@ impl Verification {
             {
                 let verification_clone = verification.clone();
 
-                let ret = c
+                let _ret = c
                     .spawn(async move {
                         verification
                             .accept_with_methods(vec![
@@ -158,7 +158,7 @@ impl Verification {
 
                         // We accept here automatically since the only method
                         // we're supporting is SAS verification
-                        let ret = connection
+                        let _ret = connection
                             .spawn(async move { sas.accept().await })
                             .await;
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -727,7 +727,7 @@ impl InnerServer {
     }
 
     /// Borrow the server buffer handle.
-    pub fn server_buffer(&self) -> Ref<Option<BufferHandle>> {
+    pub fn server_buffer(&self) -> Ref<'_, Option<BufferHandle>> {
         self.server_buffer.borrow()
     }
 

--- a/src/verification_buffer.rs
+++ b/src/verification_buffer.rs
@@ -111,7 +111,7 @@ struct InnerVerificationBuffer {
 }
 
 impl InnerVerificationBuffer {
-    fn print_done(&self, buffer: BufferHandle) {}
+    fn print_done(&self, _buffer: BufferHandle) {}
 
     pub async fn accept(&self, buffer: BufferHandle) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
@@ -227,7 +227,7 @@ impl BufferCloseCallback for InnerVerificationBuffer {
 impl VerificationBuffer {
     pub fn new(
         server_name: &str,
-        sender: &UserId,
+        _sender: &UserId,
         verification: impl Into<Verification>,
         connection: Rc<RefCell<Option<Connection>>>,
     ) -> Self {


### PR DESCRIPTION
References #187

Doesn't fix all warnings so doesn't closes it.

Left over warnings:


```
warning: field `0` is never read
   --> src/render.rs:627:14
    |
627 |     ToDevice(VerificationRequest),
    |     -------- ^^^^^^^^^^^^^^^^^^^
    |     |
    |     field in this variant
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
627 -     ToDevice(VerificationRequest),
627 +     ToDevice(()),
    |

warning: trait `HasFormattedBody` is never used
   --> src/render.rs:755:7
    |
755 | trait HasFormattedBody {
    |       ^^^^^^^^^^^^^^^^

warning: method `url` is never used
   --> src/render.rs:786:8
    |
785 | pub trait HasUrlOrFile {
    |           ------------ method in this trait
786 |     fn url(&self) -> Option<&MxcUri>;
    |        ^^^

warning: method `room` is never used
   --> src/room/members.rs:245:8
    |
 52 | impl Members {
    | ------------ method in this implementation
...
245 |     fn room(&self) -> &Room {
    |        ^^^^

warning: method `generate_qr_code` is never used
  --> src/verification_buffer.rs:90:14
   |
81 | impl Verification {
   | ----------------- method in this implementation
...
90 |     async fn generate_qr_code(&self) -> Option<QrVerification> {
   |              ^^^^^^^^^^^^^^^^

warning: unused `Result` that must be used
   --> src/server.rs:852:37
    |
852 | ...                   buffer.update(sas).await;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
help: use `let _ = ...` to ignore the resulting value
    |
852 |                                     let _ = buffer.update(sas).await;
    |                                     +++++++

warning: `weechat-matrix` (lib) generated 6 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 31s
```
