### PR TITLE
Handle Matrix /me actions without ambiguity

### DIFF
--- a/src/commands/me.rs
+++ b/src/commands/me.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use matrix_sdk::ruma::events::room::message::RoomMessageEventContent;
 use weechat::{
     buffer::Buffer,
     hooks::{CommandRun, CommandRunCallback},
@@ -13,10 +12,16 @@ pub struct MeCommand {
     servers: Servers,
 }
 
+const ME_COMMAND_PATTERN: &str = "/me *";
+
+fn action_body(command: &str) -> Option<&str> {
+    command.strip_prefix("/me ")
+}
+
 impl MeCommand {
     pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
         CommandRun::new(
-            "/me",
+            ME_COMMAND_PATTERN,
             MeCommand {
                 servers: servers.clone(),
             },
@@ -31,14 +36,34 @@ impl CommandRunCallback for MeCommand {
         buffer: &Buffer,
         cmd: Cow<str>,
     ) -> ReturnCode {
-        if let Some(room) = self.servers.find_room(buffer) {
-            self.servers.runtime().block_on(room.send_message(
-                RoomMessageEventContent::emote_plain(
-                    cmd.strip_prefix("/me ").map(|s| s.to_string()).unwrap(),
-                ),
-            ));
-        }
+        let Some(room) = self.servers.find_room(buffer) else {
+            return ReturnCode::Ok;
+        };
 
-        ReturnCode::Ok
+        let Some(body) = action_body(&cmd) else {
+            return ReturnCode::Ok;
+        };
+
+        self.servers
+            .runtime()
+            .block_on(room.send_emote(buffer, body.to_owned()));
+
+        ReturnCode::OkEat
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{action_body, ME_COMMAND_PATTERN};
+
+    #[test]
+    fn me_hook_matches_action_arguments_before_command_resolution() {
+        assert_eq!(ME_COMMAND_PATTERN, "/me *");
+    }
+
+    #[test]
+    fn me_action_body_excludes_other_commands() {
+        assert_eq!(action_body("/me waves"), Some("waves"));
+        assert_eq!(action_body("/message waves"), None);
     }
 }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -291,6 +291,26 @@ fn make_text_message_content(
     content
 }
 
+fn make_emote_message_content(
+    body: String,
+    thread_root: Option<OwnedEventId>,
+    latest_thread_event: Option<OwnedEventId>,
+) -> RoomMessageEventContent {
+    let mut content = RoomMessageEventContent::emote_plain(body);
+
+    if let Some(thread_root) = thread_root {
+        let latest_thread_event =
+            latest_thread_event.unwrap_or_else(|| thread_root.clone());
+
+        content.relates_to = Some(Relation::Thread(Thread::plain(
+            thread_root,
+            latest_thread_event,
+        )));
+    }
+
+    content
+}
+
 fn thread_root_from_buffer(buffer: &Buffer) -> Option<OwnedEventId> {
     buffer
         .get_localvar("thread_root")
@@ -538,6 +558,17 @@ impl BufferInputCallbackAsync for MatrixRoom {
 impl MatrixRoom {
     pub fn owns_buffer(&self, buffer: &Buffer) -> bool {
         self.buffer.owns_buffer(buffer)
+    }
+
+    pub async fn send_emote(&self, buffer: &Buffer<'_>, body: String) {
+        let thread_root = thread_root_from_buffer(buffer);
+        let latest_thread_event = thread_root.as_ref().and_then(|root| {
+            self.latest_thread_event_ids.borrow().get(root).cloned()
+        });
+        let content =
+            make_emote_message_content(body, thread_root, latest_thread_event);
+
+        self.send_message(content).await;
     }
 
     pub fn close_thread_buffer(&self, buffer: &Buffer) -> bool {
@@ -1791,6 +1822,31 @@ mod tests {
 
         let Some(Relation::Thread(thread)) = content.relates_to else {
             panic!("thread buffer input must send an m.thread relation");
+        };
+
+        assert_eq!(
+            thread.event_id,
+            EventId::parse("$thread-root:example.org").unwrap()
+        );
+        assert_eq!(
+            thread.in_reply_to.expect("fallback target").event_id,
+            EventId::parse("$latest-thread-event:example.org").unwrap()
+        );
+        assert!(thread.is_falling_back);
+    }
+
+    #[test]
+    fn thread_buffer_emote_sends_thread_relation() {
+        let content = make_emote_message_content(
+            "waves".to_owned(),
+            Some(EventId::parse("$thread-root:example.org").unwrap()),
+            Some(EventId::parse("$latest-thread-event:example.org").unwrap()),
+        );
+
+        assert!(matches!(content.msgtype, MessageType::Emote(_)));
+
+        let Some(Relation::Thread(thread)) = content.relates_to else {
+            panic!("thread buffer emote must send an m.thread relation");
         };
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- register the Matrix `/me *` command-run hook so WeeChat resolves actions without an ambiguity warning
- consume the command only in Matrix room and thread buffers
- preserve the current `m.thread` relation when an action is sent from a thread buffer

## Testing

- Rust 1.96.1, `WEECHAT_BUNDLED=1`: 74 library tests passed
- regression coverage for command matching and thread-related emotes
- `git diff --check`

Closes poljar/weechat-matrix-rs#256
