### PR TITLE
Add Matrix verification management commands

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -16,7 +16,7 @@ use super::{
     verification::VerificationCommand,
 };
 use crate::{
-    commands::{DevicesCommand, KeysCommand, MediaCommand},
+    commands::{DevicesCommand, KeysCommand, MediaCommand, VerifyCommand},
     config::ConfigHandle,
     MatrixServer, Servers, PLUGIN_NAME,
 };
@@ -40,6 +40,8 @@ impl MatrixCommand {
             .add_argument("devices delete|list|set-name")
             .add_argument("keys import|export <file> <passphrase>")
             .add_argument("media download <mxc-uri> [file]")
+            .add_argument("verify <contact> <device-id>")
+            .add_argument("verification info [contact]")
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
             .add_argument("sso-complete <server-name> <login-token>")
@@ -58,18 +60,21 @@ sso-complete: Finish SSO login with a copied loginToken.
      devices: {}
         keys: {}
        media: {}
+      verify: {}
 verification: {}
         help: Show detailed command help.\n
 Use /matrix [command] help to find out more.\n",
                 DevicesCommand::DESCRIPTION,
                 KeysCommand::DESCRIPTION,
                 MediaCommand::DESCRIPTION,
+                VerifyCommand::DESCRIPTION,
                 VerificationCommand::DESCRIPTION,
             ))
             .add_completion("server add|delete|list|listfull")
             .add_completion("devices list|delete|set-name %(matrix-users)")
             .add_completion(format!("keys {}", KeysCommand::COMPLETION))
             .add_completion(format!("media {}", MediaCommand::COMPLETION))
