### PR TITLE
build: add make check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SOURCES := $(wildcard src/*.rs src/bar_items/*.rs src/commands/*.rs src/room/*.r
 
 PROFILE ?= release
 
-.PHONY: install install-user uninstall uninstall-user install-dir install-user-dir lint all help deb
+.PHONY: install install-user uninstall uninstall-user install-dir install-user-dir lint check all help deb
 
 all: help
 
@@ -45,6 +45,9 @@ install-user-dir:
 
 lint: ## Lint issues with clippy
 	cargo clippy
+
+check: ## Run test suite
+	cargo test --release
 
 # Get the base package version from Cargo.toml (fallback when no git tags are found)
 CARGO_VERSION := $(shell grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')


### PR DESCRIPTION
Adds a GNU-style `make check` target that runs the existing release test suite.

References #189.

Local note: on this host, `make check` reaches `cargo test --release` but the build stops in `openssl-sys` because the host has OpenSSL 4; GitHub Actions should be the real check surface here.