### PR TITLE
fix: improve Matrix buffer short names

### DIFF
--- a/src/commands/buffer_switch.rs
+++ b/src/commands/buffer_switch.rs
@@ -1,0 +1,103 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::Servers;
+
+pub struct BufferSwitchCommand {
+    servers: Servers,
+}
+
+impl BufferSwitchCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "2000|/buffer *",
+            BufferSwitchCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for BufferSwitchCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        _: &Buffer,
+        command: Cow<str>,
+    ) -> ReturnCode {
+        let Some(short_name) = buffer_target(&command) else {
+            return ReturnCode::Ok;
+        };
+
+        let Some(buffer_handle) =
+            self.servers.find_buffer_by_short_name(short_name)
+        else {
+            return ReturnCode::Ok;
+        };
+
+        if let Ok(buffer) = buffer_handle.upgrade() {
+            buffer.switch_to();
+            ReturnCode::OkEat
+        } else {
+            ReturnCode::Ok
+        }
+    }
+}
+
+fn buffer_target(command: &str) -> Option<&str> {
+    let target = command.strip_prefix("/buffer")?.trim();
+
+    (!target.is_empty()
+        && !target.contains(char::is_whitespace)
+        && !target.starts_with('-')
+        && !is_core_buffer_subcommand(target))
+    .then_some(target)
+}
+
+fn is_core_buffer_subcommand(target: &str) -> bool {
+    matches!(
+        target,
+        "list"
+            | "clear"
+            | "move"
+            | "swap"
+            | "cycle"
+            | "merge"
+            | "unmerge"
+            | "hide"
+            | "unhide"
+            | "renumber"
+            | "close"
+            | "notify"
+            | "localvar"
+            | "set"
+            | "get"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::buffer_target;
+
+    #[test]
+    fn extracts_single_buffer_argument() {
+        assert_eq!(buffer_target("/buffer #OSGeo"), Some("#OSGeo"));
+    }
+
+    #[test]
+    fn ignores_empty_buffer_command() {
+        assert_eq!(buffer_target("/buffer"), None);
+    }
+
+    #[test]
+    fn leaves_subcommands_to_weechat() {
+        assert_eq!(buffer_target("/buffer move 1"), None);
+        assert_eq!(buffer_target("/buffer clear"), None);
+        assert_eq!(buffer_target("/buffer -merged"), None);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ use weechat::{
 use crate::{config::ConfigHandle, Servers};
 
 mod buffer_clear;
+mod buffer_switch;
 mod devices;
 mod ignore;
 mod invite;
@@ -27,6 +28,7 @@ mod upload;
 mod verification;
 
 use buffer_clear::BufferClearCommand;
+use buffer_switch::BufferSwitchCommand;
 use devices::DevicesCommand;
 use ignore::IgnoreCommand;
 use invite::InviteCommand;
@@ -57,6 +59,7 @@ pub struct Commands {
     _topic: Command,
     _verification: Command,
     _buffer_clear: CommandRun,
+    _buffer_switch: CommandRun,
     _join: CommandRun,
     _me: CommandRun,
     _upload: CommandRun,
@@ -84,6 +87,7 @@ impl Commands {
             _topic: TopicCommand::create(servers)?,
             _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,
+            _buffer_switch: BufferSwitchCommand::create(servers)?,
             _join: JoinCommand::create(servers)?,
             _me: MeCommand::create(servers)?,
             _upload: UploadCommand::create(servers)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,20 @@ impl Servers {
     pub fn find_room(&self, buffer: &Buffer) -> Option<RoomHandle> {
         self.buffer_owner(buffer).into_room()
     }
+
+    pub fn find_buffer_by_short_name(
+        &self,
+        short_name: &str,
+    ) -> Option<BufferHandle> {
+        let servers = self.borrow();
+
+        servers.values().find_map(|server| {
+            server
+                .rooms()
+                .into_iter()
+                .find_map(|room| room.buffer_handle_for_short_name(short_name))
+        })
+    }
 }
 
 impl SignalCallback for Servers {

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -53,6 +53,30 @@ impl RoomBuffer {
             .unwrap_or_default()
     }
 
+    pub fn buffer_handle_for_short_name(
+        &self,
+        short_name: &str,
+    ) -> Option<BufferHandle> {
+        if let Some(handle) = self.inner.borrow().as_ref() {
+            if handle
+                .upgrade()
+                .is_ok_and(|buffer| buffer.short_name() == short_name)
+            {
+                return Some(handle.clone());
+            }
+        }
+
+        self.thread_buffers
+            .borrow()
+            .values()
+            .find(|handle| {
+                handle
+                    .upgrade()
+                    .is_ok_and(|buffer| buffer.short_name() == short_name)
+            })
+            .cloned()
+    }
+
     pub fn owns_buffer(&self, buffer: &Buffer) -> bool {
         if self
             .inner
@@ -401,9 +425,9 @@ impl RoomBuffer {
                     .and_then(|alias| non_empty_room_name(alias.alias()))
             })
             .or_else(|| {
-                is_direct
-                    .then(|| self.runtime.block_on(room.display_name()).ok())
-                    .flatten()
+                self.runtime
+                    .block_on(room.display_name())
+                    .ok()
                     .and_then(|name| non_empty_room_name(&name.to_string()))
             })
             .unwrap_or_else(|| room.room_id().to_string());
@@ -415,7 +439,7 @@ impl RoomBuffer {
         &self,
         thread_root: &EventId,
     ) -> String {
-        format_thread_buffer_name(&self.calculate_buffer_name(), thread_root)
+        format_thread_buffer_name(thread_root)
     }
 
     pub fn thread_buffer_suffix(thread_root: &EventId) -> String {
@@ -527,12 +551,8 @@ fn format_buffer_name(
     room_name
 }
 
-fn format_thread_buffer_name(room_name: &str, thread_root: &EventId) -> String {
-    format!(
-        "{}.{}",
-        room_name,
-        RoomBuffer::thread_buffer_suffix(thread_root)
-    )
+fn format_thread_buffer_name(thread_root: &EventId) -> String {
+    format!("thread.{}", RoomBuffer::thread_buffer_suffix(thread_root))
 }
 
 impl RoomBuffer {
@@ -690,13 +710,12 @@ mod tests {
     }
 
     #[test]
-    fn thread_buffer_name_uses_room_prefix_and_short_suffix() {
+    fn thread_buffer_name_uses_thread_prefix_and_short_suffix() {
         assert_eq!(
-            format_thread_buffer_name(
-                "#OSGeo",
-                event_id!("$abcdef0123456789:example.org")
-            ),
-            "#OSGeo.abcdef012345"
+            format_thread_buffer_name(event_id!(
+                "$abcdef0123456789:example.org"
+            )),
+            "thread.abcdef012345"
         );
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -600,6 +600,13 @@ impl MatrixRoom {
         self.buffer.buffer_handle()
     }
 
+    pub fn buffer_handle_for_short_name(
+        &self,
+        short_name: &str,
+    ) -> Option<BufferHandle> {
+        self.buffer.buffer_handle_for_short_name(short_name)
+    }
+
     pub fn update_parent_spaces(&self) {
         self.buffer.update_parent_spaces();
     }


### PR DESCRIPTION
Summary:
- Let `/buffer <short_name>` switch to Matrix room and thread buffers by resolving their WeeChat short names before falling back to WeeChat core handling.
- Stop including the room short name in thread buffer `short_name`; thread buffers now use `thread.<event-prefix>` while the full buffer name and title still keep room context.
- Use the Matrix SDK computed room display name before falling back to the room ID, so unnamed non-DM rooms can get member-based names instead of `!room_id`.

Validation:
- `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo test --locked --lib` in `rust:1.96-bookworm` Docker image: 63 passed.

Closes poljar/weechat-matrix-rs#231.
Closes poljar/weechat-matrix-rs#232.
Closes poljar/weechat-matrix-rs#240.
