### PR TITLE
Complete /buffer with Matrix short names

### DIFF
--- a/src/commands/buffer_switch.rs
+++ b/src/commands/buffer_switch.rs
@@ -52,11 +52,14 @@ impl CommandRunCallback for BufferSwitchCommand {
 fn buffer_target(command: &str) -> Option<&str> {
     let target = command.strip_prefix("/buffer")?.trim();
 
-    (!target.is_empty()
+    is_buffer_target(target).then_some(target)
+}
+
+pub(crate) fn is_buffer_target(target: &str) -> bool {
+    !target.is_empty()
         && !target.contains(char::is_whitespace)
         && !target.starts_with('-')
-        && !is_core_buffer_subcommand(target))
-    .then_some(target)
+        && !is_core_buffer_subcommand(target)
 }
 
 fn is_core_buffer_subcommand(target: &str) -> bool {
@@ -82,7 +85,7 @@ fn is_core_buffer_subcommand(target: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::buffer_target;
+    use super::{buffer_target, is_buffer_target};
 
     #[test]
     fn extracts_single_buffer_argument() {
@@ -99,5 +102,13 @@ mod tests {
         assert_eq!(buffer_target("/buffer move 1"), None);
         assert_eq!(buffer_target("/buffer clear"), None);
         assert_eq!(buffer_target("/buffer -merged"), None);
+    }
+
+    #[test]
+    fn recognizes_resolvable_buffer_targets() {
+        assert!(is_buffer_target("#OSGeo"));
+        assert!(!is_buffer_target(""));
+        assert!(!is_buffer_target("matrix room"));
+        assert!(!is_buffer_target("list"));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,8 @@ mod verification;
 
 use buffer_clear::BufferClearCommand;
 use buffer_switch::BufferSwitchCommand;
+
+pub(crate) use buffer_switch::is_buffer_target;
 use devices::DevicesCommand;
 use dm::DirectMessageCommand;
 use ignore::IgnoreCommand;

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -10,10 +10,12 @@ use weechat::{
     Weechat,
 };
 
+use crate::commands::is_buffer_target;
 use crate::Servers;
 
 #[allow(dead_code)]
 pub struct Completions {
+    buffer_short_names: CompletionHook,
     servers: CompletionHook,
     users: CompletionHook,
     media: CompletionHook,
@@ -22,10 +24,58 @@ pub struct Completions {
 impl Completions {
     pub fn hook_all(servers: Servers) -> Result<Self, ()> {
         Ok(Self {
+            buffer_short_names: BufferShortNamesCompletion::create(
+                servers.clone(),
+            )?,
             servers: ServersCompletion::create(servers.clone())?,
             users: UsersCompletion::create(servers.clone())?,
             media: MediaCompletion::create(servers)?,
         })
+    }
+}
+
+struct BufferShortNamesCompletion {
+    servers: Servers,
+}
+
+impl BufferShortNamesCompletion {
+    fn create(servers: Servers) -> Result<CompletionHook, ()> {
+        let comp = BufferShortNamesCompletion { servers };
+
+        // WeeChat's /buffer completion uses this item after adding its regular
+        // buffer names. Adding Matrix short names here keeps those core
+        // candidates intact while making the command-run hook reachable.
+        CompletionHook::new(
+            "buffers_names",
+            "Completion for Matrix buffer short names",
+            comp,
+        )
+    }
+}
+
+impl CompletionCallback for BufferShortNamesCompletion {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        _: &Buffer,
+        _: Cow<str>,
+        completion: &Completion,
+    ) -> Result<(), ()> {
+        for short_name in buffer_completion_candidates(
+            self.servers
+                .borrow()
+                .values()
+                .flat_map(|server| server.rooms())
+                .flat_map(|room| room.buffer_short_names()),
+        ) {
+            completion.add_with_options(
+                &short_name,
+                false,
+                CompletionPosition::Sorted,
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -185,6 +235,16 @@ fn extract_mxc_uris(message: &str) -> Vec<String> {
         .collect()
 }
 
+fn buffer_completion_candidates<I>(short_names: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    short_names
+        .into_iter()
+        .filter(|short_name| is_buffer_target(short_name))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +263,19 @@ mod tests {
     #[test]
     fn ignores_invalid_mxc_uris() {
         assert!(extract_mxc_uris("download mxc://").is_empty());
+    }
+
+    #[test]
+    fn completes_only_resolvable_matrix_short_names() {
+        assert_eq!(
+            buffer_completion_candidates([
+                "#matrix:example.org".to_owned(),
+                "#matrix:example.org".to_owned(),
+                "".to_owned(),
+                "matrix room".to_owned(),
+                "list".to_owned(),
+            ]),
+            BTreeSet::from(["#matrix:example.org".to_owned()]),
+        );
     }
 }

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -53,6 +53,20 @@ impl RoomBuffer {
             .unwrap_or_default()
     }
 
+    pub fn short_names(&self) -> Vec<String> {
+        let mut handles =
+            self.inner.borrow().iter().cloned().collect::<Vec<_>>();
+        handles.extend(self.thread_buffers.borrow().values().cloned());
+
+        handles
+            .into_iter()
+            .filter_map(|handle| {
+                let buffer = handle.upgrade().ok()?;
+                Some(buffer.short_name().into_owned())
+            })
+            .collect()
+    }
+
     pub fn buffer_handle_for_short_name(
         &self,
         short_name: &str,

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -599,6 +599,10 @@ impl MatrixRoom {
         self.buffer.buffer_handle()
     }
 
+    pub fn buffer_short_names(&self) -> Vec<String> {
+        self.buffer.short_names()
+    }
+
     pub fn buffer_handle_for_short_name(
         &self,
         short_name: &str,


### PR DESCRIPTION
`/buffer <Tab>` currently offers Matrix room IDs but not the short names shown in the buffer list.

Add live Matrix buffer short names to WeeChat's existing `buffers_names` completion item. The core room-ID candidates stay intact, and only names the Matrix `/buffer` hook can resolve are added.

The Rust 1.96 bundled-WeeChat library suite passes 69/69 tests.

Fixes poljar/weechat-matrix-rs#246.
