### PR TITLE
feat: render recent Matrix replies inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ The inactivity delay defaults to five minutes and can be changed with:
 
        /set matrix-rust.look.smart_filter_delay 300000
 
+Recent replies can be rendered on one line in the form `> Alice: message`. By
+default, weechat-matrix-rs keeps the Matrix reply fallback quote when one is
+available. Set a positive threshold to render replies to recently printed lines
+in the compact one-line form:
+
+       /set matrix-rust.look.reply_full_quote_threshold 20
+
 # Room Status And Verification
 
 The `buffer_modes` bar item shows Matrix room state. Encrypted rooms show

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,17 @@ config!(
             // Range: 0 ms to one day.
             0..86400000,
         },
+
+        reply_full_quote_threshold: Integer {
+            // Description
+            "Render replies to recently printed events on one line when this \
+             value is positive. The default 0 keeps the Matrix reply fallback \
+             quote when available",
+            // Default value.
+            0,
+            // Range: quote-preserving default to a large scrollback window.
+            0..100000,
+        },
     },
 
     Section color {

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,6 +56,12 @@ pub struct RenderedEvent {
     pub content: RenderedContent,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ReplyContext {
+    Inline,
+    Full,
+}
+
 impl RenderedEvent {
     const MSG_TAGS: &'static [&'static str] = &["notify_message"];
     const SELF_TAGS: &'static [&'static str] =
@@ -81,6 +87,7 @@ impl RenderedEvent {
         mut self,
         event_id: &EventId,
         sender: Option<&str>,
+        context: ReplyContext,
     ) -> Self {
         let reply_fallback = self.content.reply_fallback.take();
         let reply_sender = sender
@@ -98,6 +105,15 @@ impl RenderedEvent {
             .map(|line| line.tags.clone())
             .unwrap_or_default();
         tags.push("matrix_reply".to_owned());
+
+        if context == ReplyContext::Inline {
+            if let Some(line) = self.content.lines.first_mut() {
+                line.tags = tags;
+                line.message = format!("> {}: {}", reply_sender, line.message);
+            }
+
+            return self;
+        }
 
         let mut context_lines = match reply_fallback {
             Some(fallback) => {
@@ -1631,18 +1647,21 @@ mod tests {
                 message: "reply body".to_owned(),
             }]),
         }
-        .add_reply_context(&event_id, Some("Alice"));
+        .add_reply_context(
+            &event_id,
+            Some("Alice"),
+            ReplyContext::Inline,
+        );
 
-        assert_eq!(2, rendered.content.lines.len());
-        assert_eq!("Reply to Alice", rendered.content.lines[0].message);
+        assert_eq!(1, rendered.content.lines.len());
+        assert_eq!("> Alice: reply body", rendered.content.lines[0].message);
         assert!(rendered.content.lines[0]
             .tags
             .contains(&"matrix_reply".to_owned()));
-        assert_eq!("reply body", rendered.content.lines[1].message);
     }
 
     #[test]
-    fn reply_context_falls_back_to_event_id() {
+    fn inline_reply_context_falls_back_to_event_id() {
         let event_id =
             matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
         let rendered = RenderedEvent {
@@ -1653,16 +1672,15 @@ mod tests {
                 message: "reply body".to_owned(),
             }]),
         }
-        .add_reply_context(&event_id, None);
+        .add_reply_context(&event_id, None, ReplyContext::Inline);
 
         assert_eq!(
-            "Reply to $replyevent:example.org",
+            "> $replyevent:example.org: reply body",
             rendered.content.lines[0].message
         );
         assert!(rendered.content.lines[0]
             .tags
             .contains(&"matrix_reply".to_owned()));
-        assert_eq!("reply body", rendered.content.lines[1].message);
     }
 
     #[test]
@@ -1685,7 +1703,11 @@ mod tests {
             prefix: "bob\t".to_owned(),
             content: content.render(&()),
         }
-        .add_reply_context(&event_id, Some("Alice"));
+        .add_reply_context(
+            &event_id,
+            Some("Alice"),
+            ReplyContext::Full,
+        );
 
         assert_eq!(3, rendered.content.lines.len());
         assert_eq!("Reply to Alice:", rendered.content.lines[0].message);
@@ -1716,7 +1738,7 @@ mod tests {
             prefix: "bob\t".to_owned(),
             content: content.render(&()),
         }
-        .add_reply_context(&event_id, None);
+        .add_reply_context(&event_id, None, ReplyContext::Full);
 
         assert_eq!(
             "Reply to @alice:example.org:",
@@ -1745,7 +1767,11 @@ mod tests {
             prefix: "bob\t".to_owned(),
             content: content.render(&()),
         }
-        .add_reply_context(&event_id, Some("Alice"));
+        .add_reply_context(
+            &event_id,
+            Some("Alice"),
+            ReplyContext::Full,
+        );
 
         let messages = rendered
             .content
@@ -1758,6 +1784,39 @@ mod tests {
             vec!["Reply to Alice:", "> line one", "> line two", "new message"],
             messages
         );
+    }
+
+    #[test]
+    fn inline_reply_context_keeps_reply_on_one_line_with_fallback() {
+        let event_id =
+            matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
+        let body = "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!room:example.org/$replyevent:example.org\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.org\">@alice:example.org</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <p>new message</p>";
+        let content = TextMessageEventContent::html("fallback", body);
+        let rendered = RenderedEvent {
+            message_timestamp: 0,
+            prefix: "bob\t".to_owned(),
+            content: content.render(&()),
+        }
+        .add_reply_context(
+            &event_id,
+            Some("Alice"),
+            ReplyContext::Inline,
+        );
+
+        assert_eq!(1, rendered.content.lines.len());
+        assert_eq!("> Alice: new message", rendered.content.lines[0].message);
+        assert!(rendered.content.lines[0]
+            .tags
+            .contains(&"matrix_reply".to_owned()));
     }
 
     #[test]

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -186,6 +186,23 @@ impl RoomBuffer {
         reply_sender_id_from_tags(&line.tags())
     }
 
