### PR TITLE
Fix Matrix tokens stored with literal quotes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -107,6 +107,16 @@ use crate::{
     ConfigHandle, Servers, PLUGIN_NAME,
 };
 
+fn secure_set_token_command(name: &str, token: &str) -> Option<String> {
+    let safe = !token.is_empty()
+        && token.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '.' | '_' | '~' | '+' | '/' | '=')
+        });
+
+    safe.then(|| format!("/secure set {name} {token}"))
+}
+
 fn with_entered_runtime_until_final_drop<F>(
     runtime: Rc<tokio::runtime::Runtime>,
     f: F,
@@ -1374,15 +1384,17 @@ impl InnerServer {
             return;
         };
 
-        let quote = |value: &str| {
-            format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+        let Some(access_command) =
+            secure_set_token_command(&access_name, &tokens.access_token)
+        else {
+            self.print_error(
+                "Refusing to persist an invalid Matrix access token",
+            );
+            return;
         };
 
         let commands = [
-            format!(
-                "/secure set {access_name} {}",
-                quote(&tokens.access_token)
-            ),
+            access_command,
             format!(
                 "/set matrix-rust.server.{}.access_token \
                  \"${{sec.data.{access_name}}}\"",
@@ -1400,8 +1412,17 @@ impl InnerServer {
         }
 
         if let Some(refresh_token) = tokens.refresh_token {
+            let Some(refresh_command) =
+                secure_set_token_command(&refresh_name, &refresh_token)
+            else {
+                self.print_error(
+                    "Refusing to persist an invalid Matrix refresh token",
+                );
+                return;
+            };
+
             let commands = [
-                format!("/secure set {refresh_name} {}", quote(&refresh_token)),
+                refresh_command,
                 format!(
                     "/set matrix-rust.server.{}.refresh_token \
                      \"${{sec.data.{refresh_name}}}\"",
@@ -2381,7 +2402,7 @@ impl InnerServer {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_room_request, missing_alias_action,
+        create_room_request, missing_alias_action, secure_set_token_command,
         with_entered_runtime_until_drop, InnerServer, MissingAliasAction,
     };
     use matrix_sdk::ruma::{OwnedRoomAliasId, OwnedUserId};
@@ -2409,6 +2430,34 @@ mod tests {
 
             self.0.store(context, Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn secure_token_command_does_not_store_literal_quotes() {
+        assert_eq!(
+            secure_set_token_command(
+                "matrix_access_token",
+                "syt_Abc-123._~+/="
+            )
+            .as_deref(),
+            Some("/secure set matrix_access_token syt_Abc-123._~+/=")
+        );
+    }
+
+    #[test]
+    fn secure_token_command_rejects_command_delimiters() {
+        assert_eq!(
+            secure_set_token_command("matrix_access_token", "\"syt_token\""),
+            None
+        );
+        assert_eq!(
+            secure_set_token_command("matrix_access_token", "syt token"),
+            None
+        );
+        assert_eq!(
+            secure_set_token_command("matrix_access_token", "syt\n/set x y"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist Matrix access and refresh tokens without adding literal quote characters to the secure value
- reject tokens containing command delimiters before issuing `/secure set`
- keep the server options pointing at the corresponding `sec.data` entries

## Root cause

The session persistence added by poljar/weechat-matrix-rs#263 wrapped token values in quotes when constructing the WeeChat command. Those quotes became part of the stored secret, so the restored bearer token was rejected after a plugin reload.

## Validation

- `rustfmt --edition 2018 --check src/server.rs`
- `cargo test --locked --release --lib` (93 passed)
- `cargo build --locked --release`
