### PR TITLE
Run /nick on the Matrix runtime

### DIFF
--- a/src/commands/nick.rs
+++ b/src/commands/nick.rs
@@ -32,49 +32,46 @@ impl CommandRunCallback for NickCommand {
     ) -> ReturnCode {
         let new_nick = cmd.strip_prefix("/nick ").map(|s| s.trim());
 
-        if let Some(server) = self.servers.find_server(&buffer) {
-            match new_nick {
-                Some(name) if !name.is_empty() => {
-                    let name = name.to_owned();
-                    Weechat::spawn(async move {
-                        server.set_display_name(Some(&name)).await;
-                    })
-                    .detach();
-                }
-                None => {
-                    // /nick with no arguments: show current display name
-                    Weechat::spawn(async move {
-                        match server.get_display_name().await {
-                            Some(name) => {
-                                Weechat::print(&format!(
-                                    "{}: Current display name: {}",
-                                    PLUGIN_NAME, name
-                                ));
-                            }
-                            None => {
-                                Weechat::print(&format!(
-                                    "{}: No display name set.",
-                                    PLUGIN_NAME
-                                ));
-                            }
-                        }
-                    })
-                    .detach();
-                }
-                _ => {
-                    Weechat::print(&format!(
-                        "{}Usage: /nick <new-display-name>",
-                        Weechat::prefix(weechat::Prefix::Error),
-                    ));
-                }
+        let Some(server) = self.servers.find_server(&buffer) else {
+            return ReturnCode::Ok;
+        };
+
+        match new_nick {
+            Some(name) if !name.is_empty() => {
+                let name = name.to_owned();
+                Weechat::spawn(async move {
+                    server.set_display_name(Some(&name)).await;
+                })
+                .detach();
             }
-        } else {
-            Weechat::print(&format!(
-                "{}The /nick command must be run in a Matrix buffer.",
-                Weechat::prefix(weechat::Prefix::Error),
-            ));
+            None => {
+                // /nick with no arguments: show current display name
+                Weechat::spawn(async move {
+                    match server.get_display_name().await {
+                        Some(name) => {
+                            Weechat::print(&format!(
+                                "{}: Current display name: {}",
+                                PLUGIN_NAME, name
+                            ));
+                        }
+                        None => {
+                            Weechat::print(&format!(
+                                "{}: No display name set.",
+                                PLUGIN_NAME
+                            ));
+                        }
+                    }
+                })
+                .detach();
+            }
+            _ => {
+                Weechat::print(&format!(
+                    "{}Usage: /nick <new-display-name>",
+                    Weechat::prefix(weechat::Prefix::Error),
+                ));
+            }
         }
 
-        ReturnCode::Ok
+        ReturnCode::OkEat
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -740,19 +740,34 @@ impl InnerServer {
 
     /// Set the display name for this account on the homeserver.
     pub async fn set_display_name(&self, name: Option<&str>) {
-        let Some(client) = self.get_client() else {
+        let Some(connection) = self.connection() else {
             self.print_error("Not connected to a server");
             return;
         };
-        if let Err(e) = client.account().set_display_name(name).await {
+
+        let client = connection.client().clone();
+        let name = name.map(str::to_owned);
+        let result = connection
+            .spawn(async move {
+                client.account().set_display_name(name.as_deref()).await
+            })
+            .await;
+
+        if let Err(e) = result {
             self.print_error(&format!("Failed to set display name: {}", e));
         }
     }
 
     /// Get the current display name for this account from the homeserver.
     pub async fn get_display_name(&self) -> Option<String> {
-        let client = self.get_client()?;
-        client.account().get_display_name().await.ok().flatten()
+        let connection = self.connection()?;
+        let client = connection.client().clone();
+
+        connection
+            .spawn(async move { client.account().get_display_name().await })
+            .await
+            .ok()
+            .flatten()
     }
 
     pub async fn restore_room_by_id(&self, room_id: OwnedRoomId) {


### PR DESCRIPTION
The `/nick` implementation from poljar/weechat-matrix-rs#238 called Matrix SDK account methods from a WeeChat main-loop future, outside the connection's Tokio runtime. It also returned the command to WeeChat, so the IRC `/nick` handler ran afterward.

Run both display-name requests through the Matrix connection runtime. Consume `/nick` in Matrix buffers and keep passing it through everywhere else.

The Rust 1.96 bundled-WeeChat library suite passes 67/67 tests.

Fixes poljar/weechat-matrix-rs#235.
