### PR TITLE
feat: mark Matrix Space buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ The inactivity delay defaults to five minutes and can be changed with:
 
 # Matrix Spaces
 
+Space buffers use a `+` prefix in their short name, while ordinary room buffers
+keep the `#` prefix and direct-message buffers stay unprefixed.
+
 Room buffers expose Matrix parent Spaces as WeeChat local variables. Switch to a
 room buffer that belongs to a Space and run:
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -351,6 +351,7 @@ impl RoomBuffer {
         };
         let is_direct =
             self.runtime.block_on(room.is_direct()).unwrap_or(false);
+        let is_space = room.is_space();
 
         let room_name = room
             .name()
@@ -368,7 +369,7 @@ impl RoomBuffer {
             })
             .unwrap_or_else(|| room.room_id().to_string());
 
-        format_buffer_name(&room_name, is_direct)
+        format_buffer_name(&room_name, is_direct, is_space)
     }
 
     pub fn calculate_thread_buffer_name(
@@ -430,13 +431,35 @@ fn non_empty_room_name(name: &str) -> Option<String> {
     }
 }
 
-fn format_buffer_name(room_name: &str, is_direct: bool) -> String {
+fn format_buffer_name(
+    room_name: &str,
+    is_direct: bool,
+    is_space: bool,
+) -> String {
+    if is_direct || room_name.starts_with('!') {
+        return room_name.to_owned();
+    }
+
+    if is_space {
+        if room_name == "+" {
+            return "++".to_owned();
+        }
+
+        return room_name
+            .strip_prefix('#')
+            .map(|name| format!("+{}", name))
+            .unwrap_or_else(|| {
+                if room_name.starts_with('+') {
+                    room_name.to_owned()
+                } else {
+                    format!("+{}", room_name)
+                }
+            });
+    }
+
     let room_name = if room_name == "#" {
         "##".to_owned()
-    } else if room_name.starts_with('#')
-        || room_name.starts_with('!')
-        || is_direct
-    {
+    } else if room_name.starts_with('#') {
         room_name.to_owned()
     } else {
         format!("#{}", room_name)
@@ -551,26 +574,34 @@ mod tests {
 
     #[test]
     fn preserves_named_channel_prefix() {
-        assert_eq!(format_buffer_name("OSGeo", false), "#OSGeo");
+        assert_eq!(format_buffer_name("OSGeo", false, false), "#OSGeo");
     }
 
     #[test]
     fn preserves_direct_room_names() {
-        assert_eq!(format_buffer_name("Alice", true), "Alice");
+        assert_eq!(format_buffer_name("Alice", true, false), "Alice");
     }
 
     #[test]
     fn preserves_alias_like_names() {
-        assert_eq!(format_buffer_name("#lounge", false), "#lounge");
-        assert_eq!(format_buffer_name("#", false), "##");
+        assert_eq!(format_buffer_name("#lounge", false, false), "#lounge");
+        assert_eq!(format_buffer_name("#", false, false), "##");
     }
 
     #[test]
     fn preserves_room_id_fallbacks() {
         assert_eq!(
-            format_buffer_name("!roomid:matrix.osgeo.org", false),
+            format_buffer_name("!roomid:matrix.osgeo.org", false, false),
             "!roomid:matrix.osgeo.org"
         );
+    }
+
+    #[test]
+    fn marks_space_buffers_with_plus_prefix() {
+        assert_eq!(format_buffer_name("OSGeo", false, true), "+OSGeo");
+        assert_eq!(format_buffer_name("#OSGeo", false, true), "+OSGeo");
+        assert_eq!(format_buffer_name("+OSGeo", false, true), "+OSGeo");
+        assert_eq!(format_buffer_name("+", false, true), "++");
     }
 
     #[test]


### PR DESCRIPTION
Matrix Space buffers currently look like ordinary room buffers in the buffer
list because both use the same `#` short-name prefix.

This marks Matrix Space buffers with a `+` prefix while preserving the existing
name rules for ordinary rooms, room-id fallbacks, and direct messages. The
Matrix Spaces documentation now also calls out the visual convention.

Validation:

- `cargo fmt --check`
- `WEECHAT_BUNDLED=1 cargo test --locked --lib` in the Rust 1.96 Bookworm
  container: 59 passed

Closes poljar/weechat-matrix-rs#223