+    /// Count printed lines after an event that is still visible in a buffer.
+    pub fn reply_line_distance(&self, event_id: &EventId) -> Option<usize> {
+        let event_id_tag = Cow::from(event_id.to_tag());
+
+        self.buffer_handle()
+            .upgrade()
+            .ok()
+            .and_then(|buffer| buffer_line_distance(&buffer, &event_id_tag))
+            .or_else(|| {
+                self.thread_buffers.borrow().values().find_map(|handle| {
+                    handle.upgrade().ok().and_then(|buffer| {
+                        buffer_line_distance(&buffer, &event_id_tag)
+                    })
+                })
+            })
+    }
+
     /// Return whether an event is already rendered in the buffer.
     pub fn contains_event(&self, event_id: &EventId) -> bool {
         let event_id_tag = Cow::from(event_id.to_tag());
@@ -621,6 +638,20 @@ where
 
     line.set_message(&new_message);
     line.set_tags(&tags);
+}
+
+fn buffer_line_distance(buffer: &Buffer, tag: &Cow<str>) -> Option<usize> {
+    let mut lines_after = 0;
+
+    for line in buffer.lines().rev() {
+        if line.tags().contains(tag) {
+            return Some(lines_after);
+        }
+
+        lines_after += 1;
+    }
+
+    None
 }
 
 fn sanitize_thread_id(thread_root: &EventId) -> String {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -85,7 +85,7 @@ use weechat::{
 use crate::{
     config::{Config, RedactionStyle},
     connection::Connection,
-    render::{Render, RenderedEvent},
+    render::{Render, RenderedEvent, ReplyContext},
     utils::{Edit, VerificationEvent},
     PLUGIN_NAME,
 };
@@ -822,7 +822,21 @@ impl MatrixRoom {
                 };
 
                 if let Some((event_id, sender)) = reply_to {
-                    rendered.add_reply_context(event_id, sender.as_deref())
+                    let threshold = self
+                        .config
+                        .borrow()
+                        .look()
+                        .reply_full_quote_threshold();
+                    let context = reply_context_for_distance(
+                        threshold,
+                        self.buffer.reply_line_distance(event_id),
+                    );
+
+                    rendered.add_reply_context(
+                        event_id,
+                        sender.as_deref(),
+                        context,
+                    )
                 } else {
                     rendered
                 }
@@ -1788,6 +1802,16 @@ impl MatrixRoom {
     }
 }
 
+fn reply_context_for_distance(
+    threshold: i64,
+    distance: Option<usize>,
+) -> ReplyContext {
+    distance
+        .filter(|distance| threshold > 0 && *distance <= threshold as usize)
+        .map(|_| ReplyContext::Inline)
+        .unwrap_or(ReplyContext::Full)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1813,6 +1837,22 @@ mod tests {
     fn already_rendered_events_are_not_printed_again() {
         assert!(should_render_event(false));
         assert!(!should_render_event(true));
+    }
+
+    #[test]
+    fn zero_reply_quote_threshold_keeps_full_reply_context() {
+        assert_eq!(ReplyContext::Full, reply_context_for_distance(0, Some(0)));
+        assert_eq!(ReplyContext::Full, reply_context_for_distance(0, Some(1)));
+    }
+
+    #[test]
+    fn positive_reply_quote_threshold_allows_inline_recent_replies() {
+        assert_eq!(
+            ReplyContext::Inline,
+            reply_context_for_distance(2, Some(2))
+        );
+        assert_eq!(ReplyContext::Full, reply_context_for_distance(2, Some(3)));
+        assert_eq!(ReplyContext::Full, reply_context_for_distance(2, None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep Matrix reply fallback quotes by default by setting `matrix-rust.look.reply_full_quote_threshold` to `0`
- render recent Matrix replies on one compact line as `> Alice: message` only when the threshold is set to a positive value and the replied-to event is still within that buffer distance
- keep full quoted fallback rendering for older replies or replies whose target is no longer available in local buffers
- document the reply threshold option

## Validation

- `git diff --check`
- `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target /usr/local/cargo/bin/cargo test --locked --lib` in `rust:1.96-bookworm` with `clang`, `libclang-dev`, `libsqlite3-dev`, `pkg-config`, and `weechat-dev` installed: 63 passed
- hosted `build-test-release` jobs succeeded on head `6400929df6b58c533c8495d9f17a32db531dfc6a`

Closes poljar/weechat-matrix-rs#222.
