### PR TITLE
fix: delete single Matrix devices via device endpoint

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -22,6 +22,7 @@ use matrix_sdk::{
     ruma::{
         api::client::{
             device::{
+                delete_device::{self, v3::Response as DeleteDeviceResponse},
                 delete_devices::v3::Response as DeleteDevicesResponse,
                 get_devices::v3::Response as DevicesResponse,
             },
@@ -226,6 +227,21 @@ impl Connection {
                 } else {
                     client.delete_devices(&devices, None).await
                 }
+            })
+            .await?)
+    }
+
+    pub async fn delete_device(
+        &self,
+        device: OwnedDeviceId,
+        auth_info: Option<InteractiveAuthInfo>,
+    ) -> MatrixResult<DeleteDeviceResponse> {
+        let client = self.client().clone();
+        Ok(self
+            .spawn(async move {
+                let mut request = delete_device::v3::Request::new(device);
+                request.auth = auth_info.map(|info| info.as_auth_data());
+                client.send(request).await
             })
             .await?)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1227,7 +1227,17 @@ impl InnerServer {
         };
 
         if let Some(c) = self.connection() {
-            match c.delete_devices(devices.clone(), None).await {
+            let delete = |auth_info| async {
+                if let [device] = devices.as_slice() {
+                    c.delete_device(device.clone(), auth_info).await.map(|_| ())
+                } else {
+                    c.delete_devices(devices.clone(), auth_info)
+                        .await
+                        .map(|_| ())
+                }
+            };
+
+            match delete(None).await {
                 Ok(_) => print_success(),
                 Err(e) => {
                     if let Some(info) = e.as_uiaa_response() {
@@ -1240,10 +1250,7 @@ impl InnerServer {
                             }
                         };
 
-                        if let Err(e) = c
-                            .delete_devices(devices.clone(), Some(auth_info))
-                            .await
-                        {
+                        if let Err(e) = delete(Some(auth_info)).await {
                             print_fail(e);
                         } else {
                             print_success();


### PR DESCRIPTION
Summary:
- Route `/matrix devices delete <device-id>` through the single-device Matrix endpoint instead of the bulk `delete_devices` endpoint.
- Keep multi-device deletion on the existing bulk endpoint.
- Preserve the existing user-interactive authentication retry flow for both paths.

Validation:
- `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo test --locked --lib` in `rust:1.96-bookworm` (60 passed)

Closes poljar/weechat-matrix-rs#233.
