### PR TITLE
fix: show replied-to sender in reply context

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -73,7 +73,11 @@ impl RenderedEvent {
         self
     }
 
-    pub fn add_reply_context(mut self, event_id: &EventId) -> Self {
+    pub fn add_reply_context(
+        mut self,
+        event_id: &EventId,
+        sender: Option<&str>,
+    ) -> Self {
         let mut tags = self
             .content
             .lines
@@ -86,7 +90,10 @@ impl RenderedEvent {
             0,
             RenderedLine {
                 tags,
-                message: format!("Reply to {}", event_id),
+                message: format!(
+                    "Reply to {}",
+                    sender.unwrap_or_else(|| event_id.as_str())
+                ),
             },
         );
 
@@ -1092,7 +1099,7 @@ mod tests {
     }
 
     #[test]
-    fn reply_context_is_rendered_as_visible_line() {
+    fn reply_context_names_known_sender() {
         let event_id =
             matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
         let rendered = RenderedEvent {
@@ -1105,9 +1112,32 @@ mod tests {
                 }],
             },
         }
-        .add_reply_context(&event_id);
+        .add_reply_context(&event_id, Some("Alice"));
 
         assert_eq!(2, rendered.content.lines.len());
+        assert_eq!("Reply to Alice", rendered.content.lines[0].message);
+        assert!(rendered.content.lines[0]
+            .tags
+            .contains(&"matrix_reply".to_owned()));
+        assert_eq!("reply body", rendered.content.lines[1].message);
+    }
+
+    #[test]
+    fn reply_context_falls_back_to_event_id() {
+        let event_id =
+            matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
+        let rendered = RenderedEvent {
+            message_timestamp: 0,
+            prefix: "alice\t".to_owned(),
+            content: RenderedContent {
+                lines: vec![RenderedLine {
+                    tags: vec!["matrix_text".to_owned()],
+                    message: "reply body".to_owned(),
+                }],
+            },
+        }
+        .add_reply_context(&event_id, None);
+
         assert_eq!(
             "Reply to $replyevent:example.org",
             rendered.content.lines[0].message

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, cell::RefCell, rc::Rc};
 use futures_util::StreamExt;
 use matrix_sdk::{
     room::ParentSpace,
-    ruma::{EventId, OwnedRoomAliasId, TransactionId, UserId},
+    ruma::{EventId, OwnedRoomAliasId, OwnedUserId, TransactionId, UserId},
     Error, Room,
 };
 use tokio::runtime::Handle;
@@ -46,6 +46,22 @@ impl RoomBuffer {
             .unwrap_or_default()
     }
 
+    /// Return the sender ID for an event that is still in the buffer.
+    ///
+    /// Reply rendering uses this local lookup so it never blocks on a
+    /// homeserver request. Callers retain the event-id fallback when the target
+    /// line is no longer available.
+    pub fn reply_sender_id(&self, event_id: &EventId) -> Option<OwnedUserId> {
+        let buffer_handle = self.buffer_handle();
+        let buffer = buffer_handle.upgrade().ok()?;
+        let event_id_tag = Cow::from(event_id.to_tag());
+        let line = buffer
+            .lines()
+            .rfind(|line| line.tags().contains(&event_id_tag))?;
+
+        reply_sender_id_from_tags(&line.tags())
+    }
+
     /// Replace the local echo of an event with a fully rendered one.
     pub fn replace_local_echo(
         &self,
@@ -68,8 +84,11 @@ impl RoomBuffer {
             while let Some(line) = &current_line {
                 line_num -= 1;
                 let rendered_line = &rendered.content.lines[line_num];
+                let tags: Vec<&str> =
+                    rendered_line.tags.iter().map(String::as_str).collect();
 
                 line.set_message(&rendered_line.message);
+                line.set_tags(&tags);
                 current_line = lines.next_back().filter(line_contains_uuid);
             }
         }
@@ -266,6 +285,14 @@ impl RoomBuffer {
     }
 }
 
+fn reply_sender_id_from_tags<T: AsRef<str>>(tags: &[T]) -> Option<OwnedUserId> {
+    tags.iter().find_map(|tag| {
+        tag.as_ref()
+            .strip_prefix("matrix_sender_")
+            .and_then(|sender| UserId::parse(sender).ok())
+    })
+}
+
 fn non_empty_room_name(name: &str) -> Option<String> {
     let name = name.trim();
 
@@ -341,7 +368,26 @@ impl RoomBuffer {
 
 #[cfg(test)]
 mod tests {
-    use super::format_buffer_name;
+    use matrix_sdk::ruma::user_id;
+
+    use super::{format_buffer_name, reply_sender_id_from_tags};
+
+    #[test]
+    fn reply_sender_uses_matrix_sender_tag() {
+        let tags = ["matrix_text", "matrix_sender_@alice:example.org"];
+
+        assert_eq!(
+            Some(user_id!("@alice:example.org").to_owned()),
+            reply_sender_id_from_tags(&tags)
+        );
+    }
+
+    #[test]
+    fn reply_sender_is_unknown_without_matrix_sender_tag() {
+        let tags = ["matrix_text", "matrix_reply"];
+
+        assert_eq!(None, reply_sender_id_from_tags(&tags));
+    }
 
     #[test]
     fn preserves_named_channel_prefix() {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -598,7 +598,19 @@ impl MatrixRoom {
             RoomMessage(c) => {
                 let reply_to = match c.relates_to.as_ref() {
                     Some(Relation::Reply { in_reply_to }) => {
-                        Some(&in_reply_to.event_id)
+                        let sender = match self
+                            .buffer
+                            .reply_sender_id(&in_reply_to.event_id)
+                        {
+                            Some(sender_id) => self
+                                .members
+                                .get(&sender_id)
+                                .await
+                                .map(|member| member.nick()),
+                            None => None,
+                        };
+
+                        Some((&in_reply_to.event_id, sender))
                     }
                     _ => None,
                 };
@@ -646,8 +658,8 @@ impl MatrixRoom {
                     _ => return None,
                 };
 
-                if let Some(event_id) = reply_to {
-                    rendered.add_reply_context(event_id)
+                if let Some((event_id, sender)) = reply_to {
+                    rendered.add_reply_context(event_id, sender.as_deref())
                 } else {
                     rendered
                 }


### PR DESCRIPTION
Replies currently show only the target event ID, so the WeeChat buffer does not reveal who a message addresses. When the original event is still in the buffer, use its Matrix sender tag and the local member cache to render `Reply to <nick>` instead. Keep the event ID fallback when local context is unavailable, without fetching anything from the homeserver.

This also replaces local-echo tags with the final event tags after acknowledgement, so replies to sent messages can use the same lookup.

Tested with `cargo test --locked --lib` (25 tests), `cargo fmt --check`, and `git diff --check`.

Follow-up to poljar/weechat-matrix-rs#194.
