### PR TITLE
Document state reset and crash diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,26 @@ The plugin keeps Matrix state and encryption data in
 If the cache grows or causes too much disk I/O, disconnect WeeChat and remove
 only the `-cache` directory. Do not remove the main server directory unless you
 want to reset stored Matrix state.
+
+# Troubleshooting
+
+If startup or login fails with a Matrix SDK state-store decode error, first make
+sure the plugin was built from current sources and try starting WeeChat again so
+SDK migrations can run. If the same error still stops login, disconnect WeeChat
+and move `$WEECHAT_HOME/matrix-rust/<server>/` aside before reconnecting. This
+resets the stored Matrix state for that server, including encryption/session
+data, so keep the old directory until the new login is verified.
+
+For crashes, aborts, or a blocked WeeChat UI during startup or `/quit`, collect
+a full thread backtrace from another shell while the process is still stopped or
+blocked:
+
+       gdb -p $(pidof weechat) -batch -ex 'thread apply all bt'
+
+A short `bt` from the crashing thread is often not enough to tell whether the
+Matrix plugin, WeeChat itself, another plugin, or shutdown cleanup owns the
+block.
+
 Nick prefix colors for Matrix power levels can be changed with:
 
        /set matrix-rust.color.nick_prefix_admin lightgreen


### PR DESCRIPTION
## Summary

- document the difference between the removable Matrix SDK event cache and the main per-server state directory
- add a state-store decode/login recovery path for old migration failures
- add the full `gdb` thread-backtrace command needed for startup or `/quit` crashes and blocked UI reports

## Why

poljar/weechat-matrix-rs#43 is an old `missing field room_type` state-store decode failure after upgrading. Current Matrix SDK storage has migration support, so the safe operator-facing fallback is to retry with current sources and, only if the error persists, move aside the main `$WEECHAT_HOME/matrix-rust/<server>/` directory while preserving it until the new login is verified.

poljar/weechat-matrix-rs#220 has only a short crashing-thread `bt`; the later full `/quit` trace attached under poljar/weechat-matrix-rs#183 pointed at WeeChat Python plugin shutdown rather than Matrix member restore. The README now documents the full-thread `gdb` command needed to make future shutdown/startup crash reports actionable instead of guessing at another plugin-owned frame.

Closes poljar/weechat-matrix-rs#43.
Closes poljar/weechat-matrix-rs#220.

## Validation

- `git diff --check`
