### PR TITLE
Add Matrix thread buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,8 @@ impl Servers {
             }
 
             for room in server.rooms() {
-                let buffer_handle = room.buffer_handle();
-
-                if let Ok(b) = buffer_handle.upgrade() {
-                    if buffer == &b {
-                        return BufferOwner::Room(server.clone(), room);
-                    }
+                if room.owns_buffer(buffer) {
+                    return BufferOwner::Room(server.clone(), room);
                 }
             }
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -1,9 +1,12 @@
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
+use std::{borrow::Cow, cell::RefCell, collections::HashMap, rc::Rc};
 
 use futures_util::StreamExt;
 use matrix_sdk::{
     room::ParentSpace,
-    ruma::{EventId, OwnedRoomAliasId, OwnedUserId, TransactionId, UserId},
+    ruma::{
+        EventId, OwnedEventId, OwnedRoomAliasId, OwnedUserId, TransactionId,
+        UserId,
+    },
     Error, Room,
 };
 use tokio::runtime::Handle;
@@ -19,6 +22,7 @@ pub struct RoomBuffer {
     room: Room,
     runtime: Handle,
     pub(super) inner: Rc<RefCell<Option<BufferHandle>>>,
+    thread_buffers: Rc<RefCell<HashMap<OwnedEventId, BufferHandle>>>,
 }
 
 impl RoomBuffer {
@@ -27,6 +31,7 @@ impl RoomBuffer {
             room,
             runtime,
             inner: Rc::new(RefCell::new(None)),
+            thread_buffers: Rc::new(RefCell::new(HashMap::new())),
         }
     }
 
@@ -44,6 +49,39 @@ impl RoomBuffer {
             .as_ref()
             .and_then(|b| b.upgrade().ok().map(|b| b.short_name().to_string()))
             .unwrap_or_default()
+    }
+
+    pub fn owns_buffer(&self, buffer: &Buffer) -> bool {
+        if self
+            .inner
+            .borrow()
+            .as_ref()
+            .and_then(|b| b.upgrade().ok())
+            .is_some_and(|b| &b == buffer)
+        {
+            return true;
+        }
+
+        self.thread_buffers
+            .borrow()
+            .values()
+            .any(|handle| handle.upgrade().is_ok_and(|b| &b == buffer))
+    }
+
+    pub fn thread_buffer(&self, thread_root: &EventId) -> Option<BufferHandle> {
+        self.thread_buffers.borrow().get(thread_root).cloned()
+    }
+
+    pub fn set_thread_buffer(
+        &self,
+        thread_root: OwnedEventId,
+        handle: BufferHandle,
+    ) {
+        self.thread_buffers.borrow_mut().insert(thread_root, handle);
+    }
+
+    pub fn remove_thread_buffer(&self, thread_root: &EventId) {
+        self.thread_buffers.borrow_mut().remove(thread_root);
     }
 
     /// Return the sender ID for an event that is still in the buffer.
@@ -64,16 +102,19 @@ impl RoomBuffer {
 
     /// Return whether an event is already rendered in the buffer.
     pub fn contains_event(&self, event_id: &EventId) -> bool {
-        let buffer_handle = self.buffer_handle();
-        let Ok(buffer) = buffer_handle.upgrade() else {
-            return false;
-        };
         let event_id_tag = Cow::from(event_id.to_tag());
 
-        buffer
-            .lines()
-            .rfind(|line| line.tags().contains(&event_id_tag))
-            .is_some()
+        let main_buffer_contains_event = self
+            .buffer_handle()
+            .upgrade()
+            .is_ok_and(|buffer| buffer_contains_tag(&buffer, &event_id_tag));
+
+        main_buffer_contains_event
+            || self.thread_buffers.borrow().values().any(|handle| {
+                handle.upgrade().is_ok_and(|buffer| {
+                    buffer_contains_tag(&buffer, &event_id_tag)
+                })
+            })
     }
 
     /// Replace the local echo of an event with a fully rendered one.
@@ -82,30 +123,19 @@ impl RoomBuffer {
         transaction_id: &TransactionId,
         rendered: RenderedEvent,
     ) {
-        if let Ok(buffer) = self.buffer_handle().upgrade() {
-            let uuid_tag = Cow::from(format!("matrix_echo_{}", transaction_id));
-            let line_contains_uuid =
-                |l: &BufferLine| l.tags().contains(&uuid_tag);
+        let uuid_tag = Cow::from(format!("matrix_echo_{}", transaction_id));
 
-            let mut lines = buffer.lines();
-            let mut current_line = lines.rfind(line_contains_uuid);
-
-            // We go in reverse order here since we also use rfind(). We got from
-            // the bottom of the buffer to the top since we're expecting these
-            // lines to be freshly printed and thus at the bottom.
-            let mut line_num = rendered.content.lines.len();
-
-            while let Some(line) = &current_line {
-                line_num -= 1;
-                let rendered_line = &rendered.content.lines[line_num];
-                let tags: Vec<&str> =
-                    rendered_line.tags.iter().map(String::as_str).collect();
-
-                line.set_message(&rendered_line.message);
-                line.set_tags(&tags);
-                current_line = lines.next_back().filter(line_contains_uuid);
-            }
+        if self.buffer_handle().upgrade().is_ok_and(|buffer| {
+            replace_local_echo_in_buffer(&buffer, &uuid_tag, &rendered)
+        }) {
+            return;
         }
+
+        self.thread_buffers.borrow().values().any(|handle| {
+            handle.upgrade().is_ok_and(|buffer| {
+                replace_local_echo_in_buffer(&buffer, &uuid_tag, &rendered)
+            })
+        });
     }
 
     pub fn replace_edit(
@@ -114,22 +144,53 @@ impl RoomBuffer {
         sender: &UserId,
         event: RenderedEvent,
     ) {
-        if let Ok(buffer) = self.buffer_handle().upgrade() {
-            let sender_tag = Cow::from(sender.to_tag());
-            let event_id_tag = Cow::from(event_id.to_tag());
+        let sender_tag = Cow::from(sender.to_tag());
+        let event_id_tag = Cow::from(event_id.to_tag());
 
-            let lines: Vec<BufferLine> = buffer
-                .lines()
-                .filter(|l| l.tags().contains(&event_id_tag))
-                .collect();
+        if self.buffer_handle().upgrade().is_ok_and(|buffer| {
+            self.replace_edit_in_buffer(
+                &buffer,
+                &event_id_tag,
+                &sender_tag,
+                &event,
+            )
+        }) {
+            return;
+        }
 
-            if lines
-                .get(0)
-                .map(|l| l.tags().contains(&sender_tag))
-                .unwrap_or(false)
-            {
-                self.replace_event_helper(&buffer, lines, event);
-            }
+        self.thread_buffers.borrow().values().any(|handle| {
+            handle.upgrade().is_ok_and(|buffer| {
+                self.replace_edit_in_buffer(
+                    &buffer,
+                    &event_id_tag,
+                    &sender_tag,
+                    &event,
+                )
+            })
+        });
+    }
+
+    fn replace_edit_in_buffer(
+        &self,
+        buffer: &Buffer,
+        event_id_tag: &Cow<str>,
+        sender_tag: &Cow<str>,
+        event: &RenderedEvent,
+    ) -> bool {
+        let lines: Vec<BufferLine> = buffer
+            .lines()
+            .filter(|l| l.tags().contains(event_id_tag))
+            .collect();
+
+        if lines
+            .get(0)
+            .map(|l| l.tags().contains(sender_tag))
+            .unwrap_or(false)
+        {
+            self.replace_event_helper(buffer, lines, event);
+            true
+        } else {
+            false
         }
     }
 
@@ -137,7 +198,7 @@ impl RoomBuffer {
         &self,
         buffer: &Buffer,
         lines: Vec<BufferLine<'_>>,
-        event: RenderedEvent,
+        event: &RenderedEvent,
     ) {
         use std::cmp::Ordering;
         let date = lines.get(0).map(|l| l.date()).unwrap_or_default();
@@ -297,6 +358,37 @@ impl RoomBuffer {
 
         format_buffer_name(&room_name, is_direct)
     }
+
+    pub fn calculate_thread_buffer_name(
+        &self,
+        thread_root: &EventId,
+    ) -> String {
+        format!(
+            "{}.thread.{}",
+            self.calculate_buffer_name(),
+            Self::thread_buffer_suffix(thread_root)
+        )
+    }
+
+    pub fn thread_buffer_suffix(thread_root: &EventId) -> String {
+        sanitize_thread_id(thread_root)
+    }
+}
+
+fn buffer_contains_tag(buffer: &Buffer, tag: &Cow<str>) -> bool {
+    buffer
+        .lines()
+        .rfind(|line| line.tags().contains(tag))
+        .is_some()
+}
+
+fn sanitize_thread_id(thread_root: &EventId) -> String {
+    thread_root
+        .as_str()
+        .trim_start_matches('$')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
 }
 
 fn reply_sender_id_from_tags<T: AsRef<str>>(tags: &[T]) -> Option<OwnedUserId> {
@@ -358,7 +450,7 @@ impl RoomBuffer {
                 .filter(|l| l.tags().contains(&event_id_tag))
                 .collect();
 
-            self.replace_event_helper(&buffer, lines, event);
+            self.replace_event_helper(&buffer, lines, &event);
         }
     }
 
@@ -366,25 +458,57 @@ impl RoomBuffer {
         let buffer = self.buffer_handle();
 
         if let Ok(buffer) = buffer.upgrade() {
-            for line in rendered.content.lines {
-                let message = format!("{}{}", &rendered.prefix, &line.message);
-                let tags: Vec<&str> =
-                    line.tags.iter().map(|t| t.as_str()).collect();
-                buffer.print_date_tags(
-                    rendered.message_timestamp,
-                    &tags,
-                    &message,
-                )
-            }
+            print_rendered_event_to_buffer(&buffer, rendered);
         }
     }
 }
 
+pub fn print_rendered_event_to_buffer(
+    buffer: &Buffer,
+    rendered: RenderedEvent,
+) {
+    for line in rendered.content.lines {
+        let message = format!("{}{}", &rendered.prefix, &line.message);
+        let tags: Vec<&str> = line.tags.iter().map(|t| t.as_str()).collect();
+        buffer.print_date_tags(rendered.message_timestamp, &tags, &message)
+    }
+}
+
+fn replace_local_echo_in_buffer(
+    buffer: &Buffer,
+    uuid_tag: &Cow<str>,
+    rendered: &RenderedEvent,
+) -> bool {
+    let line_contains_uuid = |line: &BufferLine| line.tags().contains(uuid_tag);
+    let mut lines = buffer.lines();
+    let mut current_line = lines.rfind(line_contains_uuid);
+    let mut replaced = false;
+
+    // We go from bottom to top since local echoes are expected to be fresh.
+    let mut line_num = rendered.content.lines.len();
+
+    while let Some(line) = &current_line {
+        line_num -= 1;
+        let rendered_line = &rendered.content.lines[line_num];
+        let tags: Vec<&str> =
+            rendered_line.tags.iter().map(String::as_str).collect();
+
+        line.set_message(&rendered_line.message);
+        line.set_tags(&tags);
+        replaced = true;
+        current_line = lines.next_back().filter(line_contains_uuid);
+    }
+
+    replaced
+}
+
 #[cfg(test)]
 mod tests {
-    use matrix_sdk::ruma::user_id;
+    use matrix_sdk::ruma::{event_id, user_id};
 
-    use super::{format_buffer_name, reply_sender_id_from_tags};
+    use super::{
+        format_buffer_name, reply_sender_id_from_tags, sanitize_thread_id,
+    };
 
     #[test]
     fn reply_sender_uses_matrix_sender_tag() {
@@ -424,6 +548,14 @@ mod tests {
         assert_eq!(
             format_buffer_name("!roomid:matrix.osgeo.org", false),
             "!roomid:matrix.osgeo.org"
+        );
+    }
+
+    #[test]
+    fn sanitizes_thread_event_id_for_buffer_name() {
+        assert_eq!(
+            sanitize_thread_id(event_id!("$abc/def:example.org")),
+            "abc_def_example_org"
         );
     }
 }

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -383,12 +383,21 @@ fn buffer_contains_tag(buffer: &Buffer, tag: &Cow<str>) -> bool {
 }
 
 fn sanitize_thread_id(thread_root: &EventId) -> String {
-    thread_root
+    const THREAD_ID_DISPLAY_CHARS: usize = 12;
+
+    let mut sanitized: String = thread_root
         .as_str()
         .trim_start_matches('$')
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect()
+        .take(THREAD_ID_DISPLAY_CHARS)
+        .collect();
+
+    if sanitized.is_empty() {
+        sanitized.push_str("unknown");
+    }
+
+    sanitized
 }
 
 fn reply_sender_id_from_tags<T: AsRef<str>>(tags: &[T]) -> Option<OwnedUserId> {
@@ -508,6 +517,7 @@ mod tests {
 
     use super::{
         format_buffer_name, reply_sender_id_from_tags, sanitize_thread_id,
+        RoomBuffer,
     };
 
     #[test]
@@ -555,7 +565,17 @@ mod tests {
     fn sanitizes_thread_event_id_for_buffer_name() {
         assert_eq!(
             sanitize_thread_id(event_id!("$abc/def:example.org")),
-            "abc_def_example_org"
+            "abc_def_exam"
+        );
+    }
+
+    #[test]
+    fn thread_buffer_suffix_uses_short_human_id() {
+        assert_eq!(
+            RoomBuffer::thread_buffer_suffix(event_id!(
+                "$abcdef0123456789:example.org"
+            )),
+            "abcdef012345"
         );
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -825,7 +825,6 @@ impl MatrixRoom {
 
         buffer.set_localvar("room_id", self.room_id.as_str());
         buffer.set_localvar("thread_root", thread_root.as_str());
-        buffer.set_localvar("type", "thread");
         buffer.set_title(&format!(
             "Thread {} in {}",
             thread_root, room_short_name

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -26,7 +26,7 @@ mod buffer;
 mod members;
 mod verification;
 
-use buffer::RoomBuffer;
+use buffer::{print_rendered_event_to_buffer, RoomBuffer};
 use members::Members;
 pub use members::WeechatRoomMember;
 use tokio::runtime::Handle;
@@ -56,6 +56,7 @@ use matrix_sdk::{
     room::Room,
     ruma::{
         events::{
+            relation::Thread,
             room::{
                 member::RoomMemberEventContent,
                 message::{
@@ -168,6 +169,7 @@ pub struct MatrixRoom {
     prev_batch: Rc<RefCell<Option<PrevBatch>>>,
     latest_event_id: Rc<RefCell<Option<OwnedEventId>>>,
     latest_read_event_id: Rc<RefCell<Option<OwnedEventId>>>,
+    latest_thread_event_ids: Rc<RefCell<HashMap<OwnedEventId, OwnedEventId>>>,
 
     outgoing_messages: MessageQueue,
 
@@ -249,6 +251,59 @@ fn take_transaction_event(
     }
 }
 
+fn make_text_message_content(
+    input: String,
+    markdown: bool,
+    thread_root: Option<OwnedEventId>,
+    latest_thread_event: Option<OwnedEventId>,
+) -> RoomMessageEventContent {
+    let text = if markdown {
+        TextMessageEventContent::markdown(input)
+    } else {
+        TextMessageEventContent::plain(input)
+    };
+
+    let mut content = RoomMessageEventContent::new(MessageType::Text(text));
+
+    if let Some(thread_root) = thread_root {
+        let latest_thread_event =
+            latest_thread_event.unwrap_or_else(|| thread_root.clone());
+
+        content.relates_to = Some(Relation::Thread(Thread::plain(
+            thread_root,
+            latest_thread_event,
+        )));
+    }
+
+    content
+}
+
+fn thread_root_from_buffer(buffer: &Buffer) -> Option<OwnedEventId> {
+    buffer
+        .get_localvar("thread_root")
+        .and_then(|thread_root| EventId::parse(thread_root.as_ref()).ok())
+}
+
+fn thread_root_from_content(
+    content: &RoomMessageEventContent,
+) -> Option<&EventId> {
+    match content.relates_to.as_ref() {
+        Some(Relation::Thread(thread)) => Some(&thread.event_id),
+        _ => None,
+    }
+}
+
+fn thread_root_from_event(
+    event: &AnySyncMessageLikeEvent,
+) -> Option<OwnedEventId> {
+    event.original_content().and_then(|content| match content {
+        AnyMessageLikeEventContent::RoomMessage(content) => {
+            thread_root_from_content(&content).map(ToOwned::to_owned)
+        }
+        _ => None,
+    })
+}
+
 impl RoomHandle {
     pub fn new(
         server_name: &str,
@@ -292,6 +347,7 @@ impl RoomHandle {
             )),
             latest_event_id: Rc::new(RefCell::new(None)),
             latest_read_event_id: Rc::new(RefCell::new(None)),
+            latest_thread_event_ids: Rc::new(RefCell::new(HashMap::new())),
             own_user_id: own_user_id.into(),
             members,
             buffer,
@@ -431,22 +487,30 @@ impl RoomHandle {
 
 #[async_trait(?Send)]
 impl BufferInputCallbackAsync for MatrixRoom {
-    async fn callback(&mut self, _: BufferHandle, input: String) {
-        let content = if self.config.borrow().input().markdown_input() {
-            RoomMessageEventContent::new(MessageType::Text(
-                TextMessageEventContent::markdown(input),
-            ))
-        } else {
-            RoomMessageEventContent::new(MessageType::Text(
-                TextMessageEventContent::plain(input),
-            ))
-        };
+    async fn callback(&mut self, buffer: BufferHandle, input: String) {
+        let thread_root = buffer
+            .upgrade()
+            .ok()
+            .and_then(|buffer| thread_root_from_buffer(&buffer));
+        let latest_thread_event = thread_root.as_ref().and_then(|root| {
+            self.latest_thread_event_ids.borrow().get(root).cloned()
+        });
+        let content = make_text_message_content(
+            input,
+            self.config.borrow().input().markdown_input(),
+            thread_root,
+            latest_thread_event,
+        );
 
         self.send_message(content).await;
     }
 }
 
 impl MatrixRoom {
+    pub fn owns_buffer(&self, buffer: &Buffer) -> bool {
+        self.buffer.owns_buffer(buffer)
+    }
+
     pub fn is_encrypted(&self) -> bool {
         self.members
             .runtime
@@ -705,6 +769,92 @@ impl MatrixRoom {
         Some(rendered)
     }
 
+    fn get_or_create_thread_buffer(
+        &self,
+        thread_root: &EventId,
+    ) -> Option<BufferHandle> {
+        if let Some(handle) = self.buffer.thread_buffer(thread_root) {
+            if handle.upgrade().is_ok() {
+                return Some(handle);
+            }
+
+            self.buffer.remove_thread_buffer(thread_root);
+        }
+
+        let room_buffer_handle = self.buffer_handle();
+        let room_buffer = room_buffer_handle.upgrade().ok()?;
+        let thread_short_name =
+            self.buffer.calculate_thread_buffer_name(thread_root);
+        let buffer_name = format!(
+            "{}.thread.{}",
+            room_buffer.name(),
+            RoomBuffer::thread_buffer_suffix(thread_root)
+        );
+        let server = room_buffer
+            .get_localvar("server")
+            .map(|value| value.to_string());
+        let nick = room_buffer
+            .get_localvar("nick")
+            .map(|value| value.to_string());
+        let domain = room_buffer
+            .get_localvar("domain")
+            .map(|value| value.to_string());
+        let room_short_name = self.buffer.short_name();
+
+        let buffer_handle = BufferBuilderAsync::new(&buffer_name)
+            .input_callback(self.clone())
+            .close_callback(|_weechat: &Weechat, _buffer: &Buffer| Ok(()))
+            .build()
+            .ok()?;
+        let buffer = buffer_handle.upgrade().ok()?;
+
+        buffer.set_short_name(&thread_short_name);
+        buffer.enable_multiline();
+        buffer.disable_nicklist();
+        buffer.disable_nicklist_groups();
+
+        if let Some(server) = server {
+            buffer.set_localvar("server", &server);
+        }
+        if let Some(nick) = nick {
+            buffer.set_localvar("nick", &nick);
+        }
+        if let Some(domain) = domain {
+            buffer.set_localvar("domain", &domain);
+        }
+
+        buffer.set_localvar("room_id", self.room_id.as_str());
+        buffer.set_localvar("thread_root", thread_root.as_str());
+        buffer.set_localvar("type", "thread");
+        buffer.set_title(&format!(
+            "Thread {} in {}",
+            thread_root, room_short_name
+        ));
+
+        self.buffer
+            .set_thread_buffer(thread_root.to_owned(), buffer_handle.clone());
+
+        Some(buffer_handle)
+    }
+
+    fn print_rendered_event_for_relation(
+        &self,
+        thread_root: Option<&EventId>,
+        rendered: RenderedEvent,
+    ) {
+        if let Some(handle) =
+            thread_root.and_then(|root| self.get_or_create_thread_buffer(root))
+        {
+            if let Ok(buffer) = handle.upgrade() {
+                print_rendered_event_to_buffer(&buffer, rendered);
+            } else {
+                self.buffer.print_rendered_event(rendered);
+            }
+        } else {
+            self.buffer.print_rendered_event(rendered);
+        }
+    }
+
     async fn render_sync_message(
         &self,
         event: &AnySyncMessageLikeEvent,
@@ -744,6 +894,9 @@ impl MatrixRoom {
         transaction_id: &TransactionId,
         content: &RoomMessageEventContent,
     ) {
+        let thread_root =
+            thread_root_from_content(content).map(ToOwned::to_owned);
+
         if self.config.borrow().look().local_echo() {
             if let MessageType::Text(c) = &content.msgtype {
                 let sender =
@@ -754,7 +907,10 @@ impl MatrixRoom {
                 let local_echo = c
                     .render_with_prefix_for_echo(&sender, transaction_id, &())
                     .add_self_tags();
-                self.buffer.print_rendered_event(local_echo);
+                self.print_rendered_event_for_relation(
+                    thread_root.as_deref(),
+                    local_echo,
+                );
 
                 self.outgoing_messages
                     .add_with_echo(transaction_id.to_owned(), content.clone());
@@ -1127,6 +1283,9 @@ impl MatrixRoom {
         echo: bool,
         content: RoomMessageEventContent,
     ) {
+        let thread_root =
+            thread_root_from_content(&content).map(ToOwned::to_owned);
+
         let event = OriginalSyncMessageLikeEvent {
             sender: (*self.own_user_id).to_owned(),
             origin_server_ts: MilliSecondsSinceUnixEpoch::now(),
@@ -1147,9 +1306,17 @@ impl MatrixRoom {
         if echo {
             self.buffer.replace_local_echo(transaction_id, rendered);
         } else {
-            self.buffer.print_rendered_event(rendered);
+            self.print_rendered_event_for_relation(
+                thread_root.as_deref(),
+                rendered,
+            );
         }
 
+        if let Some(thread_root) = thread_root {
+            self.latest_thread_event_ids
+                .borrow_mut()
+                .insert(thread_root, event_id.to_owned());
+        }
         self.mark_event_as_read(event_id.to_owned(), false);
     }
 
@@ -1227,7 +1394,18 @@ impl MatrixRoom {
         } else if event.is_edit() {
             self.handle_edits(event).await;
         } else if let Some(rendered) = self.render_sync_message(event).await {
-            self.buffer.print_rendered_event(rendered);
+            let thread_root = thread_root_from_event(event);
+
+            if let Some(thread_root) = &thread_root {
+                self.latest_thread_event_ids
+                    .borrow_mut()
+                    .insert(thread_root.clone(), event.event_id().to_owned());
+            }
+
+            self.print_rendered_event_for_relation(
+                thread_root.as_deref(),
+                rendered,
+            );
         }
     }
 
@@ -1411,6 +1589,32 @@ mod tests {
     #[test]
     fn restored_rooms_without_prev_batch_have_no_history_request() {
         assert_eq!(restored_prev_batch(None), None);
+    }
+
+    #[test]
+    fn thread_buffer_input_sends_thread_relation() {
+        let content = make_text_message_content(
+            "thread body".to_owned(),
+            false,
+            Some(EventId::parse("$thread-root:example.org").unwrap()),
+            Some(EventId::parse("$latest-thread-event:example.org").unwrap()),
+        );
+
+        assert!(matches!(content.msgtype, MessageType::Text(_)));
+
+        let Some(Relation::Thread(thread)) = content.relates_to else {
+            panic!("thread buffer input must send an m.thread relation");
+        };
+
+        assert_eq!(
+            thread.event_id,
+            EventId::parse("$thread-root:example.org").unwrap()
+        );
+        assert_eq!(
+            thread.in_reply_to.expect("fallback target").event_id,
+            EventId::parse("$latest-thread-event:example.org").unwrap()
+        );
+        assert!(thread.is_falling_back);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This adds Matrix thread support using separate WeeChat buffers for each thread, matching the second UX option discussed in poljar/weechat-matrix-rs#166.

Threaded incoming messages now open or reuse a thread buffer derived from the room buffer and the thread root event id. Typing in that thread buffer sends an `m.thread` relation back to Matrix, using the latest known event in that thread as the fallback target.

The room-level buffer ownership and rendered-line lookup paths now also know about thread buffers, so local echo replacement, edit replacement, and duplicate detection still work when a message belongs to a thread.

Fixes poljar/weechat-matrix-rs#166.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `WEECHAT_BUNDLED=1 cargo test --locked --lib thread` in the Rust 1.96 Bookworm container
