### PR TITLE
fix: reject /ignore in Matrix buffers

### DIFF
--- a/src/commands/ignore.rs
+++ b/src/commands/ignore.rs
@@ -1,0 +1,74 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    Prefix, ReturnCode, Weechat,
+};
+
+use crate::PLUGIN_NAME;
+
+pub struct IgnoreCommand;
+
+#[derive(Debug, Eq, PartialEq)]
+enum IgnoreDisposition {
+    EatWithUnsupportedMessage,
+    PassThrough,
+}
+
+impl IgnoreCommand {
+    pub fn create() -> Result<[CommandRun; 2], ()> {
+        Ok([
+            CommandRun::new("2000|/ignore", IgnoreCommand)?,
+            CommandRun::new("2000|/ignore *", IgnoreCommand)?,
+        ])
+    }
+}
+
+fn disposition(plugin_name: &str) -> IgnoreDisposition {
+    if plugin_name == PLUGIN_NAME {
+        IgnoreDisposition::EatWithUnsupportedMessage
+    } else {
+        IgnoreDisposition::PassThrough
+    }
+}
+
+impl CommandRunCallback for IgnoreCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        _: Cow<str>,
+    ) -> ReturnCode {
+        match disposition(&buffer.plugin_name()) {
+            IgnoreDisposition::EatWithUnsupportedMessage => {
+                buffer.print(&format!(
+                    "{}{}: /ignore is not supported in Matrix buffers.",
+                    Weechat::prefix(Prefix::Error),
+                    PLUGIN_NAME,
+                ));
+                ReturnCode::OkEat
+            }
+            IgnoreDisposition::PassThrough => ReturnCode::Ok,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{disposition, IgnoreDisposition};
+
+    #[test]
+    fn eats_ignore_in_matrix_buffers() {
+        assert_eq!(
+            IgnoreDisposition::EatWithUnsupportedMessage,
+            disposition("matrix")
+        );
+    }
+
+    #[test]
+    fn passes_ignore_through_in_other_buffers() {
+        assert_eq!(IgnoreDisposition::PassThrough, disposition("irc"));
+        assert_eq!(IgnoreDisposition::PassThrough, disposition("core"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::{config::ConfigHandle, Servers};
 
 mod buffer_clear;
 mod devices;
+mod ignore;
 mod invite;
 mod join;
 mod keys;
@@ -26,6 +27,7 @@ mod verification;
 
 use buffer_clear::BufferClearCommand;
 use devices::DevicesCommand;
+use ignore::IgnoreCommand;
 use invite::InviteCommand;
 use join::JoinCommand;
 use keys::KeysCommand;
@@ -45,6 +47,7 @@ pub struct Commands {
     _keys: Command,
     _devices: Command,
     _invite: Command,
+    _ignore: [CommandRun; 2],
     _ban: Command,
     _kick: Command,
     _page_up: CommandRun,
@@ -69,6 +72,7 @@ impl Commands {
             _matrix: MatrixCommand::create(servers, config)?,
             _devices: DevicesCommand::create(servers)?,
             _invite: InviteCommand::create(servers)?,
+            _ignore: IgnoreCommand::create()?,
             _ban: ModerationCommand::ban(servers)?,
             _kick: ModerationCommand::kick(servers)?,
             _keys: KeysCommand::create(servers)?,


### PR DESCRIPTION
Running `/ignore` from a Matrix buffer currently falls through to the IRC
plugin and creates a global IRC ignore. Intercept both the bare command and
argument forms on Matrix-owned buffers, print an explicit unsupported message
in the same buffer, and preserve native `/ignore` behavior elsewhere.

Fixes https://github.com/poljar/weechat-matrix-rs/issues/214.

Validation:

- `WEECHAT_BUNDLED=1 cargo test --locked --lib`
- WeeChat 4.4.4 FIFO smoke covering Matrix rejection, an unchanged empty IRC
  ignore list, and a successful native IRC ignore
