### PR TITLE
feat: add /nick command to change display name

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod me;
 mod media;
 mod moderation;
 mod names;
+mod nick;
 mod page_up;
 mod part;
 mod redact;
@@ -36,6 +37,7 @@ use me::MeCommand;
 use media::MediaCommand;
 use moderation::ModerationCommand;
 use names::NamesCommand;
+use nick::NickCommand;
 use page_up::PageUpCommand;
 use part::PartCommand;
 use redact::RedactCommand;
@@ -61,6 +63,7 @@ pub struct Commands {
     _part: CommandRun,
     _names: CommandRun,
     _unban: Command,
+    _nick: CommandRun,
 }
 
 impl Commands {
@@ -87,6 +90,7 @@ impl Commands {
             _part: PartCommand::create(servers)?,
             _names: NamesCommand::create(servers)?,
             _unban: ModerationCommand::unban(servers)?,
+            _nick: NickCommand::create(servers)?,
         })
     }
 }

--- a/src/commands/nick.rs
+++ b/src/commands/nick.rs
@@ -1,0 +1,80 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::{Servers, PLUGIN_NAME};
+
+pub struct NickCommand {
+    servers: Servers,
+}
+
+impl NickCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/nick",
+            NickCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for NickCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        cmd: Cow<str>,
+    ) -> ReturnCode {
+        let new_nick = cmd.strip_prefix("/nick ").map(|s| s.trim());
+
+        if let Some(server) = self.servers.find_server(&buffer) {
+            match new_nick {
+                Some(name) if !name.is_empty() => {
+                    let name = name.to_owned();
+                    Weechat::spawn(async move {
+                        server.set_display_name(Some(&name)).await;
+                    })
+                    .detach();
+                }
+                None => {
+                    // /nick with no arguments: show current display name
+                    Weechat::spawn(async move {
+                        match server.get_display_name().await {
+                            Some(name) => {
+                                Weechat::print(&format!(
+                                    "{}: Current display name: {}",
+                                    PLUGIN_NAME, name
+                                ));
+                            }
+                            None => {
+                                Weechat::print(&format!(
+                                    "{}: No display name set.",
+                                    PLUGIN_NAME
+                                ));
+                            }
+                        }
+                    })
+                    .detach();
+                }
+                _ => {
+                    Weechat::print(&format!(
+                        "{}Usage: /nick <new-display-name>",
+                        Weechat::prefix(weechat::Prefix::Error),
+                    ));
+                }
+            }
+        } else {
+            Weechat::print(&format!(
+                "{}The /nick command must be run in a Matrix buffer.",
+                Weechat::prefix(weechat::Prefix::Error),
+            ));
+        }
+
+        ReturnCode::Ok
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -726,6 +726,23 @@ impl InnerServer {
         self.settings.borrow().password.clone()
     }
 
+    /// Set the display name for this account on the homeserver.
+    pub async fn set_display_name(&self, name: Option<&str>) {
+        let Some(client) = self.get_client() else {
+            self.print_error("Not connected to a server");
+            return;
+        };
+        if let Err(e) = client.account().set_display_name(name).await {
+            self.print_error(&format!("Failed to set display name: {}", e));
+        }
+    }
+
+    /// Get the current display name for this account from the homeserver.
+    pub async fn get_display_name(&self) -> Option<String> {
+        let client = self.get_client()?;
+        client.account().get_display_name().await.ok().flatten()
+    }
+
     pub async fn restore_room_by_id(&self, room_id: OwnedRoomId) {
         if self.rooms.borrow().contains_key(&room_id) {
             return;


### PR DESCRIPTION
Closes #235

Add a `/nick` command that intercepts the built-in WeeChat `/nick` to change the Matrix display name on the homeserver.

- `/nick NewName` — sets the display name via the matrix-sdk Account API
- `/nick` — shows the current display name

Changes:
- `src/server.rs`: add `set_display_name()` and `get_display_name()` async methods to `InnerServer`
- `src/commands/nick.rs`: new `CommandRun` interceptor for `/nick`
- `src/commands/mod.rs`: register `NickCommand`