### PR TITLE
feat: add Matrix direct message commands

### DIFF
--- a/src/commands/dm.rs
+++ b/src/commands/dm.rs
@@ -1,0 +1,177 @@
+use std::borrow::Cow;
+
+use matrix_sdk::ruma::events::room::message::RoomMessageEventContent;
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    Prefix, ReturnCode, Weechat,
+};
+
+use super::invite::normalize_invitee;
+use crate::{MatrixServer, Servers, PLUGIN_NAME};
+
+pub struct DirectMessageCommand {
+    servers: Servers,
+    kind: DirectMessageCommandKind,
+}
+
+#[derive(Clone, Copy)]
+enum DirectMessageCommandKind {
+    Query,
+    Msg,
+}
+
+impl DirectMessageCommandKind {
+    fn command(self) -> &'static str {
+        match self {
+            Self::Query => "/query",
+            Self::Msg => "/msg",
+        }
+    }
+}
+
+impl DirectMessageCommand {
+    pub fn query(servers: &Servers) -> Result<CommandRun, ()> {
+        Self::create(servers, DirectMessageCommandKind::Query)
+    }
+
+    pub fn msg(servers: &Servers) -> Result<CommandRun, ()> {
+        Self::create(servers, DirectMessageCommandKind::Msg)
+    }
+
+    fn create(
+        servers: &Servers,
+        kind: DirectMessageCommandKind,
+    ) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            &format!("{} *", kind.command()),
+            DirectMessageCommand {
+                servers: servers.clone(),
+                kind,
+            },
+        )
+    }
+
+    fn matrix_server(&self, buffer: &Buffer) -> Option<MatrixServer> {
+        self.servers.find_server(buffer)
+    }
+
+    fn default_domain(&self, buffer: &Buffer, server: &MatrixServer) -> String {
+        self.servers
+            .find_room(buffer)
+            .and_then(|room| {
+                room.room_id()
+                    .server_name()
+                    .map(|server_name| server_name.as_str().to_owned())
+            })
+            .or_else(|| server.user_id_domain())
+            .unwrap_or_default()
+    }
+
+    fn print_error(buffer: &Buffer, message: &str) {
+        buffer.print(&format!(
+            "{}{}: {}",
+            Weechat::prefix(Prefix::Error),
+            PLUGIN_NAME,
+            message
+        ));
+    }
+
+    fn run_matrix_command(
+        &self,
+        buffer: &Buffer,
+        user: &str,
+        message: Option<String>,
+    ) {
+        let Some(server) = self.matrix_server(buffer) else {
+            return;
+        };
+
+        let domain = self.default_domain(buffer, &server);
+        let user_id = match normalize_invitee(user, &domain) {
+            Ok(user_id) => user_id,
+            Err(error) => {
+                Self::print_error(buffer, &error);
+                return;
+            }
+        };
+
+        Weechat::spawn(async move {
+            let Some(room) = server.get_or_create_dm(user_id).await else {
+                return;
+            };
+
+            if let Ok(buffer) = room.buffer_handle().upgrade() {
+                buffer.switch_to();
+            }
+
+            if let Some(message) = message.filter(|message| !message.is_empty())
+            {
+                room.send_message(RoomMessageEventContent::text_plain(message))
+                    .await;
+            }
+        })
+        .detach();
+    }
+}
+
+impl CommandRunCallback for DirectMessageCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        command: Cow<str>,
+    ) -> ReturnCode {
+        if self.matrix_server(buffer).is_none() {
+            return ReturnCode::Ok;
+        }
+
+        let Some(arguments) = command.strip_prefix(self.kind.command()) else {
+            return ReturnCode::Ok;
+        };
+
+        let arguments = arguments.trim();
+        if arguments.is_empty() {
+            Self::print_error(
+                buffer,
+                &format!("Usage: {} <user-id> [message]", self.kind.command()),
+            );
+            return ReturnCode::OkEat;
+        }
+
+        let (user, message) = match self.kind {
+            DirectMessageCommandKind::Query => (arguments, None),
+            DirectMessageCommandKind::Msg => parse_msg_arguments(arguments),
+        };
+
+        self.run_matrix_command(buffer, user, message);
+
+        ReturnCode::OkEat
+    }
+}
+
+fn parse_msg_arguments(arguments: &str) -> (&str, Option<String>) {
+    let mut parts = arguments.splitn(2, char::is_whitespace);
+    let user = parts.next().unwrap_or_default();
+    let message = parts.next().map(str::trim_start).map(str::to_owned);
+
+    (user, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_msg_arguments;
+
+    #[test]
+    fn msg_arguments_preserve_message_body() {
+        assert_eq!(
+            parse_msg_arguments("@friend hi there"),
+            ("@friend", Some("hi there".to_owned()))
+        );
+    }
+
+    #[test]
+    fn msg_arguments_allow_opening_without_message() {
+        assert_eq!(parse_msg_arguments("@friend"), ("@friend", None));
+    }
+}

--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -82,7 +82,7 @@ impl CommandCallback for InviteCommand {
     }
 }
 
