### PR TITLE
Preload history for restored Matrix rooms

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -58,6 +58,7 @@ use crate::{
 
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const SSO_CALLBACK_PORT: u16 = 29_325;
+const HISTORY_BATCH_SIZE: u16 = 200;
 
 pub struct InteractiveAuthInfo {
     pub user: String,
@@ -253,14 +254,15 @@ impl Connection {
         prev_batch: PrevBatch,
     ) -> MatrixResult<Messages> {
         self.spawn(async move {
-            let request = match &prev_batch {
+            let mut request = match &prev_batch {
                 PrevBatch::Backwards(t) => {
-                    MessagesOptions::backward().from(Some(t.as_ref()))
+                    MessagesOptions::backward().from(t.as_deref())
                 }
                 PrevBatch::Forward(t) => {
                     MessagesOptions::forward().from(Some(t.as_ref()))
                 }
             };
+            request.limit = HISTORY_BATCH_SIZE.into();
 
             room.messages(request).await
         })

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -108,11 +108,15 @@ pub(super) fn active_room(room: &SharedRoom) -> Room {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PrevBatch {
     Forward(String),
-    Backwards(String),
+    Backwards(Option<String>),
 }
 
 fn restored_prev_batch(prev_batch: Option<String>) -> Option<PrevBatch> {
-    prev_batch.map(PrevBatch::Backwards)
+    // A restored SDK room does not always have a sync pagination token in its
+    // store. Matrix permits a backward /messages request without `from`, which
+    // starts at the newest visible event. Keep that request representable so a
+    // freshly restored room can still populate its WeeChat buffer.
+    Some(PrevBatch::Backwards(prev_batch))
 }
 
 fn should_render_event(already_rendered: bool) -> bool {
@@ -388,9 +392,9 @@ impl RoomHandle {
             room_id: room_id.into(),
             connection: connection.clone(),
             config,
-            prev_batch: Rc::new(RefCell::new(
-                sdk_room.last_prev_batch().map(PrevBatch::Backwards),
-            )),
+            prev_batch: Rc::new(RefCell::new(restored_prev_batch(
+                sdk_room.last_prev_batch(),
+            ))),
             latest_event_id: Rc::new(RefCell::new(None)),
             latest_read_event_id: Rc::new(RefCell::new(None)),
             latest_thread_event_ids: Rc::new(RefCell::new(HashMap::new())),
@@ -1449,12 +1453,14 @@ impl MatrixRoom {
                 let mut prev_batch = self.prev_batch.borrow_mut();
 
                 if let Some(PrevBatch::Forward(t)) = prev_batch.as_ref() {
-                    *prev_batch = Some(PrevBatch::Backwards(t.to_owned()));
+                    *prev_batch =
+                        Some(PrevBatch::Backwards(Some(t.to_owned())));
                     self.buffer.sort_messages();
                 } else if r.chunk.is_empty() {
                     *prev_batch = None;
                 } else {
-                    *prev_batch = r.end.map(PrevBatch::Backwards);
+                    *prev_batch =
+                        r.end.map(|token| PrevBatch::Backwards(Some(token)));
                     self.buffer.sort_messages();
                 }
             }
@@ -1675,7 +1681,7 @@ impl MatrixRoom {
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             if buffer.num_lines() == 0 {
                 *self.prev_batch.borrow_mut() =
-                    self.room().last_prev_batch().map(PrevBatch::Backwards);
+                    restored_prev_batch(self.room().last_prev_batch());
             }
         }
     }
@@ -1800,13 +1806,13 @@ mod tests {
     fn restored_rooms_fetch_history_backwards_from_prev_batch() {
         assert_eq!(
             restored_prev_batch(Some("token".to_owned())),
-            Some(PrevBatch::Backwards("token".to_owned()))
+            Some(PrevBatch::Backwards(Some("token".to_owned())))
         );
     }
 
     #[test]
-    fn restored_rooms_without_prev_batch_have_no_history_request() {
-        assert_eq!(restored_prev_batch(None), None);
+    fn restored_rooms_without_prev_batch_fetch_history_from_end() {
+        assert_eq!(restored_prev_batch(None), Some(PrevBatch::Backwards(None)));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -875,7 +875,13 @@ impl InnerServer {
             Ok(buffer) => {
                 let room_id = buffer.room_id().to_owned();
 
-                self.rooms.borrow_mut().insert(room_id, buffer);
+                self.rooms.borrow_mut().insert(room_id, buffer.clone());
+
+                // Relay-native frontends select buffers without triggering
+                // WeeChat's buffer_switch signal. Populate restored Matrix
+                // buffers proactively instead of waiting for a TUI-only hook.
+                Weechat::spawn(async move { buffer.get_messages().await })
+                    .detach();
             }
             Err(e) => self.print_error(&format!("Error restoring room: {}", e)),
         }


### PR DESCRIPTION
## Summary

- request backwards history for restored rooms from their saved `prev_batch` token
- preload that history while the initial sync is being established so a restarted client does not show an empty timeline

## Testing

- `WEECHAT_BUNDLED=1 cargo test --locked --lib` with Rust 1.96.1: 91 passed