### PR TITLE
feat: add /matrix version command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,4 +27,16 @@ fn main() {
     } else {
         println!("cargo::rustc-cfg=weechat410");
     }
+
+    // Capture git describe output for the version command
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["describe", "--long", "--tags", "--always", "--all", "--dirty"])
+        .current_dir(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .output()
+    {
+        if output.status.success() {
+            let describe = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("cargo::rustc-env=GIT_DESCRIBE={}", describe);
+        }
+    }
 }

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -51,10 +51,10 @@ impl MatrixCommand {
      connect: Connect to Matrix servers.
   disconnect: Disconnect from one or all Matrix servers.
    reconnect: Reconnect to server(s).
-       join: Join a Matrix room by ID or alias.
+        join: Join a Matrix room by ID or alias.
 sso-complete: Finish SSO login with a copied loginToken.
-       read: Mark the current room as read.
-      version: Show version information about weechat-matrix.
+        read: Mark the current room as read.
+     version: Show version information about weechat-matrix.
      devices: {}
         keys: {}
        media: {}

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -44,6 +44,7 @@ impl MatrixCommand {
             .add_argument("reconnect <server-name>")
             .add_argument("sso-complete <server-name> <login-token>")
             .add_argument("read")
+            .add_argument("version")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(format!(
                 "      server: List, add, or remove Matrix servers.
@@ -53,6 +54,7 @@ impl MatrixCommand {
        join: Join a Matrix room by ID or alias.
 sso-complete: Finish SSO login with a copied loginToken.
        read: Mark the current room as read.
+      version: Show version information about weechat-matrix.
      devices: {}
         keys: {}
        media: {}
@@ -77,7 +79,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("reconnect %(matrix_servers)")
             .add_completion("sso-complete %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|sso-complete|read|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media",
             );
 
         Command::new(
@@ -292,6 +294,14 @@ Use /matrix [command] help to find out more.\n",
                     room.mark_as_read();
                 }
             }
+            ("version", _) => {
+                Weechat::print(&format!(
+                    "{}: weechat-matrix version {} ({})",
+                    PLUGIN_NAME,
+                    env!("CARGO_PKG_VERSION"),
+                    option_env!("GIT_DESCRIBE").unwrap_or("unknown"),
+                ));
+            }
             _ => unreachable!(),
         }
     }
@@ -416,6 +426,10 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("read")
                     .about("Mark the current room as read."),
+            )
+            .subcommand(
+                SubCommand::with_name("version")
+                    .about("Show version information about weechat-matrix."),
             );
 
         parse_and_run(argparse, arguments, |args| self.run(buffer, args));


### PR DESCRIPTION
Show version and git-describe revision via `/matrix version`.

- `/matrix version` prints `weechat-matrix version 0.1.0 (heads/main-0-g8fe716a-dirty)`
- `build.rs` captures `git describe --long --tags --always --all --dirty` at build time
- Output includes the dirty flag when the working tree is modified

Replaces #237 (rebased and squashed onto a feature branch).