### PR TITLE
Expose Matrix room avatars, member profiles, and semantic mentions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
 name = "weechat-matrix"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "clap",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = []
 
 [dependencies]
 clap = "2.34.0"
+base64 = "0.22"
 chrono = "0.4.22"
 dashmap = "6.1.0"
 url = "2.3.1"

--- a/src/commands/mention_send.rs
+++ b/src/commands/mention_send.rs
@@ -1,0 +1,135 @@
+use std::{borrow::Cow, convert::TryFrom};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use matrix_sdk::ruma::OwnedUserId;
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    Prefix, ReturnCode, Weechat,
+};
+
+use crate::{Servers, PLUGIN_NAME};
+
+pub struct MentionSendCommand {
+    servers: Servers,
+}
+
+impl MentionSendCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/matrix-send *",
+            MentionSendCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+
+    fn parse_payload(
+        encoded: &str,
+    ) -> Result<(String, Vec<OwnedUserId>), String> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .map_err(|_| "invalid encoded mention payload".to_owned())?;
+        let payload: serde_json::Value = serde_json::from_slice(&bytes)
+            .map_err(|_| "invalid mention payload".to_owned())?;
+        let body = payload
+            .get("body")
+            .and_then(|value| value.as_str())
+            .filter(|body| !body.is_empty())
+            .ok_or_else(|| "mention message body is empty".to_owned())?
+            .to_owned();
+        let user_ids = payload
+            .get("user_ids")
+            .and_then(|value| value.as_array())
+            .ok_or_else(|| "mention payload has no user IDs".to_owned())?
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .ok_or_else(|| "mention user ID is not a string".to_owned())
+                    .and_then(|value| {
+                        OwnedUserId::try_from(value).map_err(|_| {
+                            format!("invalid Matrix user ID: {}", value)
+                        })
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if user_ids.is_empty() {
+            return Err("mention payload has no user IDs".to_owned());
+        }
+
+        Ok((body, user_ids))
+    }
+
+    fn print_error(buffer: &Buffer, message: &str) {
+        buffer.print(&format!(
+            "{}{}: {}",
+            Weechat::prefix(Prefix::Error),
+            PLUGIN_NAME,
+            message
+        ));
+    }
+}
+
+impl CommandRunCallback for MentionSendCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        command: Cow<str>,
+    ) -> ReturnCode {
+        let Some(room) = self.servers.find_room(buffer) else {
+            return ReturnCode::Ok;
+        };
+        let Some(encoded) = command
+            .strip_prefix("/matrix-send ")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            Self::print_error(buffer, "missing mention payload");
+            return ReturnCode::OkEat;
+        };
+        let (body, user_ids) = match Self::parse_payload(encoded) {
+            Ok(payload) => payload,
+            Err(error) => {
+                Self::print_error(buffer, &error);
+                return ReturnCode::OkEat;
+            }
+        };
+        let content = room.mention_message_content(buffer, body, user_ids);
+
+        Weechat::spawn(async move { room.send_message(content).await })
+            .detach();
+
+        ReturnCode::OkEat
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use matrix_sdk::ruma::owned_user_id;
+
+    use super::MentionSendCommand;
+
+    #[test]
+    fn mention_payload_keeps_body_and_matrix_ids() {
+        let encoded = URL_SAFE_NO_PAD.encode(
+            br#"{"body":"hello @Ada","user_ids":["@ada:example.org"]}"#,
+        );
+        let (body, user_ids) =
+            MentionSendCommand::parse_payload(&encoded).unwrap();
+
+        assert_eq!(body, "hello @Ada");
+        assert_eq!(user_ids, vec![owned_user_id!("@ada:example.org")]);
+    }
+
+    #[test]
+    fn mention_payload_rejects_non_matrix_ids() {
+        let encoded =
+            URL_SAFE_NO_PAD.encode(br#"{"body":"hello","user_ids":["Ada"]}"#);
+
+        assert!(MentionSendCommand::parse_payload(&encoded).is_err());
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod keys;
 mod matrix;
 mod me;
 mod media;
+mod mention_send;
 mod moderation;
 mod names;
 mod nick;
@@ -43,6 +44,7 @@ use keys::KeysCommand;
 use matrix::MatrixCommand;
 use me::MeCommand;
 use media::MediaCommand;
+use mention_send::MentionSendCommand;
 use moderation::ModerationCommand;
 use names::NamesCommand;
 use nick::NickCommand;
@@ -56,6 +58,7 @@ use verify::VerifyCommand;
 
 pub struct Commands {
     _matrix: Command,
+    _mention_send: CommandRun,
     _keys: Command,
     _devices: Command,
     _invite: Command,
@@ -87,6 +90,7 @@ impl Commands {
     ) -> Result<Commands, ()> {
         Ok(Commands {
             _matrix: MatrixCommand::create(servers, config)?,
+            _mention_send: MentionSendCommand::create(servers)?,
             _devices: DevicesCommand::create(servers)?,
             _invite: InviteCommand::create(servers)?,
             _ignore: IgnoreCommand::create()?,

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -419,6 +419,22 @@ impl RoomBuffer {
         }
     }
 
+    pub fn update_avatar(&self) {
+        let Some(room) = maybe_active_room(&self.room) else {
+            return;
+        };
+
+        if let Ok(buffer) = self.buffer_handle().upgrade() {
+            buffer.set_localvar(
+                "matrix_avatar_mxc",
+                room.avatar_url()
+                    .as_ref()
+                    .map(|uri| uri.as_str())
+                    .unwrap_or_default(),
+            );
+        }
+    }
+
     pub fn update_parent_spaces(&self) {
         let Some(room) = maybe_active_room(&self.room) else {
             return;

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -68,6 +68,31 @@ fn bounded_member_profiles(
     profiles
 }
 
+fn resolved_room_avatar_mxc(
+    explicit_room_avatar: Option<String>,
+    is_direct: bool,
+    own_user_id: &str,
+    profiles: &[MatrixMemberProfile],
+) -> Option<String> {
+    if explicit_room_avatar.is_some() || !is_direct {
+        return explicit_room_avatar;
+    }
+
+    let mut joined_peers = profiles.iter().filter(|profile| {
+        profile.membership == MembershipState::Join.as_str()
+            && profile.user_id != own_user_id
+    });
+    let peer = joined_peers.next()?;
+
+    // An m.direct room is not necessarily a two-person conversation. Avoid
+    // assigning one arbitrary member's face to a multi-user direct room.
+    if joined_peers.next().is_some() {
+        return None;
+    }
+
+    peer.avatar_mxc.clone()
+}
+
 #[derive(Clone, Debug)]
 pub struct WeechatRoomMember {
     inner: RoomMember,
@@ -162,6 +187,19 @@ impl Members {
                 .map(|entry| entry.value().clone())
                 .collect();
             let profiles = bounded_member_profiles(profiles);
+            let room = active_room(&self.room);
+            let room_avatar = resolved_room_avatar_mxc(
+                room.avatar_url().map(|uri| uri.as_str().to_owned()),
+                buffer
+                    .get_localvar("type")
+                    .is_some_and(|kind| kind == "private"),
+                room.own_user_id().as_str(),
+                &profiles,
+            );
+            buffer.set_localvar(
+                "matrix_avatar_mxc",
+                room_avatar.as_deref().unwrap_or_default(),
+            );
             let profiles: Vec<_> = profiles
                 .into_iter()
                 .map(|profile| {
@@ -542,6 +580,57 @@ mod tests {
         assert_eq!(profiles.len(), MEMBER_PROFILE_LIMIT);
         assert_eq!(profiles.first().unwrap().display_name, "Member 0000");
         assert_eq!(profiles.last().unwrap().display_name, "Member 0511");
+    }
+
+    #[test]
+    fn explicit_room_avatar_wins_for_rooms_and_direct_chats() {
+        let profiles = vec![profile(1, "Peer")];
+        let explicit = Some("mxc://example.org/room-avatar".to_owned());
+
+        assert_eq!(
+            resolved_room_avatar_mxc(
+                explicit.clone(),
+                false,
+                "@me:example.org",
+                &profiles,
+            ),
+            explicit,
+        );
+    }
+
+    #[test]
+    fn one_to_one_direct_chat_uses_the_other_members_avatar() {
+        let mut own = profile(0, "Me");
+        own.user_id = "@me:example.org".to_owned();
+        own.avatar_mxc = Some("mxc://example.org/me".to_owned());
+        let peer = profile(1, "Peer");
+
+        assert_eq!(
+            resolved_room_avatar_mxc(
+                None,
+                true,
+                "@me:example.org",
+                &[own, peer],
+            )
+            .as_deref(),
+            Some("mxc://example.org/avatar1"),
+        );
+    }
+
+    #[test]
+    fn multi_user_direct_room_does_not_choose_an_arbitrary_avatar() {
+        let mut own = profile(0, "Me");
+        own.user_id = "@me:example.org".to_owned();
+
+        assert_eq!(
+            resolved_room_avatar_mxc(
+                None,
+                true,
+                "@me:example.org",
+                &[own, profile(1, "One"), profile(2, "Two")],
+            ),
+            None,
+        );
     }
 }
 

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -99,6 +99,37 @@ impl Members {
         self.nicks.insert(member.user_id().to_owned(), nick);
     }
 
+    pub(super) fn update_mentions_localvar(&self) {
+        let mut candidates: Vec<_> = self
+            .nicks
+            .iter()
+            .map(|entry| {
+                serde_json::json!({
+                    "display_name": entry.value(),
+                    "user_id": entry.key().as_str(),
+                })
+            })
+            .collect();
+        candidates.sort_by(|left, right| {
+            left["display_name"]
+                .as_str()
+                .unwrap_or_default()
+                .to_lowercase()
+                .cmp(
+                    &right["display_name"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_lowercase(),
+                )
+        });
+
+        if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
+            if let Ok(json) = serde_json::to_string(&candidates) {
+                buffer.set_localvar("matrix_mentions", &json);
+            }
+        }
+    }
+
     fn weechat_member(&self, member: RoomMember) -> WeechatRoomMember {
         let user_id = member.user_id();
         let sdk_room = active_room(&self.room);
@@ -215,6 +246,7 @@ impl Members {
         }
 
         self.update_member(user_id).await;
+        self.update_mentions_localvar();
     }
 
     /// Remove a Weechat room member by user ID.
@@ -251,6 +283,7 @@ impl Members {
         if let Some((_, nick)) = self.nicks.remove(user_id) {
             buffer.remove_nick(&nick);
         }
+        self.update_mentions_localvar();
     }
 
     /// Retrieve a reference to a Weechat room member by user ID.

--- a/src/room/members.rs
+++ b/src/room/members.rs
@@ -36,9 +36,36 @@ pub struct Members {
     pub(super) runtime: Handle,
     ambiguity_map: Rc<DashMap<OwnedUserId, bool>>,
     nicks: Rc<DashMap<OwnedUserId, String>>,
+    profiles: Rc<DashMap<OwnedUserId, MatrixMemberProfile>>,
     last_active: Rc<DashMap<OwnedUserId, MilliSecondsSinceUnixEpoch>>,
     config: Rc<RefCell<Config>>,
     buffer: RoomBuffer,
+}
+
+const MEMBER_PROFILE_LIMIT: usize = 512;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MatrixMemberProfile {
+    user_id: String,
+    display_name: String,
+    nick: String,
+    membership: String,
+    role: String,
+    power_level: Option<i64>,
+    avatar_mxc: Option<String>,
+}
+
+fn bounded_member_profiles(
+    mut profiles: Vec<MatrixMemberProfile>,
+) -> Vec<MatrixMemberProfile> {
+    profiles.sort_by(|left, right| {
+        left.display_name
+            .to_lowercase()
+            .cmp(&right.display_name.to_lowercase())
+            .then_with(|| left.user_id.cmp(&right.user_id))
+    });
+    profiles.truncate(MEMBER_PROFILE_LIMIT);
+    profiles
 }
 
 #[derive(Clone, Debug)]
@@ -66,6 +93,7 @@ impl Members {
             room,
             runtime,
             nicks: DashMap::new().into(),
+            profiles: DashMap::new().into(),
             ambiguity_map: DashMap::new().into(),
             last_active: DashMap::new().into(),
             config,
@@ -99,7 +127,7 @@ impl Members {
         self.nicks.insert(member.user_id().to_owned(), nick);
     }
 
-    pub(super) fn update_mentions_localvar(&self) {
+    pub(super) fn update_member_localvars(&self) {
         let mut candidates: Vec<_> = self
             .nicks
             .iter()
@@ -126,6 +154,30 @@ impl Members {
         if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
             if let Ok(json) = serde_json::to_string(&candidates) {
                 buffer.set_localvar("matrix_mentions", &json);
+            }
+
+            let profiles: Vec<_> = self
+                .profiles
+                .iter()
+                .map(|entry| entry.value().clone())
+                .collect();
+            let profiles = bounded_member_profiles(profiles);
+            let profiles: Vec<_> = profiles
+                .into_iter()
+                .map(|profile| {
+                    serde_json::json!({
+                        "user_id": profile.user_id,
+                        "display_name": profile.display_name,
+                        "nick": profile.nick,
+                        "membership": profile.membership,
+                        "role": profile.role,
+                        "power_level": profile.power_level,
+                        "avatar_mxc": profile.avatar_mxc,
+                    })
+                })
+                .collect();
+            if let Ok(json) = serde_json::to_string(&profiles) {
+                buffer.set_localvar("matrix_members_v1", &json);
             }
         }
     }
@@ -192,6 +244,8 @@ impl Members {
         }
 
         let member = self.weechat_member(member);
+        self.profiles
+            .insert(member.user_id().to_owned(), member.profile());
         self.add_nick(&buffer, &member);
     }
 
@@ -246,7 +300,7 @@ impl Members {
         }
 
         self.update_member(user_id).await;
-        self.update_mentions_localvar();
+        self.update_member_localvars();
     }
 
     /// Remove a Weechat room member by user ID.
@@ -283,7 +337,8 @@ impl Members {
         if let Some((_, nick)) = self.nicks.remove(user_id) {
             buffer.remove_nick(&nick);
         }
-        self.update_mentions_localvar();
+        self.profiles.remove(user_id);
+        self.update_member_localvars();
     }
 
     /// Retrieve a reference to a Weechat room member by user ID.
@@ -461,7 +516,56 @@ impl Members {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(index: usize, display_name: &str) -> MatrixMemberProfile {
+        MatrixMemberProfile {
+            user_id: format!("@user{index}:example.org"),
+            display_name: display_name.to_owned(),
+            nick: display_name.to_owned(),
+            membership: "join".to_owned(),
+            role: "member".to_owned(),
+            power_level: Some(0),
+            avatar_mxc: Some(format!("mxc://example.org/avatar{index}")),
+        }
+    }
+
+    #[test]
+    fn profile_export_is_sorted_and_bounded() {
+        let profiles = (0..MEMBER_PROFILE_LIMIT + 20)
+            .rev()
+            .map(|index| profile(index, &format!("Member {index:04}")))
+            .collect();
+        let profiles = bounded_member_profiles(profiles);
+        assert_eq!(profiles.len(), MEMBER_PROFILE_LIMIT);
+        assert_eq!(profiles.first().unwrap().display_name, "Member 0000");
+        assert_eq!(profiles.last().unwrap().display_name, "Member 0511");
+    }
+}
+
 impl WeechatRoomMember {
+    fn profile(&self) -> MatrixMemberProfile {
+        let power_level = match self.inner.power_level() {
+            UserPowerLevel::Infinite => None,
+            UserPowerLevel::Int(level) => Some(level.into()),
+            _ => None,
+        };
+        MatrixMemberProfile {
+            user_id: self.user_id().as_str().to_owned(),
+            display_name: self.inner.name().to_owned(),
+            nick: self.nick(),
+            membership: self.inner.membership().as_str().to_owned(),
+            role: self.role().to_owned(),
+            power_level,
+            avatar_mxc: self
+                .inner
+                .avatar_url()
+                .map(|uri| uri.as_str().to_owned()),
+        }
+    }
+
     pub fn user_id(&self) -> &UserId {
         self.inner.user_id()
     }
@@ -485,6 +589,16 @@ impl WeechatRoomMember {
             p if p >= Int::from(50) => "001|h",
             p if p > Int::from(0) => "002|v",
             _ => "999|...",
+        }
+    }
+
+    fn role(&self) -> &'static str {
+        match self.inner.normalized_power_level() {
+            UserPowerLevel::Infinite => "admin",
+            p if p >= Int::from(100) => "admin",
+            p if p >= Int::from(50) => "moderator",
+            p if p > Int::from(0) => "power user",
+            _ => "member",
         }
     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -315,6 +315,16 @@ fn make_emote_message_content(
     content
 }
 
+fn with_mentions(
+    mut content: RoomMessageEventContent,
+    mentioned_user_ids: Vec<OwnedUserId>,
+) -> RoomMessageEventContent {
+    content.mentions = Some(matrix_sdk::ruma::events::Mentions::with_user_ids(
+        mentioned_user_ids,
+    ));
+    content
+}
+
 fn thread_root_from_buffer(buffer: &Buffer) -> Option<OwnedEventId> {
     buffer
         .get_localvar("thread_root")
@@ -529,6 +539,7 @@ impl RoomHandle {
             trace!("Restoring member {}", &user_id);
             room_buffer.members.restore_member(user_id).await;
         }
+        room_buffer.members.update_mentions_localvar();
 
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();
@@ -560,6 +571,27 @@ impl BufferInputCallbackAsync for MatrixRoom {
 }
 
 impl MatrixRoom {
+    pub(crate) fn mention_message_content(
+        &self,
+        buffer: &Buffer,
+        input: String,
+        mentioned_user_ids: Vec<OwnedUserId>,
+    ) -> RoomMessageEventContent {
+        let thread_root = thread_root_from_buffer(buffer);
+        let latest_thread_event = thread_root.as_ref().and_then(|root| {
+            self.latest_thread_event_ids.borrow().get(root).cloned()
+        });
+        with_mentions(
+            make_text_message_content(
+                input,
+                self.config.borrow().input().markdown_input(),
+                thread_root,
+                latest_thread_event,
+            ),
+            mentioned_user_ids,
+        )
+    }
+
     pub fn owns_buffer(&self, buffer: &Buffer) -> bool {
         self.buffer.owns_buffer(buffer)
     }
@@ -1808,6 +1840,24 @@ mod tests {
             restored_prev_batch(Some("token".to_owned())),
             Some(PrevBatch::Backwards(Some("token".to_owned())))
         );
+    }
+
+    #[test]
+    fn accepted_mentions_become_matrix_mentions() {
+        let user_id = UserId::parse("@ada:example.org").unwrap();
+        let content =
+            with_mentions(text_content("hello @Ada"), vec![user_id.clone()]);
+
+        let mentions = content.mentions.expect("m.mentions");
+        assert!(mentions.user_ids.contains(&user_id));
+        assert!(!mentions.room);
+
+        let json = serde_json::to_value(with_mentions(
+            text_content("hello @Ada"),
+            vec![user_id],
+        ))
+        .unwrap();
+        assert_eq!(json["m.mentions"]["user_ids"][0], "@ada:example.org");
     }
 
     #[test]

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -539,7 +539,7 @@ impl RoomHandle {
             trace!("Restoring member {}", &user_id);
             room_buffer.members.restore_member(user_id).await;
         }
-        room_buffer.members.update_mentions_localvar();
+        room_buffer.members.update_member_localvars();
 
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -483,6 +483,24 @@ impl RoomHandle {
                 .unwrap_or_default(),
         );
         buffer.set_localvar("room_id", room.room_id().as_str());
+        buffer.set_localvar("matrix_upload_v1", "1");
+        let sdk_room = room.room();
+        buffer.set_localvar(
+            "matrix_predecessor_room_id",
+            sdk_room
+                .predecessor_room()
+                .as_ref()
+                .map(|predecessor| predecessor.room_id.as_str())
+                .unwrap_or_default(),
+        );
+        buffer.set_localvar(
+            "matrix_replacement_room_id",
+            sdk_room
+                .successor_room()
+                .as_ref()
+                .map(|successor| successor.room_id.as_str())
+                .unwrap_or_default(),
+        );
         let room_avatar = room.room().avatar_url();
         buffer.set_localvar(
             "matrix_avatar_mxc",
@@ -1825,6 +1843,18 @@ impl MatrixRoom {
             AnySyncStateEvent::RoomCanonicalAlias(_) => {
                 self.buffer.set_alias();
                 self.buffer.update_buffer_name();
+            }
+            AnySyncStateEvent::RoomTombstone(_) => {
+                if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
+                    buffer.set_localvar(
+                        "matrix_replacement_room_id",
+                        self.room()
+                            .successor_room()
+                            .as_ref()
+                            .map(|successor| successor.room_id.as_str())
+                            .unwrap_or_default(),
+                    );
+                }
             }
             AnySyncStateEvent::SpaceParent(_) => {
                 self.buffer.update_parent_spaces()

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -483,6 +483,14 @@ impl RoomHandle {
                 .unwrap_or_default(),
         );
         buffer.set_localvar("room_id", room.room_id().as_str());
+        let room_avatar = room.room().avatar_url();
+        buffer.set_localvar(
+            "matrix_avatar_mxc",
+            room_avatar
+                .as_ref()
+                .map(|uri| uri.as_str())
+                .unwrap_or_default(),
+        );
         if room.is_direct() {
             buffer.set_localvar("type", "private")
         } else {
@@ -1808,6 +1816,10 @@ impl MatrixRoom {
             .mark_active(event.sender(), event.origin_server_ts());
 
         match event {
+            AnySyncStateEvent::RoomAvatar(_) => {
+                self.buffer.update_avatar();
+                self.members.update_member_localvars();
+            }
             AnySyncStateEvent::RoomName(_) => self.buffer.update_buffer_name(),
             AnySyncStateEvent::RoomTopic(_) => self.buffer.set_topic(),
             AnySyncStateEvent::RoomCanonicalAlias(_) => {


### PR DESCRIPTION
## Summary

- expose each Matrix room's avatar as `matrix_avatar_mxc` for relay UIs; when a one-to-one direct chat has no room avatar, use the sole other joined member's avatar
- keep rooms without an image explicit and never choose an arbitrary face for multi-user direct chats
- expose joined-room members as structured mention candidates for relay clients
- add `/matrix-send`, accepting a URL-safe base64 JSON payload and sending standard `m.mentions` metadata
- validate mentioned Matrix user IDs and cover the command payload and event content
- expose a deterministic, bounded `matrix_members_v1` profile list for native relay UIs, including exact Matrix ID, display name, disambiguated room nick, membership, role, power level, and avatar MXC URI
- keep credentials and media bytes out of relay metadata; consumers continue to download MXC content through the authenticated Matrix media command

Profile metadata is capped at 512 joined members, sorted by display name and Matrix ID, and refreshed with the existing member-localvar update path. Room-avatar metadata is initialized with the buffer and refreshed on room-avatar and membership changes.

The native sidebar consumer and aggregate UI smoke live in rnocx/WeeChatRS#18.

## Testing

- `cargo test --locked --release` with Rust 1.96 in Debian Bookworm and the WeeChat 4.9.5 API header: 98 passed
- `profile_export_is_sorted_and_bounded` covers deterministic order and the 512-member cap
- focused room-avatar tests cover explicit room images, one-to-one member fallback, and the multi-user-direct negative control

## Update: room upgrade relationships

- Expose Matrix predecessor and replacement room IDs as structured buffer local variables alongside the existing avatar, profile, and semantic-mention metadata.
- This lets relay GUIs represent an upgrade chain as one current chat with predecessor history instead of showing both physical rooms as current.
- `git diff --check` passes. The integrated backend composite containing this change passed all 101 tests, and all four exact-head build-test-release jobs are green.