### PR TITLE
Document build compatibility and Matrix capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,20 @@ path to that header:
 
     export WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h
 
+Use the same WeeChat API headers as the WeeChat binary that will load the
+plugin. If WeeChat reports an API mismatch while loading `matrix.so`, rebuild
+after installing the matching development package or setting
+`WEECHAT_PLUGIN_FILE`. Set `WEECHAT_BUNDLED=1` only when you deliberately want
+to build against the bundled fallback header, for example in a controlled test
+or package build.
+
 If `bindgen` reports that `stddef.h`, `libclang`, or `libLLVM` is missing, check
 that the `clang` command-line tools, C/C++ compiler headers, and matching
 `libclang` package are installed. On minimal distributions the library package
 alone may not provide the compiler include paths that `bindgen` needs.
+Use a coherent `clang`/`libclang`/`libLLVM` set from the same toolchain; copying
+only one shared library from another package or SDK can leave `bindgen` loading
+an incompatible LLVM library.
 
 After the dependencies are installed the plugin can be compiled with:
 
@@ -185,6 +195,24 @@ The inactivity delay defaults to five minutes and can be changed with:
 
        /set matrix-rust.look.smart_filter_delay 300000
 
+# Room Status And Verification
+
+The `buffer_modes` bar item shows Matrix room state. Encrypted rooms show
+`matrix-rust.look.encrypted_room_sign`; encrypted rooms that still contain
+unverified devices also show `matrix-rust.look.encryption_warning_sign`. Public
+rooms show `matrix-rust.look.public_room_sign`, and busy rooms show
+`matrix-rust.look.busy_sign`.
+
+Interactive verification requests can be accepted, confirmed, or cancelled from
+the room or verification buffer:
+
+       /verification accept
+       /verification confirm
+       /verification cancel
+
+The plugin renders in-room SAS verification requests and shows the emoji or
+decimal short authentication string when it is ready.
+
 # Matrix Spaces
 
 Room buffers expose Matrix parent Spaces as WeeChat local variables. Switch to a
@@ -206,6 +234,12 @@ example, to prefix Matrix room names with their first parent Space:
 Remove that prefix again with:
 
        /unset buflist.format.name
+
+Matrix rooms can belong to more than one Space. WeeChat buffers cannot be shown
+as the same room under multiple server-like parents at the same time, so the
+plugin exposes all known parent Spaces as metadata instead of moving room
+buffers into a fake hierarchy. Matrix Space buffers use a `+` short-name prefix;
+ordinary rooms keep the usual room/channel naming rules.
 
 # Storage
 


### PR DESCRIPTION
## Summary

- clarify how to build against the same WeeChat API headers that will load the plugin
- add build troubleshooting for coherent clang/libclang/libLLVM toolchains
- document room status signs, in-room SAS verification, and Space metadata limits

## Why

poljar/weechat-matrix-rs#19 and poljar/weechat-matrix-rs#79 are build-environment reports around stddef.h/libclang/libLLVM; the README now names the native dependency boundary and warns against mixing LLVM shared libraries from another package or SDK.

poljar/weechat-matrix-rs#90 and poljar/weechat-matrix-rs#124 are current-WeeChat API/header mismatch reports. Current code selects WeeChat API cfgs from the header in build.rs and the rust-weechat dependency defaults to the system header unless `WEECHAT_BUNDLED` is requested, so the README now documents the operator-side rule: build against the headers matching the WeeChat binary that will load `matrix.so`.

poljar/weechat-matrix-rs#31 and poljar/weechat-matrix-rs#32 are implemented in the current room status and verification paths, and the README now documents the visible signs and verification commands.

poljar/weechat-matrix-rs#48 is covered by parent Space localvars and the Space buffer marker; the README now documents why rooms are exposed as metadata rather than moved into a fake multi-parent hierarchy.

Closes poljar/weechat-matrix-rs#19.
Closes poljar/weechat-matrix-rs#31.
Closes poljar/weechat-matrix-rs#32.
Closes poljar/weechat-matrix-rs#48.
Closes poljar/weechat-matrix-rs#79.
Closes poljar/weechat-matrix-rs#90.
Closes poljar/weechat-matrix-rs#124.

## Validation

- `git diff --check`
