### PR TITLE
fix: clean up Rust 1.96 warnings

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -1,9 +1,7 @@
 use url::Url;
 
 use matrix_sdk::{
-    encryption::verification::{
-        SasVerification, Verification, VerificationRequest,
-    },
+    encryption::verification::{SasVerification, Verification},
     ruma::{
         events::{
             key::verification::{
@@ -624,7 +622,7 @@ render_start_content!(ToDeviceKeyVerificationStartEventContent);
 
 pub enum VerificationContext {
     Room(WeechatRoomMember, WeechatRoomMember),
-    ToDevice(VerificationRequest),
+    ToDevice,
 }
 
 macro_rules! render_request_content {
@@ -650,7 +648,7 @@ macro_rules! render_request_content {
                             )
                         }
                     }
-                    VerificationContext::ToDevice(_) => {
+                    VerificationContext::ToDevice => {
                         format!("You have requested this device to be verified")
                     }
                 };
@@ -749,42 +747,9 @@ macro_rules! render_key_content {
 render_key_content!(KeyVerificationKeyEventContent);
 render_key_content!(ToDeviceKeyVerificationKeyEventContent);
 
-/// Trait for message event types that contain an optional formatted body.
-/// `resolve_body` will return the formatted body if present, else fallback to
-/// the regular body.
-trait HasFormattedBody {
-    fn body(&self) -> &str;
-    fn formatted_body(&self) -> Option<&str>;
-    #[inline]
-    fn resolve_body(&self) -> &str {
-        self.formatted_body().unwrap_or_else(|| self.body())
-    }
-}
-
-// Repeating this for each event type would get boring fast so lets use a simple
-// macro to implement the trait for a struct that has a `body` and
-// `formatted_body` field
-macro_rules! has_formatted_body {
-    ($content: ident) => {
-        impl HasFormattedBody for $content {
-            #[inline]
-            fn body(&self) -> &str {
-                &self.body
-            }
-
-            #[inline]
-            fn formatted_body(&self) -> Option<&str> {
-                self.formatted.as_ref().map(|f| f.body.as_ref())
-            }
-        }
-    };
-}
-
 /// This trait is implemented for message types that can contain either an URL
 /// or an encrypted file. One of these _must_ be present.
 pub trait HasUrlOrFile {
-    fn url(&self) -> Option<&MxcUri>;
-
     fn body(&self) -> &str;
 
     #[inline]
@@ -809,14 +774,6 @@ macro_rules! has_url_or_file {
                 &self.body
             }
 
-            #[inline]
-            fn url(&self) -> Option<&MxcUri> {
-                match &self.source {
-                    MediaSource::Plain(url) => Some(url),
-                    _ => None,
-                }
-            }
-
             fn source(&self) -> &MediaSource {
                 &self.source
             }
@@ -830,11 +787,6 @@ macro_rules! has_url_or_file {
         }
     };
 }
-
-// this actually implements the trait for different event types
-has_formatted_body!(EmoteMessageEventContent);
-has_formatted_body!(NoticeMessageEventContent);
-has_formatted_body!(TextMessageEventContent);
 
 has_url_or_file!(AudioMessageEventContent);
 has_url_or_file!(FileMessageEventContent);

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -242,10 +242,6 @@ impl Members {
         }
     }
 
-    fn room(&self) -> &Room {
-        &self.room
-    }
-
     pub fn mark_active(
         &self,
         user_id: &UserId,

--- a/src/room/verification.rs
+++ b/src/room/verification.rs
@@ -68,7 +68,7 @@ impl Verification {
             if let Some(ActiveVerification::Sas(verification)) =
                 self.inner.borrow().clone()
             {
-                let ret =
+                let _ret =
                     c.spawn(async move { verification.confirm().await }).await;
             }
         }
@@ -84,7 +84,7 @@ impl Verification {
             {
                 let verification_clone = verification.clone();
 
-                let ret = c
+                let _ret = c
                     .spawn(async move {
                         verification
                             .accept_with_methods(vec![
@@ -158,7 +158,7 @@ impl Verification {
 
                         // We accept here automatically since the only method
                         // we're supporting is SAS verification
-                        let ret = connection
+                        let _ret = connection
                             .spawn(async move { sas.accept().await })
                             .await;
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -727,7 +727,7 @@ impl InnerServer {
     }
 
     /// Borrow the server buffer handle.
-    pub fn server_buffer(&self) -> Ref<Option<BufferHandle>> {
+    pub fn server_buffer(&self) -> Ref<'_, Option<BufferHandle>> {
         self.server_buffer.borrow()
     }
 
@@ -849,7 +849,7 @@ impl InnerServer {
                                     .cloned();
 
                                 if let Some(mut buffer) = buffer {
-                                    buffer.update(sas).await;
+                                    let _ = buffer.update(sas).await;
                                     buffer.handle_event(&event).await;
                                 } else {
                                     let buffer = VerificationBuffer::new(

--- a/src/verification_buffer.rs
+++ b/src/verification_buffer.rs
@@ -87,14 +87,6 @@ impl Verification {
         }
     }
 
-    async fn generate_qr_code(&self) -> Option<QrVerification> {
-        match self {
-            Verification::Request(r) => r.generate_qr_code().await.unwrap(),
-            Verification::Sas(_) => None,
-            Verification::Qr(_) => None,
-        }
-    }
-
     async fn cancel(&self) -> Result<(), Error> {
         match self {
             Verification::Request(r) => r.cancel().await,
@@ -111,7 +103,7 @@ struct InnerVerificationBuffer {
 }
 
 impl InnerVerificationBuffer {
-    fn print_done(&self, buffer: BufferHandle) {}
+    fn print_done(&self, _buffer: BufferHandle) {}
 
     pub async fn accept(&self, buffer: BufferHandle) -> Result<(), Error> {
         if let Some(c) = self.connection.borrow().clone() {
@@ -227,7 +219,7 @@ impl BufferCloseCallback for InnerVerificationBuffer {
 impl VerificationBuffer {
     pub fn new(
         server_name: &str,
-        sender: &UserId,
+        _sender: &UserId,
         verification: impl Into<Verification>,
         connection: Rc<RefCell<Option<Connection>>>,
     ) -> Self {
@@ -305,12 +297,11 @@ impl VerificationBuffer {
     pub async fn handle_event(&self, event: &AnyToDeviceEvent) {
         match event {
             AnyToDeviceEvent::KeyVerificationRequest(e) => {
-                if let Verification::Request(request) =
+                if let Verification::Request(_) =
                     self.inner.verification.borrow().clone()
                 {
-                    let content = e
-                        .content
-                        .render(&VerificationContext::ToDevice(request));
+                    let content =
+                        e.content.render(&VerificationContext::ToDevice);
 
                     self.print(&content);
                 }


### PR DESCRIPTION
Cleans up the Rust 1.96 warnings from #187, including the simple `cargo fix` suggestions and the remaining dead-code / unused-result warnings.

Fixes #187.

Validation: Ubuntu 24.04 container, Rust 1.96.1: `cargo fmt --check`; `cargo check --lib`.