-fn normalize_invitee(
+pub(crate) fn normalize_invitee(
     input: &str,
     default_domain: &str,
 ) -> Result<OwnedUserId, String> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::{config::ConfigHandle, Servers};
 
 mod buffer_clear;
 mod devices;
+mod dm;
 mod ignore;
 mod invite;
 mod join;
@@ -28,6 +29,7 @@ mod verification;
 
 use buffer_clear::BufferClearCommand;
 use devices::DevicesCommand;
+use dm::DirectMessageCommand;
 use ignore::IgnoreCommand;
 use invite::InviteCommand;
 use join::JoinCommand;
@@ -61,6 +63,8 @@ pub struct Commands {
     _me: CommandRun,
     _upload: CommandRun,
     _part: CommandRun,
+    _query: CommandRun,
+    _msg: CommandRun,
     _names: CommandRun,
     _unban: Command,
     _nick: CommandRun,
@@ -88,6 +92,8 @@ impl Commands {
             _me: MeCommand::create(servers)?,
             _upload: UploadCommand::create(servers)?,
             _part: PartCommand::create(servers)?,
+            _query: DirectMessageCommand::query(servers)?,
+            _msg: DirectMessageCommand::msg(servers)?,
             _names: NamesCommand::create(servers)?,
             _unban: ModerationCommand::unban(servers)?,
             _nick: NickCommand::create(servers)?,

--- a/src/server.rs
+++ b/src/server.rs
@@ -726,6 +726,18 @@ impl InnerServer {
         self.settings.borrow().password.clone()
     }
 
+    pub fn user_id_domain(&self) -> Option<String> {
+        if let Some(login_state) = self.login_state.borrow().as_ref() {
+            return Some(login_state.user_id.server_name().as_str().to_owned());
+        }
+
+        self.settings
+            .borrow()
+            .homeserver
+            .as_ref()
+            .and_then(|url| url.host_str().map(str::to_owned))
+    }
+
     /// Set the display name for this account on the homeserver.
     pub async fn set_display_name(&self, name: Option<&str>) {
         let Some(client) = self.get_client() else {
@@ -785,6 +797,46 @@ impl InnerServer {
             }
             Err(e) => self.print_error(&format!("Error restoring room: {}", e)),
         }
+    }
+
+    pub async fn get_or_create_dm(
+        &self,
+        user_id: OwnedUserId,
+    ) -> Option<RoomHandle> {
+        let Some(connection) = self.connection() else {
+            self.print_error("Not connected. Please connect first.");
+            return None;
+        };
+
+        let client = connection.client().clone();
+        let target = user_id.clone();
+        let room = connection
+            .spawn(async move {
+                if let Some(room) = client.get_dm_room(&target) {
+                    Ok(room)
+                } else {
+                    client.create_dm(&target).await
+                }
+            })
+            .await;
+
+        let room = match room {
+            Ok(room) => room,
+            Err(error) => {
+                self.print_error(&format!(
+                    "Failed to open direct message with {}: {}",
+                    user_id, error
+                ));
+                return None;
+            }
+        };
+
+        let room_id = room.room_id().to_owned();
+        if !self.rooms.borrow().contains_key(&room_id) {
+            self.restore_room(room).await;
+        }
+
+        self.rooms.borrow().get(&room_id).cloned()
     }
 
     fn create_server_buffer(&self) -> BufferHandle {


### PR DESCRIPTION
## Summary

- Add Matrix-aware `/query <user-id>` handling that opens an existing DM room or creates one for the requested user.
- Add Matrix-aware `/msg <user-id> [message]` handling that opens the DM and optionally sends the provided plain-text message.
- Keep native WeeChat behavior outside Matrix buffers, and accept both local user IDs and fully-qualified Matrix user IDs.

## Validation

- `WEECHAT_BUNDLED=1 CARGO_TARGET_DIR=/target cargo test --locked --lib` in `rust:1.96-bookworm` Docker image: 62 passed.

Closes poljar/weechat-matrix-rs#236.
