### PR TITLE
fix: show reply relation in rendered messages

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -74,6 +74,26 @@ impl RenderedEvent {
 
         self
     }
+
+    pub fn add_reply_context(mut self, event_id: &EventId) -> Self {
+        let mut tags = self
+            .content
+            .lines
+            .first()
+            .map(|line| line.tags.clone())
+            .unwrap_or_default();
+        tags.push("matrix_reply".to_owned());
+
+        self.content.lines.insert(
+            0,
+            RenderedLine {
+                tags,
+                message: format!("Reply to {}", event_id),
+            },
+        );
+
+        self
+    }
 }
 
 #[derive(Debug)]
@@ -1087,5 +1107,32 @@ mod tests {
         let source = MediaSource::Encrypted(Box::new(encrypt_info));
 
         assert_eq!(None, media_download_command(&source));
+    }
+
+    #[test]
+    fn reply_context_is_rendered_as_visible_line() {
+        let event_id =
+            matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
+        let rendered = RenderedEvent {
+            message_timestamp: 0,
+            prefix: "alice\t".to_owned(),
+            content: RenderedContent {
+                lines: vec![RenderedLine {
+                    tags: vec!["matrix_text".to_owned()],
+                    message: "reply body".to_owned(),
+                }],
+            },
+        }
+        .add_reply_context(&event_id);
+
+        assert_eq!(2, rendered.content.lines.len());
+        assert_eq!(
+            "Reply to $replyevent:example.org",
+            rendered.content.lines[0].message
+        );
+        assert!(rendered.content.lines[0]
+            .tags
+            .contains(&"matrix_reply".to_owned()));
+        assert_eq!("reply body", rendered.content.lines[1].message);
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -59,7 +59,7 @@ use matrix_sdk::{
             room::{
                 member::RoomMemberEventContent,
                 message::{
-                    MessageType, RoomMessageEventContent,
+                    MessageType, Relation, RoomMessageEventContent,
                     TextMessageEventContent,
                 },
                 redaction::SyncRoomRedactionEvent,
@@ -589,48 +589,63 @@ impl MatrixRoom {
             RoomEncrypted(c) => {
                 c.render_with_prefix(send_time, event_id, sender, &())
             }
-            RoomMessage(c) => match &c.msgtype {
-                Text(c) => {
-                    c.render_with_prefix(send_time, event_id, sender, &())
+            RoomMessage(c) => {
+                let reply_to = match c.relates_to.as_ref() {
+                    Some(Relation::Reply { in_reply_to }) => {
+                        Some(&in_reply_to.event_id)
+                    }
+                    _ => None,
+                };
+
+                let rendered = match &c.msgtype {
+                    Text(c) => {
+                        c.render_with_prefix(send_time, event_id, sender, &())
+                    }
+                    Emote(c) => c.render_with_prefix(
+                        send_time, event_id, sender, sender,
+                    ),
+                    Notice(c) => c.render_with_prefix(
+                        send_time, event_id, sender, sender,
+                    ),
+                    ServerNotice(c) => c.render_with_prefix(
+                        send_time, event_id, sender, sender,
+                    ),
+                    Location(c) => c.render_with_prefix(
+                        send_time, event_id, sender, sender,
+                    ),
+                    Audio(c) => c.render_with_prefix(
+                        send_time,
+                        event_id,
+                        sender,
+                        &self.homeserver,
+                    ),
+                    Video(c) => c.render_with_prefix(
+                        send_time,
+                        event_id,
+                        sender,
+                        &self.homeserver,
+                    ),
+                    File(c) => c.render_with_prefix(
+                        send_time,
+                        event_id,
+                        sender,
+                        &self.homeserver,
+                    ),
+                    Image(c) => c.render_with_prefix(
+                        send_time,
+                        event_id,
+                        sender,
+                        &self.homeserver,
+                    ),
+                    _ => return None,
+                };
+
+                if let Some(event_id) = reply_to {
+                    rendered.add_reply_context(event_id)
+                } else {
+                    rendered
                 }
-                Emote(c) => {
-                    c.render_with_prefix(send_time, event_id, sender, sender)
-                }
-                Notice(c) => {
-                    c.render_with_prefix(send_time, event_id, sender, sender)
-                }
-                ServerNotice(c) => {
-                    c.render_with_prefix(send_time, event_id, sender, sender)
-                }
-                Location(c) => {
-                    c.render_with_prefix(send_time, event_id, sender, sender)
-                }
-                Audio(c) => c.render_with_prefix(
-                    send_time,
-                    event_id,
-                    sender,
-                    &self.homeserver,
-                ),
-                Video(c) => c.render_with_prefix(
-                    send_time,
-                    event_id,
-                    sender,
-                    &self.homeserver,
-                ),
-                File(c) => c.render_with_prefix(
-                    send_time,
-                    event_id,
-                    sender,
-                    &self.homeserver,
-                ),
-                Image(c) => c.render_with_prefix(
-                    send_time,
-                    event_id,
-                    sender,
-                    &self.homeserver,
-                ),
-                _ => return None,
-            },
+            }
             _ => return None,
         };
 


### PR DESCRIPTION
Matrix replies now get an explicit `Reply to <event id>` line before the message body, so they are visibly different from ordinary messages even when the quoted event is not loaded locally.

References #112.

Validation: Ubuntu 24.04 container: `cargo fmt --check`; `cargo test --lib reply_context_is_rendered_as_visible_line`; `cargo check --lib`.