### PR TITLE
Restore Matrix sessions from secure tokens

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -16,6 +16,7 @@ use tracing::error;
 
 use matrix_sdk::{
     self,
+    authentication::matrix::MatrixSession,
     config::SyncSettings,
     deserialized_responses::AmbiguityChange,
     room::{Messages, MessagesOptions, Receipts, Room},
@@ -43,10 +44,13 @@ use matrix_sdk::{
             SyncStateEvent,
         },
         OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+        OwnedUserId,
     },
+    store::RoomLoadSettings,
     sync::State,
     utils::local_server::LocalServerBuilder,
-    Client, LoopCtrl, Result as MatrixResult, RoomMemberships,
+    Client, LoopCtrl, Result as MatrixResult, RoomMemberships, SessionMeta,
+    SessionTokens,
 };
 
 use weechat::{Task, Weechat};
@@ -76,6 +80,7 @@ impl InteractiveAuthInfo {
 
 pub enum ClientMessage {
     LoginMessage(LoginResponse),
+    SessionRestored(OwnedUserId),
     SsoLoginUrl(String),
     SyncState(OwnedRoomId, AnySyncStateEvent),
     SyncEvent(OwnedRoomId, AnySyncTimelineEvent),
@@ -173,6 +178,9 @@ impl Connection {
             tx,
             server.user_name(),
             server.password(),
+            server.access_token(),
+            server.refresh_token(),
+            server.device_id(),
             server_name.to_string(),
             server.get_server_path(),
         ));
@@ -362,6 +370,9 @@ impl Connection {
             match message {
                 Ok(message) => match message {
                     ClientMessage::LoginMessage(r) => server.receive_login(r),
+                    ClientMessage::SessionRestored(user_id) => {
+                        server.receive_restored_login(user_id)
+                    }
                     ClientMessage::SsoLoginUrl(url) => {
                         server.receive_sso_url(&url)
                     }
@@ -418,9 +429,76 @@ impl Connection {
         channel: Sender<Result<ClientMessage, String>>,
         username: String,
         password: String,
+        access_token: String,
+        refresh_token: String,
+        device_id: String,
         server_name: String,
         server_path: PathBuf,
     ) {
+        if !client.matrix_auth().logged_in() && !access_token.is_empty() {
+            let user_id = match username.parse::<OwnedUserId>() {
+                Ok(user_id) => user_id,
+                Err(error) => {
+                    let _ = channel
+                        .send(Err(format!(
+                            "Invalid Matrix user ID for restored session: {error}"
+                        )))
+                        .await;
+                    return;
+                }
+            };
+            if device_id.is_empty() {
+                let _ = channel
+                    .send(Err(
+                        "A device ID is required with a Matrix access token"
+                            .to_owned(),
+                    ))
+                    .await;
+                return;
+            }
+            let session = MatrixSession {
+                meta: SessionMeta {
+                    user_id: user_id.clone(),
+                    device_id: OwnedDeviceId::from(device_id),
+                },
+                tokens: SessionTokens {
+                    access_token,
+                    refresh_token: (!refresh_token.is_empty())
+                        .then_some(refresh_token),
+                },
+            };
+            if let Err(error) = client
+                .matrix_auth()
+                .restore_session(session, RoomLoadSettings::default())
+                .await
+            {
+                let _ = channel
+                    .send(Err(format!(
+                        "Failed to restore Matrix access-token session: {error}"
+                    )))
+                    .await;
+                return;
+            }
+            if channel
+                .send(Ok(ClientMessage::SessionRestored(user_id)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+            for room in client.joined_rooms() {
+                if channel
+                    .send(Ok(ClientMessage::RestoredRoom(
+                        room.room_id().to_owned(),
+                    )))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+
         if !client.matrix_auth().logged_in() {
             let device_id_key = if username.is_empty() {
                 server_name.as_str()

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -49,8 +49,8 @@ use matrix_sdk::{
     store::RoomLoadSettings,
     sync::State,
     utils::local_server::LocalServerBuilder,
-    Client, LoopCtrl, Result as MatrixResult, RoomMemberships, SessionMeta,
-    SessionTokens,
+    Client, LoopCtrl, Result as MatrixResult, RoomMemberships, SessionChange,
+    SessionMeta, SessionTokens,
 };
 
 use weechat::{Task, Weechat};
@@ -81,6 +81,7 @@ impl InteractiveAuthInfo {
 pub enum ClientMessage {
     LoginMessage(LoginResponse),
     SessionRestored(OwnedUserId),
+    SessionTokensRefreshed(SessionTokens),
     SsoLoginUrl(String),
     SyncState(OwnedRoomId, AnySyncStateEvent),
     SyncEvent(OwnedRoomId, AnySyncTimelineEvent),
@@ -373,6 +374,9 @@ impl Connection {
                     ClientMessage::SessionRestored(user_id) => {
                         server.receive_restored_login(user_id)
                     }
+                    ClientMessage::SessionTokensRefreshed(tokens) => {
+                        server.receive_session_tokens(tokens)
+                    }
                     ClientMessage::SsoLoginUrl(url) => {
                         server.receive_sso_url(&url)
                     }
@@ -637,6 +641,56 @@ impl Connection {
                 }
             }
         }
+
+        // Refresh tokens can be rotated by the homeserver. Persist every
+        // rotated pair on the WeeChat thread so a later restart does not try
+        // the now-invalid token from the original login.
+        let mut session_changes = client.subscribe_to_session_changes();
+        let session_client = client.clone();
+        let session_channel = channel.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = session_channel.closed() => return,
+                    change = session_changes.recv() => {
+                        match change {
+                            Ok(SessionChange::TokensRefreshed) => {
+                                let Some(tokens) =
+                                    session_client.session_tokens()
+                                else {
+                                    continue;
+                                };
+
+                                if session_channel
+                                    .send(Ok(
+                                        ClientMessage::SessionTokensRefreshed(
+                                            tokens,
+                                        ),
+                                    ))
+                                    .await
+                                    .is_err()
+                                {
+                                    return;
+                                }
+                            }
+                            Ok(SessionChange::UnknownToken { .. }) => {}
+                            Err(
+                                tokio::sync::broadcast::error::RecvError::Lagged(
+                                    _,
+                                ),
+                            ) => {
+                                // The current client tokens are authoritative;
+                                // the next refresh notification will persist
+                                // their latest value.
+                            }
+                            Err(
+                                tokio::sync::broadcast::error::RecvError::Closed,
+                            ) => return,
+                        }
+                    }
+                }
+            }
+        });
 
         let filter = client
             .get_or_upload_filter("sync", Connection::sync_filter())

--- a/src/server.rs
+++ b/src/server.rs
@@ -154,6 +154,9 @@ pub struct ServerSettings {
     pub autoconnect: bool,
     pub username: String,
     pub password: String,
+    pub access_token: String,
+    pub refresh_token: String,
+    pub device_id: String,
     pub ssl_verify: bool,
 }
 
@@ -166,6 +169,9 @@ impl Default for ServerSettings {
             homeserver: None,
             username: "".to_owned(),
             password: "".to_owned(),
+            access_token: "".to_owned(),
+            refresh_token: "".to_owned(),
+            device_id: "".to_owned(),
         }
     }
 }
@@ -568,6 +574,63 @@ impl MatrixServer {
             .expect("Can't create password option");
 
         let server = server_copy;
+        let server_copy = server.clone();
+
+        let access_token =
+            StringOptionSettings::new(format!("{}.access_token", server_name))
+                .set_change_callback(move |_, option| {
+                    let server_ref = server.upgrade().expect(
+                        "Server got deleted while server config is alive",
+                    );
+
+                    server_ref.settings.borrow_mut().access_token =
+                        Weechat::eval_string_expression(&option.value())
+                            .expect("Can't evaluate access token");
+                });
+
+        server_section
+            .new_string_option(access_token)
+            .expect("Can't create access token option");
+
+        let server = server_copy;
+        let server_copy = server.clone();
+
+        let refresh_token =
+            StringOptionSettings::new(format!("{}.refresh_token", server_name))
+                .set_change_callback(move |_, option| {
+                    let server_ref = server.upgrade().expect(
+                        "Server got deleted while server config is alive",
+                    );
+
+                    server_ref.settings.borrow_mut().refresh_token =
+                        Weechat::eval_string_expression(&option.value())
+                            .expect("Can't evaluate refresh token");
+                });
+
+        server_section
+            .new_string_option(refresh_token)
+            .expect("Can't create refresh token option");
+
+        let server = server_copy;
+        let server_copy = server.clone();
+
+        let device_id =
+            StringOptionSettings::new(format!("{}.device_id", server_name))
+                .set_change_callback(move |_, option| {
+                    let server_ref = server.upgrade().expect(
+                        "Server got deleted while server config is alive",
+                    );
+
+                    server_ref.settings.borrow_mut().device_id =
+                        Weechat::eval_string_expression(&option.value())
+                            .expect("Can't evaluate device id");
+                });
+
+        server_section
+            .new_string_option(device_id)
+            .expect("Can't create device id option");
+
+        let server = server_copy;
 
         let ssl_verify =
             BooleanOptionSettings::new(format!("{}.ssl_verify", server_name))
@@ -710,6 +773,9 @@ impl Drop for MatrixServer {
                 "autoconnect",
                 "homeserver",
                 "password",
+                "access_token",
+                "refresh_token",
+                "device_id",
                 "proxy",
                 "ssl_verify",
                 "username",
@@ -791,6 +857,18 @@ impl InnerServer {
 
     pub fn password(&self) -> String {
         self.settings.borrow().password.clone()
+    }
+
+    pub fn access_token(&self) -> String {
+        self.settings.borrow().access_token.clone()
+    }
+
+    pub fn refresh_token(&self) -> String {
+        self.settings.borrow().refresh_token.clone()
+    }
+
+    pub fn device_id(&self) -> String {
+        self.settings.borrow().device_id.clone()
     }
 
     pub fn user_id_domain(&self) -> Option<String> {
@@ -1256,6 +1334,16 @@ impl InnerServer {
         *self.login_state.borrow_mut() = Some(login_state);
     }
 
+    pub fn receive_restored_login(&self, user_id: OwnedUserId) {
+        *self.login_state.borrow_mut() = Some(LoginInfo { user_id });
+        self.print_network(&format!(
+            "Restored Element session for {}{}{}",
+            Weechat::color("chat_server"),
+            self.name(),
+            Weechat::color("reset"),
+        ));
+    }
+
     pub fn receive_sso_url(&self, url: &str) {
         self.print_network(&format!(
             "Open this URL to finish SSO login for {}{}{}: {}",
@@ -1313,6 +1401,7 @@ impl InnerServer {
 
         let mut client_builder = Client::builder()
             .homeserver_url(homeserver)
+            .handle_refresh_tokens()
             .sqlite_store_with_cache_path(
                 self.get_server_path(),
                 self.get_server_cache_path(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,7 +88,7 @@ use matrix_sdk::{
         OwnedDeviceId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
         OwnedRoomOrAliasId, OwnedUserId, RoomAliasId, RoomId, UserId,
     },
-    Client, Error,
+    Client, Error, SessionTokens,
 };
 
 use weechat::{
@@ -1342,6 +1342,85 @@ impl InnerServer {
             self.name(),
             Weechat::color("reset"),
         ));
+    }
+
+    pub fn receive_session_tokens(&self, tokens: SessionTokens) {
+        let secure_prefix: String = self
+            .server_name
+            .chars()
+            .map(|character| {
+                if character.is_ascii_alphanumeric() {
+                    character
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        let access_name = format!("{secure_prefix}_access_token");
+        let refresh_name = format!("{secure_prefix}_refresh_token");
+
+        let buffer_handle = {
+            let mut server_buffer = self.server_buffer.borrow_mut();
+            self.get_or_create_buffer(&mut server_buffer).clone()
+        };
+        let Ok(buffer) = buffer_handle.upgrade() else {
+            self.print_error("Unable to persist refreshed Matrix session");
+            return;
+        };
+
+        let quote = |value: &str| {
+            format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+        };
+
+        let commands = [
+            format!(
+                "/secure set {access_name} {}",
+                quote(&tokens.access_token)
+            ),
+            format!(
+                "/set matrix-rust.server.{}.access_token \
+                 \"${{sec.data.{access_name}}}\"",
+                self.server_name
+            ),
+        ];
+
+        for command in commands {
+            if buffer.run_command(&command).is_err() {
+                self.print_error(
+                    "Unable to persist refreshed Matrix access token",
+                );
+                return;
+            }
+        }
+
+        if let Some(refresh_token) = tokens.refresh_token {
+            let commands = [
+                format!("/secure set {refresh_name} {}", quote(&refresh_token)),
+                format!(
+                    "/set matrix-rust.server.{}.refresh_token \
+                     \"${{sec.data.{refresh_name}}}\"",
+                    self.server_name
+                ),
+            ];
+
+            for command in commands {
+                if buffer.run_command(&command).is_err() {
+                    self.print_error(
+                        "Unable to persist refreshed Matrix refresh token",
+                    );
+                    return;
+                }
+            }
+        }
+
+        if buffer.run_command("/save sec").is_err()
+            || buffer.run_command("/save matrix-rust").is_err()
+        {
+            self.print_error("Unable to save refreshed Matrix session");
+            return;
+        }
+
+        self.print_network("Persisted refreshed Matrix session");
     }
 
     pub fn receive_sso_url(&self, url: &str) {


### PR DESCRIPTION
## Summary

- restore persisted Matrix sessions from secure storage instead of requiring another password login
- persist rotated access and refresh tokens while keeping the existing device and session

## Testing

- `WEECHAT_BUNDLED=1 cargo test --locked --lib` with Rust 1.96.1: 91 passed