### PR TITLE
feat: add manual SSO token completion

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -42,6 +42,7 @@ impl MatrixCommand {
             .add_argument("media download <mxc-uri> [file]")
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
+            .add_argument("sso-complete <server-name> <login-token>")
             .add_argument("read")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(format!(
@@ -50,6 +51,7 @@ impl MatrixCommand {
   disconnect: Disconnect from one or all Matrix servers.
    reconnect: Reconnect to server(s).
        join: Join a Matrix room by ID or alias.
+sso-complete: Finish SSO login with a copied loginToken.
        read: Mark the current room as read.
      devices: {}
         keys: {}
@@ -73,8 +75,9 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("connect %(matrix_servers)")
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
+            .add_completion("sso-complete %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|read|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|keys|devices|media",
             );
 
         Command::new(
@@ -231,6 +234,22 @@ Use /matrix [command] help to find out more.\n",
         }
     }
 
+    fn sso_complete_command(&self, args: &ArgMatches) {
+        let server_name = args
+            .value_of("name")
+            .expect("Server name not set but was required");
+        let login_token = args
+            .value_of("login-token")
+            .expect("Login token not set but was required")
+            .to_owned();
+
+        if let Some(s) = self.servers.get(server_name) {
+            s.complete_sso_login(login_token);
+        } else {
+            self.server_not_found(server_name)
+        }
+    }
+
     fn join_command(&self, buffer: &Buffer, args: &ArgMatches) {
         let room_id_or_alias = args
             .value_of("room")
@@ -251,6 +270,9 @@ Use /matrix [command] help to find out more.\n",
         match args.subcommand() {
             ("connect", Some(subargs)) => self.connect_command(subargs),
             ("disconnect", Some(subargs)) => self.disconnect_command(subargs),
+            ("sso-complete", Some(subargs)) => {
+                self.sso_complete_command(subargs)
+            }
             ("join", Some(subargs)) => self.join_command(buffer, subargs),
             ("server", Some(subargs)) => self.server_command(subargs),
             ("devices", Some(subargs)) => {
@@ -365,6 +387,20 @@ impl CommandCallback for MatrixCommand {
                     .arg(
                         Arg::with_name("name")
                             .value_name("server-name")
+                            .required(true),
+                    ),
+            )
+            .subcommand(
+                SubCommand::with_name("sso-complete")
+                    .about("Finish SSO login with a copied loginToken")
+                    .arg(
+                        Arg::with_name("name")
+                            .value_name("server-name")
+                            .required(true),
+                    )
+                    .arg(
+                        Arg::with_name("login-token")
+                            .value_name("login-token")
                             .required(true),
                     ),
             )

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -293,7 +293,7 @@ impl Connection {
         .await
     }
 
-    fn save_device_id(
+    pub(crate) fn save_device_id(
         user_name: &str,
         mut server_path: PathBuf,
         response: &LoginResponse,

--- a/src/server.rs
+++ b/src/server.rs
@@ -327,6 +327,84 @@ impl MatrixServer {
         Ok(())
     }
 
+    pub fn complete_sso_login(&self, login_token: String) {
+        if self
+            .get_client()
+            .map(|client| client.matrix_auth().logged_in())
+            .unwrap_or(false)
+        {
+            self.print_error(&format!(
+                "Already connected to {}{}{}",
+                Weechat::color("chat_server"),
+                self.name(),
+                Weechat::color("reset")
+            ));
+            return;
+        }
+
+        if self.connected() {
+            self.connection.borrow_mut().take();
+        }
+
+        let client = match self.get_or_create_client() {
+            Ok(client) => client,
+            Err(e) => {
+                self.print_error(&format!(
+                    "Failed to create Matrix client: {:?}",
+                    e
+                ));
+                return;
+            }
+        };
+
+        let server_name = self.name().to_owned();
+        let server_path = self.get_server_path();
+
+        let response = self.servers.runtime().block_on(async {
+            client
+                .matrix_auth()
+                .login_token(&login_token)
+                .initial_device_display_name("WeeChat-Matrix-rs")
+                .send()
+                .await
+        });
+
+        match response {
+            Ok(response) => {
+                if let Err(e) = Connection::save_device_id(
+                    &server_name,
+                    server_path,
+                    &response,
+                ) {
+                    self.print_error(&format!(
+                        "Error while writing the device id for server {}{}{}: {:?}",
+                        Weechat::color("chat_server"),
+                        self.name(),
+                        Weechat::color("reset"),
+                        e
+                    ));
+                    return;
+                }
+
+                self.receive_login(response);
+                let connection = Connection::new(self, &client);
+                self.set_connection(connection);
+                self.print_network(&format!(
+                    "Completed SSO login for {}{}{}",
+                    Weechat::color("chat_server"),
+                    self.name(),
+                    Weechat::color("reset")
+                ));
+            }
+            Err(e) => {
+                self.print_error(&format!(
+                    "Failed to complete SSO login: {:?}",
+                    e
+                ));
+            }
+        }
+    }
+
     fn inner(&self) -> Rc<InnerServer> {
         self.inner.clone()
     }


### PR DESCRIPTION
Adds `/matrix sso-complete <server-name> <login-token>` for the manual SSO fallback requested in poljar/weechat-matrix-rs#172.

The command lets a user paste a `loginToken` from a browser redirect when the local callback flow cannot finish cleanly. It completes Matrix token login on the configured server, stores the returned device id through the same persistence path as normal login, and then starts the normal sync connection.

It also handles the pending-callback case from `/matrix connect`: if a connection object exists but the client is not logged in yet, the pending connection is dropped before the copied token is consumed.

Fixes poljar/weechat-matrix-rs#172.

Validation:

- `cargo fmt --check`
- `git diff --check`
- Docker `rust:1.96-bookworm` with `WEECHAT_BUNDLED=1 cargo check --locked`
