### PR TITLE
fix: close thread buffers on part

### DIFF
--- a/src/commands/part.rs
+++ b/src/commands/part.rs
@@ -31,6 +31,10 @@ impl CommandRunCallback for PartCommand {
         _: Cow<str>,
     ) -> ReturnCode {
         if let Some(room) = self.servers.find_room(buffer) {
+            if room.close_thread_buffer(buffer) {
+                return ReturnCode::OkEat;
+            }
+
             Weechat::spawn(async move { room.leave().await }).detach();
 
             ReturnCode::OkEat

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -70,6 +70,21 @@ impl RoomBuffer {
             .any(|handle| handle.upgrade().is_ok_and(|b| &b == buffer))
     }
 
+    pub fn thread_root_for_buffer(
+        &self,
+        buffer: &Buffer,
+    ) -> Option<OwnedEventId> {
+        self.thread_buffers
+            .borrow()
+            .iter()
+            .find_map(|(thread_root, handle)| {
+                handle
+                    .upgrade()
+                    .is_ok_and(|b| &b == buffer)
+                    .then(|| thread_root.clone())
+            })
+    }
+
     pub fn thread_buffer(&self, thread_root: &EventId) -> Option<BufferHandle> {
         self.thread_buffers.borrow().get(thread_root).cloned()
     }
@@ -84,6 +99,17 @@ impl RoomBuffer {
 
     pub fn remove_thread_buffer(&self, thread_root: &EventId) {
         self.thread_buffers.borrow_mut().remove(thread_root);
+    }
+
+    pub fn remove_thread_buffer_for_buffer(&self, buffer: &Buffer) -> bool {
+        let thread_root = self.thread_root_for_buffer(buffer);
+
+        if let Some(thread_root) = thread_root {
+            self.remove_thread_buffer(&thread_root);
+            true
+        } else {
+            false
+        }
     }
 
     /// Return the sender ID for an event that is still in the buffer.

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -530,6 +530,15 @@ impl MatrixRoom {
         self.buffer.owns_buffer(buffer)
     }
 
+    pub fn close_thread_buffer(&self, buffer: &Buffer) -> bool {
+        if self.buffer.remove_thread_buffer_for_buffer(buffer) {
+            buffer.close();
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn release_sdk_state(&self) {
         self.verification.release_sdk_state();
         self.room.borrow_mut().take();


### PR DESCRIPTION
Typing `/part` in a Matrix thread buffer currently resolves to the parent
room, so it leaves that room instead of closing the thread view.

This changes `/part` to detect Matrix thread buffers first. When the active
buffer is a thread buffer, the plugin removes that thread buffer handle from
the room tracking map and queues the buffer to close. Regular Matrix room
buffers keep the existing room-leave behavior.

Validation:

- `cargo fmt --check`
- `WEECHAT_BUNDLED=1 cargo test --locked --lib` in the Rust 1.96 Bookworm
  container: 58 passed

Closes poljar/weechat-matrix-rs#221
