### PR TITLE
fix: apply redactions in thread buffers

### DIFF
--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -211,6 +211,42 @@ impl RoomBuffer {
         });
     }
 
+    pub fn redact_event_lines<F, G>(
+        &self,
+        event_id_tag: &Cow<str>,
+        redacted_tag: &Cow<str>,
+        redact_first_line: F,
+        redact_rest_line: G,
+    ) -> bool
+    where
+        F: Fn(Cow<str>) -> String,
+        G: Fn(Cow<str>) -> String,
+    {
+        let mut redacted = self.buffer_handle().upgrade().is_ok_and(|buffer| {
+            redact_event_lines_in_buffer(
+                &buffer,
+                event_id_tag,
+                redacted_tag,
+                &redact_first_line,
+                &redact_rest_line,
+            )
+        });
+
+        for handle in self.thread_buffers.borrow().values() {
+            redacted |= handle.upgrade().is_ok_and(|buffer| {
+                redact_event_lines_in_buffer(
+                    &buffer,
+                    event_id_tag,
+                    redacted_tag,
+                    &redact_first_line,
+                    &redact_rest_line,
+                )
+            });
+        }
+
+        redacted
+    }
+
     fn replace_edit_in_buffer(
         &self,
         buffer: &Buffer,
@@ -452,6 +488,53 @@ fn copy_buffer_line_by_tag(
     target.print_date_tags(line.date(), &tags, &message);
 
     true
+}
+
+fn redact_event_lines_in_buffer<F, G>(
+    buffer: &Buffer,
+    event_id_tag: &Cow<str>,
+    redacted_tag: &Cow<str>,
+    redact_first_line: &F,
+    redact_rest_line: &G,
+) -> bool
+where
+    F: Fn(Cow<str>) -> String,
+    G: Fn(Cow<str>) -> String,
+{
+    let predicate = |line: &BufferLine| {
+        let tags = line.tags();
+        tags.contains(event_id_tag) && !tags.contains(redacted_tag)
+    };
+
+    let mut lines = buffer.lines();
+    let first_line = lines.rfind(predicate);
+
+    if let Some(line) = first_line {
+        modify_line(line, redacted_tag.clone(), redact_first_line);
+    } else {
+        return false;
+    }
+
+    while let Some(line) = lines.next_back().filter(predicate) {
+        modify_line(line, redacted_tag.clone(), redact_rest_line);
+    }
+
+    true
+}
+
+fn modify_line<F>(line: BufferLine, tag: Cow<str>, redaction_func: F)
+where
+    F: Fn(Cow<str>) -> String,
+{
+    let message = line.message();
+    let new_message = redaction_func(message);
+
+    let mut tags = line.tags();
+    tags.push(tag);
+    let tags: Vec<&str> = tags.iter().map(|tag| tag.as_ref()).collect();
+
+    line.set_message(&new_message);
+    line.set_tags(&tags);
 }
 
 fn sanitize_thread_id(thread_root: &EventId) -> String {

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -78,7 +78,6 @@ use matrix_sdk::{
 use weechat::{
     buffer::{
         Buffer, BufferBuilderAsync, BufferHandle, BufferInputCallbackAsync,
-        BufferLine,
     },
     Prefix, Weechat,
 };
@@ -628,14 +627,6 @@ impl MatrixRoom {
             return;
         };
 
-        let buffer_handle = self.buffer_handle();
-
-        let buffer = if let Ok(b) = buffer_handle.upgrade() {
-            b
-        } else {
-            return;
-        };
-
         // TODO: remove this unwrap.
         let redacter = self.members.get(&event.sender).await.unwrap();
 
@@ -664,12 +655,6 @@ impl MatrixRoom {
 
         let redaction_style = self.config.borrow().look().redaction_style();
 
-        let predicate = |l: &BufferLine| {
-            let tags = l.tags();
-            tags.contains(&event_id_tag)
-                && !tags.contains(&Cow::from("matrix_redacted"))
-        };
-
         let strike_through = |string: Cow<str>| {
             Weechat::remove_color(&string)
                 .graphemes(true)
@@ -696,33 +681,12 @@ impl MatrixRoom {
             RedactionStyle::StrikeThrough => strike_through(message),
         };
 
-        fn modify_line<F>(line: BufferLine, tag: Cow<str>, redaction_func: F)
-        where
-            F: Fn(Cow<str>) -> String,
-        {
-            let message = line.message();
-            let new_message = redaction_func(message);
-
-            let mut tags = line.tags();
-            tags.push(tag);
-            let tags: Vec<&str> = tags.iter().map(|t| t.as_ref()).collect();
-
-            line.set_message(&new_message);
-            line.set_tags(&tags);
-        }
-
-        let mut lines = buffer.lines();
-        let first_line = lines.rfind(predicate);
-
-        if let Some(line) = first_line {
-            modify_line(line, tag.clone(), redact_first_line);
-        } else {
-            return;
-        }
-
-        while let Some(line) = lines.next_back().filter(predicate) {
-            modify_line(line, tag.clone(), redact_string);
-        }
+        self.buffer.redact_event_lines(
+            &event_id_tag,
+            &tag,
+            redact_first_line,
+            redact_string,
+        );
     }
 
     async fn render_message_content(


### PR DESCRIPTION
## Summary

- apply incoming Matrix redaction events to both the main room buffer and any owned thread buffers
- keep `/redact` command routing unchanged: thread buffers still resolve to their parent Matrix room
- move the visible line mutation helper into `RoomBuffer`, next to the existing main/thread buffer update paths for edits and local echoes

## Validation

- `git diff --check`
- `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target /usr/local/cargo/bin/cargo test --locked --lib` in `rust:1.96-bookworm` with `clang`, `libclang-dev`, `libsqlite3-dev`, `pkg-config`, and `weechat-dev` installed: 60 passed

Closes poljar/weechat-matrix-rs#234.
