### PR TITLE
fix: avoid scary duplicate nick errors

### DIFF
--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use dashmap::DashMap;
 use tokio::runtime::Handle;
-use tracing::{error, info};
+use tracing::{debug, info};
 
 use matrix_sdk::{
     deserialized_responses::AmbiguityChange,
@@ -76,8 +76,8 @@ impl Members {
         info!("Inserting nick {} for room {}", nick, buffer.short_name());
 
         if group.add_nick(nick_settings).is_err() {
-            error!(
-                "Error adding nick {} ({}) to room {}, already added.",
+            debug!(
+                "Nick {} ({}) is already present in room {}, skipping duplicate insert.",
                 nick,
                 member.user_id(),
                 buffer.short_name()

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use dashmap::DashMap;
 use tokio::runtime::Handle;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use matrix_sdk::{
     deserialized_responses::AmbiguityChange,


### PR DESCRIPTION
Duplicate nick inserts can happen while restoring or refreshing room members. Keep a debug trace for that case, but do not log it as an `ERROR` at startup.

Fixes #190.