+            .add_completion("verify %(matrix-users)")
             .add_completion(format!(
                 "verification {}",
                 VerificationCommand::COMPLETION
@@ -79,7 +84,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("reconnect %(matrix_servers)")
             .add_completion("sso-complete %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media|verification",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media|verify|verification",
             );
 
         Command::new(
@@ -286,6 +291,9 @@ Use /matrix [command] help to find out more.\n",
             ("media", Some(subargs)) => {
                 MediaCommand::run(buffer, &self.servers, subargs)
             }
+            ("verify", Some(subargs)) => {
+                VerifyCommand::run(buffer, &self.servers, subargs)
+            }
             ("verification", Some(subargs)) => {
                 VerificationCommand::run(buffer, &self.servers, subargs)
             }
@@ -381,6 +389,7 @@ impl CommandCallback for MatrixCommand {
                     .settings(VerificationCommand::SETTINGS)
                     .subcommands(VerificationCommand::subcommands()),
             )
+            .subcommand(VerifyCommand::parser())
             .subcommand(
                 SubCommand::with_name("connect")
                     .about("Connect to Matrix servers.")

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -79,7 +79,7 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("reconnect %(matrix_servers)")
             .add_completion("sso-complete %(matrix_servers)")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media|verification",
             );
 
         Command::new(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,6 +28,7 @@ mod reply;
 mod topic;
 mod upload;
 mod verification;
+mod verify;
 
 use buffer_clear::BufferClearCommand;
 use buffer_switch::BufferSwitchCommand;
@@ -51,6 +52,7 @@ use redact::RedactCommand;
 use reply::ReplyCommand;
 use topic::TopicCommand;
 use upload::UploadCommand;
+use verify::VerifyCommand;
 
 pub struct Commands {
     _matrix: Command,

--- a/src/commands/verification.rs
+++ b/src/commands/verification.rs
@@ -1,6 +1,8 @@
 use clap::{
-    App as Argparse, AppSettings as ArgParseSettings, ArgMatches, SubCommand,
+    App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches,
+    SubCommand,
 };
+use matrix_sdk::ruma::{OwnedUserId, UserId};
 
 use weechat::{
     buffer::Buffer,
@@ -25,7 +27,8 @@ impl VerificationCommand {
     pub const DESCRIPTION: &'static str =
         "Control interactive verification flows";
 
-    pub const COMPLETION: &'static str = "accept|confirm|cancel";
+    pub const COMPLETION: &'static str =
+        "start %(matrix-users)|accept|confirm|cancel";
     pub const SETTINGS: &'static [ArgParseSettings] = &[
         ArgParseSettings::DisableHelpFlags,
         ArgParseSettings::DisableVersion,
@@ -36,9 +39,11 @@ impl VerificationCommand {
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("verification")
             .description(Self::DESCRIPTION)
+            .add_argument("verification start <contact>")
             .add_argument("verification accept|confirm|cancel")
             .arguments_description(
-                "accept: accept the verification request
+                "  start: start an interactive verification with a contact
+                accept: accept the verification request
                 confirm: confirm that the emojis match on both sides or \
                 confirm that the other side has scanned our QR code
                 cancel: cancel the verification flow or request",
@@ -77,8 +82,27 @@ impl VerificationCommand {
         }
     }
 
+    fn start(servers: &Servers, buffer: &Buffer, user_id: OwnedUserId) {
+        if let Some(server) = servers.find_server(buffer) {
+            Weechat::spawn(async move {
+                server.start_verification(user_id).await;
+            })
+            .detach();
+        } else {
+            Weechat::print("Must be executed on Matrix buffer")
+        }
+    }
+
     pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
         match args.subcommand() {
+            ("start", Some(args)) => {
+                let user_id =
+                    UserId::parse(args.value_of("contact").expect(
+                        "Contact wasn't provided despite being required",
+                    ))
+                    .expect("Contact wasn't a valid Matrix user ID");
+                Self::start(servers, buffer, user_id);
+            }
             ("accept", _) => {
                 Self::verification(servers, buffer, CommandType::Accept)
             }
@@ -94,6 +118,16 @@ impl VerificationCommand {
 
     pub fn subcommands() -> Vec<Argparse<'static, 'static>> {
         vec![
+            SubCommand::with_name("start")
+                .about("Start an interactive verification with a contact")
+                .arg(Arg::with_name("contact").required(true).validator(
+                    |contact| {
+                        UserId::parse(contact).map(|_| ()).map_err(|_| {
+                            "The contact isn't a valid Matrix user ID"
+                                .to_owned()
+                        })
+                    },
+                )),
             SubCommand::with_name("accept")
                 .about("Accept a verification request"),
             SubCommand::with_name("confirm").about(
@@ -103,6 +137,38 @@ impl VerificationCommand {
             SubCommand::with_name("cancel")
                 .about("Cancel the verification flow"),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parser() -> Argparse<'static, 'static> {
+        Argparse::new("verification")
+            .settings(VerificationCommand::SETTINGS)
+            .subcommands(VerificationCommand::subcommands())
+    }
+
+    #[test]
+    fn parses_verification_start_contact() {
+        let matches = parser()
+            .get_matches_from_safe(vec![
+                "verification",
+                "start",
+                "@alice:example.org",
+            ])
+            .expect("valid verification start command");
+        let args = matches.subcommand_matches("start").expect("start args");
+
+        assert_eq!(args.value_of("contact"), Some("@alice:example.org"));
+    }
+
+    #[test]
+    fn rejects_invalid_verification_start_contact() {
+        assert!(parser()
+            .get_matches_from_safe(vec!["verification", "start", "alice"])
+            .is_err());
     }
 }
 

--- a/src/commands/verification.rs
+++ b/src/commands/verification.rs
@@ -28,7 +28,7 @@ impl VerificationCommand {
         "Control interactive verification flows";
 
     pub const COMPLETION: &'static str =
-        "start %(matrix-users)|accept|confirm|cancel";
+        "start %(matrix-users)|info %(matrix-users)|accept|confirm|cancel";
     pub const SETTINGS: &'static [ArgParseSettings] = &[
         ArgParseSettings::DisableHelpFlags,
         ArgParseSettings::DisableVersion,
@@ -40,16 +40,18 @@ impl VerificationCommand {
         let settings = CommandSettings::new("verification")
             .description(Self::DESCRIPTION)
             .add_argument("verification start <contact>")
+            .add_argument("verification info [contact]")
             .add_argument("verification accept|confirm|cancel")
             .arguments_description(
                 "  start: start an interactive verification with a contact
+                  info: show verification state for one or all known contacts
                 accept: accept the verification request
                 confirm: confirm that the emojis match on both sides or \
                 confirm that the other side has scanned our QR code
                 cancel: cancel the verification flow or request",
             )
             .add_completion(Self::COMPLETION)
-            .add_completion("help accept|confirm|cancel");
+            .add_completion("help start|info|accept|confirm|cancel");
 
         Command::new(
             settings,
@@ -93,6 +95,17 @@ impl VerificationCommand {
         }
     }
 
+    fn info(servers: &Servers, buffer: &Buffer, user_id: Option<OwnedUserId>) {
+        if let Some(server) = servers.find_server(buffer) {
+            Weechat::spawn(async move {
+                server.verification_info(user_id).await;
+            })
+            .detach();
+        } else {
+            Weechat::print("Must be executed on Matrix buffer")
+        }
+    }
+
     pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
         match args.subcommand() {
             ("start", Some(args)) => {
@@ -102,6 +115,13 @@ impl VerificationCommand {
                     ))
                     .expect("Contact wasn't a valid Matrix user ID");
                 Self::start(servers, buffer, user_id);
+            }
+            ("info", Some(args)) => {
+                let user_id = args.value_of("contact").map(|contact| {
+                    UserId::parse(contact)
+                        .expect("Contact wasn't a valid Matrix user ID")
+                });
+                Self::info(servers, buffer, user_id);
             }
             ("accept", _) => {
                 Self::verification(servers, buffer, CommandType::Accept)
@@ -121,6 +141,16 @@ impl VerificationCommand {
             SubCommand::with_name("start")
                 .about("Start an interactive verification with a contact")
                 .arg(Arg::with_name("contact").required(true).validator(
+                    |contact| {
+                        UserId::parse(contact).map(|_| ()).map_err(|_| {
+                            "The contact isn't a valid Matrix user ID"
+                                .to_owned()
+                        })
+                    },
+                )),
+            SubCommand::with_name("info")
+                .about("Show verification state for one or all known contacts")
+                .arg(Arg::with_name("contact").required(false).validator(
                     |contact| {
                         UserId::parse(contact).map(|_| ()).map_err(|_| {
                             "The contact isn't a valid Matrix user ID"
@@ -168,6 +198,40 @@ mod tests {
     fn rejects_invalid_verification_start_contact() {
         assert!(parser()
             .get_matches_from_safe(vec!["verification", "start", "alice"])
+            .is_err());
+    }
+
+    #[test]
+    fn parses_verification_info_with_optional_contact() {
+        let all = parser()
+            .get_matches_from_safe(vec!["verification", "info"])
+            .expect("valid verification info command");
+        assert_eq!(
+            all.subcommand_matches("info")
+                .expect("info args")
+                .value_of("contact"),
+            None
+        );
+
+        let one = parser()
+            .get_matches_from_safe(vec![
+                "verification",
+                "info",
+                "@alice:example.org",
+            ])
+            .expect("valid verification info contact");
+        assert_eq!(
+            one.subcommand_matches("info")
+                .expect("info args")
+                .value_of("contact"),
+            Some("@alice:example.org")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_verification_info_contact() {
+        assert!(parser()
+            .get_matches_from_safe(vec!["verification", "info", "alice"])
             .is_err());
     }
 }

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,0 +1,75 @@
+use clap::{App as Argparse, Arg, ArgMatches};
+use matrix_sdk::ruma::{OwnedDeviceId, UserId};
+use weechat::{buffer::Buffer, Weechat};
+
+use crate::Servers;
+
+pub struct VerifyCommand;
+
+impl VerifyCommand {
+    pub const DESCRIPTION: &'static str =
+        "Mark an exact Matrix device as locally verified";
+
+    pub fn run(buffer: &Buffer, servers: &Servers, args: &ArgMatches) {
+        let user_id = UserId::parse(
+            args.value_of("contact")
+                .expect("Contact wasn't provided despite being required"),
+        )
+        .expect("Contact wasn't a valid Matrix user ID");
+        let device_id: OwnedDeviceId = args
+            .value_of("device-id")
+            .expect("Device ID wasn't provided despite being required")
+            .into();
+
+        if let Some(server) = servers.find_server(buffer) {
+            Weechat::spawn(async move {
+                server.mark_device_verified(user_id, device_id).await;
+            })
+            .detach();
+        } else {
+            Weechat::print("Must be executed on Matrix buffer")
+        }
+    }
+
+    pub fn parser() -> Argparse<'static, 'static> {
+        Argparse::new("verify")
+            .about(Self::DESCRIPTION)
+            .arg(Arg::with_name("contact").required(true).validator(
+                |contact| {
+                    UserId::parse(contact).map(|_| ()).map_err(|_| {
+                        "The contact isn't a valid Matrix user ID".to_owned()
+                    })
+                },
+            ))
+            .arg(Arg::with_name("device-id").required(true))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_exact_contact_and_device() {
+        let matches = VerifyCommand::parser()
+            .get_matches_from_safe(vec![
+                "verify",
+                "@alice:example.org",
+                "ALICEDEVICE",
+            ])
+            .expect("valid verify command");
+
+        assert_eq!(matches.value_of("contact"), Some("@alice:example.org"));
+        assert_eq!(matches.value_of("device-id"), Some("ALICEDEVICE"));
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_target() {
+        assert!(VerifyCommand::parser()
+            .get_matches_from_safe(vec!["verify", "alice", "ALICEDEVICE"])
+            .is_err());
+        assert!(VerifyCommand::parser()
+            .get_matches_from_safe(vec!["verify", "@alice:example.org"])
+            .is_err());
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,7 @@ use url::Url;
 use matrix_sdk::{
     self,
     deserialized_responses::AmbiguityChange,
-    encryption::RoomKeyImportResult,
+    encryption::{LocalTrust, RoomKeyImportResult},
     media::{MediaFormat, MediaRequestParameters},
     room::Room,
     ruma::{
@@ -1847,6 +1847,177 @@ impl InnerServer {
             Err(error) => self.print_error(&format!(
                 "Error starting verification with {}: {}",
                 user_id, error
+            )),
+        }
+    }
+
+    pub async fn mark_device_verified(
+        &self,
+        user_id: OwnedUserId,
+        device_id: OwnedDeviceId,
+    ) {
+        let Some(connection) = self.connection() else {
+            self.print_error("You must be connected to execute this command");
+            return;
+        };
+
+        let client = connection.client().clone();
+        let requested_user_id = user_id.clone();
+        let requested_device_id = device_id.clone();
+        let result = connection
+            .spawn(async move {
+                client
+                    .encryption()
+                    .request_user_identity(&requested_user_id)
+                    .await
+                    .map_err(|error| error.to_string())?;
+
+                let Some(device) = client
+                    .encryption()
+                    .get_device(&requested_user_id, &requested_device_id)
+                    .await
+                    .map_err(|error| error.to_string())?
+                else {
+                    return Ok::<_, String>(false);
+                };
+
+                device
+                    .set_local_trust(LocalTrust::Verified)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok::<_, String>(true)
+            })
+            .await;
+
+        match result {
+            Ok(true) => self.print_network(&format!(
+                "Marked device {} of {} as locally verified on this client",
+                device_id, user_id
+            )),
+            Ok(false) => self.print_error(&format!(
+                "Device {} of {} was not found",
+                device_id, user_id
+            )),
+            Err(error) => self.print_error(&format!(
+                "Error marking device {} of {} as locally verified: {}",
+                device_id, user_id, error
+            )),
+        }
+    }
+
+    pub async fn verification_info(&self, user_id: Option<OwnedUserId>) {
+        let Some(connection) = self.connection() else {
+            self.print_error("You must be connected to execute this command");
+            return;
+        };
+
+        let client = connection.client().clone();
+        let result = connection
+            .spawn(async move {
+                let encryption = client.encryption();
+                let refresh_identity = user_id.is_some();
+                let mut users = if let Some(user_id) = user_id {
+                    vec![user_id]
+                } else {
+                    encryption
+                        .tracked_users()
+                        .await
+                        .map_err(|error| error.to_string())?
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                };
+                users.sort();
+
+                let mut report = Vec::new();
+
+                for user_id in users {
+                    let identity = if refresh_identity {
+                        encryption
+                            .request_user_identity(&user_id)
+                            .await
+                            .map_err(|error| error.to_string())?
+                    } else {
+                        encryption
+                            .get_user_identity(&user_id)
+                            .await
+                            .map_err(|error| error.to_string())?
+                    };
+                    let identity_state = match identity.as_ref() {
+                        Some(identity)
+                            if identity.has_verification_violation() =>
+                        {
+                            "verification violation"
+                        }
+                        Some(identity) if identity.is_verified() => "verified",
+                        Some(identity)
+                            if identity.was_previously_verified() =>
+                        {
+                            "previously verified"
+                        }
+                        Some(_) => "not verified",
+                        None => "no cross-signing identity",
+                    };
+
+                    report.push(format!("{}: {}", user_id, identity_state));
+
+                    let devices = encryption
+                        .get_user_devices(&user_id)
+                        .await
+                        .map_err(|error| error.to_string())?;
+                    let mut device_lines = devices
+                        .devices()
+                        .map(|device| {
+                            let state = if device
+                                .is_verified_with_cross_signing()
+                            {
+                                "verified by cross-signing"
+                            } else {
+                                match device.local_trust_state() {
+                                    LocalTrust::Verified => {
+                                        "locally trusted only"
+                                    }
+                                    LocalTrust::BlackListed => "blacklisted",
+                                    LocalTrust::Ignored => "ignored",
+                                    LocalTrust::Unset
+                                        if device.is_verified() =>
+                                    {
+                                        "verified"
+                                    }
+                                    LocalTrust::Unset => "not verified",
+                                }
+                            };
+                            let name = device
+                                .display_name()
+                                .map(|name| format!(" ({name})"))
+                                .unwrap_or_default();
+
+                            format!(
+                                "  {}{}: {}",
+                                device.device_id(),
+                                name,
+                                state
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    device_lines.sort();
+                    report.extend(device_lines);
+                }
+
+                Ok::<_, String>(report)
+            })
+            .await;
+
+        match result {
+            Ok(report) if report.is_empty() => self.print_error(
+                "No tracked Matrix contacts have verification information",
+            ),
+            Ok(report) => {
+                self.print_network("Matrix verification state:");
+                self.print(&report.join("\n"));
+            }
+            Err(error) => self.print_error(&format!(
+                "Error fetching Matrix verification state: {}",
+                error
             )),
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1793,6 +1793,64 @@ impl InnerServer {
         }
     }
 
+    pub async fn start_verification(&self, user_id: OwnedUserId) {
+        let Some(connection) = self.connection() else {
+            self.print_error("You must be connected to execute this command");
+            return;
+        };
+
+        let client = connection.client().clone();
+        let requested_user_id = user_id.clone();
+        let result = connection
+            .spawn(async move {
+                let Some(identity) = client
+                    .encryption()
+                    .request_user_identity(&requested_user_id)
+                    .await
+                    .map_err(|error| error.to_string())?
+                else {
+                    return Ok(None);
+                };
+
+                identity
+                    .request_verification()
+                    .await
+                    .map(Some)
+                    .map_err(|error| error.to_string())
+            })
+            .await;
+
+        match result {
+            Ok(Some(request)) => {
+                self.print_network(&format!(
+                    "Sent a verification request to {}",
+                    user_id
+                ));
+
+                if request.room_id().is_none() {
+                    let flow_id = request.flow_id().to_owned();
+                    let buffer = VerificationBuffer::new(
+                        &self.server_name,
+                        &user_id,
+                        request,
+                        self.connection.clone(),
+                    );
+                    self.verification_buffers
+                        .borrow_mut()
+                        .insert(flow_id, buffer);
+                }
+            }
+            Ok(None) => self.print_error(&format!(
+                "No cross-signing identity was found for {}",
+                user_id
+            )),
+            Err(error) => self.print_error(&format!(
+                "Error starting verification with {}: {}",
+                user_id, error
+            )),
+        }
+    }
+
     pub fn autoconnect(&self) -> bool {
         self.settings.borrow().autoconnect
     }


### PR DESCRIPTION
## Summary

- add `/matrix verification start <contact>` for interactive contact verification
- add `/matrix verify <contact> <device-id>` for explicit local device trust
- add `/matrix verification info [contact]` to report cross-signing and per-device verification state
- validate Matrix user IDs and report missing identities, devices, and connection errors

## Testing

- Rust 1.96.1, `WEECHAT_BUNDLED=1`: 77 library tests passed
- command parser regression tests
- `git diff --check`
- independent code review found no correctness issues

Closes poljar/weechat-matrix-rs#251
Closes poljar/weechat-matrix-rs#252
Closes poljar/weechat-matrix-rs#253
