### PR TITLE
feat: add /matrix version command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,4 +27,16 @@ fn main() {
     } else {
         println!("cargo::rustc-cfg=weechat410");
     }
+
+    // Capture git describe output for the version command
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["describe", "--long", "--tags", "--always", "--all", "--dirty"])
+        .current_dir(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .output()
+    {
+        if output.status.success() {
+            let describe = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("cargo::rustc-env=GIT_DESCRIBE={}", describe);
+        }
+    }
 }

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -296,9 +296,10 @@ Use /matrix [command] help to find out more.\n",
             }
             ("version", _) => {
                 Weechat::print(&format!(
-                    "{}: weechat-matrix version {}",
+                    "{}: weechat-matrix version {} ({})",
                     PLUGIN_NAME,
                     env!("CARGO_PKG_VERSION"),
+                    option_env!("GIT_DESCRIBE").unwrap_or("unknown"),
                 ));
             }
             _ => unreachable!(),

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -44,6 +44,7 @@ impl MatrixCommand {
             .add_argument("reconnect <server-name>")
             .add_argument("sso-complete <server-name> <login-token>")
             .add_argument("read")
+            .add_argument("version")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(format!(
                 "      server: List, add, or remove Matrix servers.
@@ -52,12 +53,13 @@ impl MatrixCommand {
    reconnect: Reconnect to server(s).
        join: Join a Matrix room by ID or alias.
 sso-complete: Finish SSO login with a copied loginToken.
-       read: Mark the current room as read.
+        read: Mark the current room as read.
+      version: Show version information about weechat-matrix.
      devices: {}
-        keys: {}
-       media: {}
-verification: {}
-        help: Show detailed command help.\n
+         keys: {}
+        media: {}
+ verification: {}
+         help: Show detailed command help.\n
 Use /matrix [command] help to find out more.\n",
                 DevicesCommand::DESCRIPTION,
                 KeysCommand::DESCRIPTION,
@@ -77,7 +79,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("reconnect %(matrix_servers)")
             .add_completion("sso-complete %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|sso-complete|read|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media",
             );
 
         Command::new(
@@ -292,6 +294,13 @@ Use /matrix [command] help to find out more.\n",
                     room.mark_as_read();
                 }
             }
+            ("version", _) => {
+                Weechat::print(&format!(
+                    "{}: weechat-matrix version {}",
+                    PLUGIN_NAME,
+                    env!("CARGO_PKG_VERSION"),
+                ));
+            }
             _ => unreachable!(),
         }
     }
@@ -416,6 +425,10 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("read")
                     .about("Mark the current room as read."),
+            )
+            .subcommand(
+                SubCommand::with_name("version")
+                    .about("Show version information about weechat-matrix."),
             );
 
         parse_and_run(argparse, arguments, |args| self.run(buffer, args));


### PR DESCRIPTION
Add a `/matrix version` command that prints the plugin version along with the git-describe revision (including the dirty flag when the working tree is modified).

Example output:
```
matrix: weechat-matrix version 0.1.0 (heads/main-0-g8fe716a)
```

Changes:
- `build.rs`: capture `git describe` output at build time via `cargo::rustc-env`
- `src/commands/matrix.rs`: register and handle the `version` subcommand