### PR TITLE
Load complete Matrix threads and expose reply context

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -4,6 +4,7 @@ use clap::{
 };
 use url::Url;
 
+use matrix_sdk::ruma::EventId;
 use weechat::{
     buffer::Buffer,
     hooks::{Command, CommandCallback, CommandSettings},
@@ -48,6 +49,7 @@ impl MatrixCommand {
             .add_argument("sso-complete <server-name> <login-token>")
             .add_argument("history")
             .add_argument("read")
+            .add_argument("thread <event-id>")
             .add_argument("version")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
             .arguments_description(format!(
@@ -59,6 +61,7 @@ impl MatrixCommand {
 sso-complete: Finish SSO login with a copied loginToken.
      history: Load an older page of messages in the current room.
         read: Mark the current room as read.
+      thread: Open a thread buffer and load its complete history.
      version: Show version information about weechat-matrix.
      devices: {}
         keys: {}
@@ -86,8 +89,9 @@ Use /matrix [command] help to find out more.\n",
             .add_completion("disconnect %(matrix_servers)")
             .add_completion("reconnect %(matrix_servers)")
             .add_completion("sso-complete %(matrix_servers)")
+            .add_completion("thread")
             .add_completion(
-                "help server|connect|disconnect|reconnect|join|sso-complete|read|version|keys|devices|media|verify|verification",
+                "help server|connect|disconnect|reconnect|join|sso-complete|read|thread|version|keys|devices|media|verify|verification",
             );
 
         Command::new(
@@ -276,6 +280,42 @@ Use /matrix [command] help to find out more.\n",
         }
     }
 
+    fn thread_command(&self, buffer: &Buffer, args: &ArgMatches) {
+        let Some(room) = self.servers.find_room(buffer) else {
+            Weechat::print(&format!(
+                "{}{}: Run /matrix thread from a Matrix room buffer.",
+                Weechat::prefix(Prefix::Error),
+                PLUGIN_NAME,
+            ));
+            return;
+        };
+        let event_id = args
+            .value_of("event-id")
+            .expect("Event ID not set but was required");
+        let Ok(event_id) = EventId::parse(event_id) else {
+            Weechat::print(&format!(
+                "{}{}: Invalid Matrix event ID: {}",
+                Weechat::prefix(Prefix::Error),
+                PLUGIN_NAME,
+                event_id,
+            ));
+            return;
+        };
+
+        if let Some(handle) = room.open_thread_buffer(&event_id) {
+            if let Ok(thread_buffer) = handle.upgrade() {
+                thread_buffer.switch_to();
+            }
+        } else {
+            Weechat::print(&format!(
+                "{}{}: Event {} is not loaded in this room.",
+                Weechat::prefix(Prefix::Error),
+                PLUGIN_NAME,
+                event_id,
+            ));
+        }
+    }
+
     fn run(&self, buffer: &Buffer, args: &ArgMatches) {
         match args.subcommand() {
             ("connect", Some(subargs)) => self.connect_command(subargs),
@@ -328,6 +368,7 @@ Use /matrix [command] help to find out more.\n",
                 })
                 .detach();
             }
+            ("thread", Some(subargs)) => self.thread_command(buffer, subargs),
             ("version", _) => {
                 Weechat::print(&format!(
                     "{}: weechat-matrix version {} ({})",
@@ -466,6 +507,15 @@ impl CommandCallback for MatrixCommand {
                 SubCommand::with_name("history").about(
                     "Load an older page of messages in the current room.",
                 ),
+            )
+            .subcommand(
+                SubCommand::with_name("thread")
+                    .about("Open a thread buffer and load its history.")
+                    .arg(
+                        Arg::with_name("event-id")
+                            .value_name("event-id")
+                            .required(true),
+                    ),
             )
             .subcommand(
                 SubCommand::with_name("version")

--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -1,7 +1,7 @@
 use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg};
 use matrix_sdk::ruma::{
     events::{
-        relation::InReplyTo,
+        relation::{InReplyTo, Thread},
         room::message::{Relation, RoomMessageEventContent},
     },
     EventId, OwnedEventId,
@@ -138,8 +138,12 @@ impl ReplyCommand {
 
     fn reply(&self, buffer: &Buffer, event_id: OwnedEventId, message: String) {
         if let Some(room) = self.servers.find_room(buffer) {
+            let thread_root = buffer
+                .get_localvar("thread_root")
+                .and_then(|root| EventId::parse(root.as_ref()).ok());
             Weechat::spawn(async move {
-                room.send_message(reply_content(event_id, message)).await
+                room.send_message(reply_content(event_id, message, thread_root))
+                    .await
             })
             .detach();
         } else {
@@ -173,10 +177,16 @@ impl CommandCallback for ReplyCommand {
 fn reply_content(
     event_id: OwnedEventId,
     message: String,
+    thread_root: Option<OwnedEventId>,
 ) -> RoomMessageEventContent {
     let mut content = RoomMessageEventContent::text_plain(message);
-    content.relates_to = Some(Relation::Reply {
-        in_reply_to: InReplyTo::new(event_id),
+    content.relates_to = Some(match thread_root {
+        Some(thread_root) => {
+            Relation::Thread(Thread::plain(thread_root, event_id))
+        }
+        None => Relation::Reply {
+            in_reply_to: InReplyTo::new(event_id),
+        },
     });
     content
 }
@@ -200,7 +210,8 @@ mod tests {
     #[test]
     fn reply_content_sets_reply_relation() {
         let event_id = owned_event_id!("$replyevent:example.org");
-        let content = reply_content(event_id.clone(), "Thanks".to_owned());
+        let content =
+            reply_content(event_id.clone(), "Thanks".to_owned(), None);
 
         let Some(Relation::Reply { in_reply_to }) = content.relates_to else {
             panic!("reply command must create a Matrix reply relation");
@@ -233,5 +244,27 @@ mod tests {
             matches.values_of("arguments").unwrap().collect();
 
         assert_eq!(vec!["-2", "message"], arguments);
+    }
+
+    #[test]
+    fn reply_content_keeps_thread_relation_in_thread_buffer() {
+        let event_id = owned_event_id!("$replyevent:example.org");
+        let thread_root = owned_event_id!("$threadroot:example.org");
+        let content = reply_content(
+            event_id.clone(),
+            "Thanks".to_owned(),
+            Some(thread_root.clone()),
+        );
+
+        let Some(Relation::Thread(thread)) = content.relates_to else {
+            panic!("reply from a thread buffer must stay in that thread");
+        };
+
+        assert_eq!(thread_root, thread.event_id);
+        assert_eq!(
+            event_id,
+            thread.in_reply_to.expect("fallback reply target").event_id
+        );
+        assert!(thread.is_falling_back);
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -89,6 +89,7 @@ impl RenderedEvent {
         event_id: &EventId,
         sender: Option<&str>,
         context: ReplyContext,
+        fetched_body: Option<&str>,
     ) -> Self {
         let reply_fallback = self.content.reply_fallback.take();
         let reply_sender = sender
@@ -106,6 +107,11 @@ impl RenderedEvent {
             .map(|line| line.tags.clone())
             .unwrap_or_default();
         tags.push("matrix_reply".to_owned());
+        tags.push(format!(
+            "matrix_reply_sender_hex_{}",
+            hex_encode(reply_sender.as_bytes())
+        ));
+        tags.push(format!("matrix_reply_id_{}", event_id.as_str()));
 
         if context == ReplyContext::Inline {
             if let Some(line) = self.content.lines.first_mut() {
@@ -116,32 +122,60 @@ impl RenderedEvent {
             return self;
         }
 
-        let mut context_lines = match reply_fallback {
-            Some(fallback) => {
+        let quoted_body = reply_fallback
+            .as_ref()
+            .map(|fallback| fallback.body.as_str())
+            .or(fetched_body);
+        let mut context_lines = match quoted_body {
+            Some(body) => {
+                let mut header_tags = tags.clone();
+                header_tags.push("matrix_reply_header".to_owned());
                 let mut lines = vec![RenderedLine {
-                    tags: tags.clone(),
+                    tags: header_tags,
                     message: format!("Reply to {}:", reply_sender),
                 }];
 
-                lines.extend(reply_quote_lines(&fallback.body).map(
-                    |message| RenderedLine {
-                        tags: tags.clone(),
+                lines.extend(reply_quote_lines(body).map(|message| {
+                    let mut quote_tags = tags.clone();
+                    quote_tags.push("matrix_reply_quote".to_owned());
+
+                    RenderedLine {
+                        tags: quote_tags,
                         message,
-                    },
-                ));
+                    }
+                }));
 
                 lines
             }
-            None => vec![RenderedLine {
-                tags,
-                message: format!("Reply to {}", reply_sender),
-            }],
+            None => {
+                tags.push("matrix_reply_header".to_owned());
+                vec![RenderedLine {
+                    tags,
+                    message: format!("Reply to {}", reply_sender),
+                }]
+            }
         };
 
         self.content.lines.splice(0..0, context_lines.drain(..));
 
         self
     }
+
+    pub fn has_reply_fallback(&self) -> bool {
+        self.content.reply_fallback.is_some()
+    }
+}
+
+fn hex_encode(input: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(input.len() * 2);
+
+    for byte in input {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+
+    encoded
 }
 
 #[derive(Debug)]
@@ -1700,6 +1734,7 @@ mod tests {
             &event_id,
             Some("Alice"),
             ReplyContext::Inline,
+            None,
         );
 
         assert_eq!(1, rendered.content.lines.len());
@@ -1707,6 +1742,12 @@ mod tests {
         assert!(rendered.content.lines[0]
             .tags
             .contains(&"matrix_reply".to_owned()));
+        assert!(rendered.content.lines[0]
+            .tags
+            .contains(&"matrix_reply_sender_hex_416c696365".to_owned()));
+        assert!(rendered.content.lines[0]
+            .tags
+            .contains(&"matrix_reply_id_$replyevent:example.org".to_owned()));
     }
 
     #[test]
@@ -1721,7 +1762,7 @@ mod tests {
                 message: "reply body".to_owned(),
             }]),
         }
-        .add_reply_context(&event_id, None, ReplyContext::Inline);
+        .add_reply_context(&event_id, None, ReplyContext::Inline, None);
 
         assert_eq!(
             "> $replyevent:example.org: reply body",
@@ -1756,6 +1797,7 @@ mod tests {
             &event_id,
             Some("Alice"),
             ReplyContext::Full,
+            None,
         );
 
         assert_eq!(3, rendered.content.lines.len());
@@ -1787,7 +1829,7 @@ mod tests {
             prefix: "bob\t".to_owned(),
             content: content.render(&()),
         }
-        .add_reply_context(&event_id, None, ReplyContext::Full);
+        .add_reply_context(&event_id, None, ReplyContext::Full, None);
 
         assert_eq!(
             "Reply to @alice:example.org:",
@@ -1820,6 +1862,7 @@ mod tests {
             &event_id,
             Some("Alice"),
             ReplyContext::Full,
+            None,
         );
 
         let messages = rendered
@@ -1832,6 +1875,39 @@ mod tests {
         assert_eq!(
             vec!["Reply to Alice:", "> line one", "> line two", "new message"],
             messages
+        );
+        assert!(rendered.content.lines[1]
+            .tags
+            .contains(&"matrix_reply_quote".to_owned()));
+    }
+
+    #[test]
+    fn reply_context_uses_fetched_body_without_matrix_fallback() {
+        let event_id =
+            matrix_sdk::ruma::owned_event_id!("$replyevent:example.org");
+        let rendered = RenderedEvent {
+            message_timestamp: 0,
+            prefix: "bob\t".to_owned(),
+            content: RenderedContent::new(vec![RenderedLine {
+                tags: vec!["matrix_text".to_owned()],
+                message: "new message".to_owned(),
+            }]),
+        }
+        .add_reply_context(
+            &event_id,
+            Some("Alice"),
+            ReplyContext::Full,
+            Some("previous message"),
+        );
+
+        assert_eq!(
+            vec!["Reply to Alice:", "> previous message", "new message"],
+            rendered
+                .content
+                .lines
+                .iter()
+                .map(|line| line.message.as_str())
+                .collect::<Vec<_>>()
         );
     }
 
@@ -1859,6 +1935,7 @@ mod tests {
             &event_id,
             Some("Alice"),
             ReplyContext::Inline,
+            None,
         );
 
         assert_eq!(1, rendered.content.lines.len());

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -165,17 +165,6 @@ impl RoomBuffer {
         self.thread_buffers.borrow_mut().remove(thread_root);
     }
 
-    pub fn remove_thread_buffer_for_buffer(&self, buffer: &Buffer) -> bool {
-        let thread_root = self.thread_root_for_buffer(buffer);
-
-        if let Some(thread_root) = thread_root {
-            self.remove_thread_buffer(&thread_root);
-            true
-        } else {
-            false
-        }
-    }
-
     /// Return the sender ID for an event that is still in the buffer.
     ///
     /// Reply rendering uses this local lookup so it never blocks on a
@@ -263,6 +252,23 @@ impl RoomBuffer {
         }
 
         event_ids
+    }
+
+    /// Return whether an event is already rendered in a specific thread
+    /// buffer.
+    pub fn thread_contains_event(
+        &self,
+        thread_root: &EventId,
+        event_id: &EventId,
+    ) -> bool {
+        let event_id_tag = Cow::from(event_id.to_tag());
+        let Some(handle) = self.thread_buffer(thread_root) else {
+            return false;
+        };
+
+        handle
+            .upgrade()
+            .is_ok_and(|buffer| buffer_contains_tag(&buffer, &event_id_tag))
     }
 
     /// Copy the root event line into a newly created thread buffer.
@@ -462,6 +468,17 @@ impl RoomBuffer {
     pub fn sort_messages(&self) {
         if let Ok(buffer) = self.buffer_handle().upgrade() {
             sort_buffer_lines(&buffer, None);
+        }
+    }
+
+    pub fn sort_thread_messages(&self, thread_root: &EventId) {
+        let Some(handle) = self.thread_buffer(thread_root) else {
+            return;
+        };
+
+        if let Ok(buffer) = handle.upgrade() {
+            let root_tag = thread_root.to_tag();
+            sort_buffer_lines(&buffer, Some(root_tag.as_ref()));
         }
     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -141,6 +141,8 @@ const HISTORY_PAGE_TAGS: [&str; 2] =
     ["matrix_history_page", "matrix_smart_filter"];
 const RESTORED_HISTORY_BATCH_SIZE: u16 = 25;
 const INTERACTIVE_HISTORY_BATCH_SIZE: u16 = 25;
+const RESTORED_HISTORY_TARGET_LINES: i32 = 100;
+const RESTORED_HISTORY_MAX_PAGES: usize = 10;
 
 fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
     // The SDK does not replay the stored sync timeline when a room is restored.
@@ -172,6 +174,16 @@ fn history_page_marker(result: &HistoryPageResult) -> String {
             "matrix_history_page added=0 exhausted=0 state=failed".to_owned()
         }
     }
+}
+
+fn should_continue_restored_history(
+    lines_before: i32,
+    lines_after: i32,
+    has_older_page: bool,
+) -> bool {
+    has_older_page
+        && lines_after > lines_before
+        && lines_after < RESTORED_HISTORY_TARGET_LINES
 }
 
 fn should_render_event(already_rendered: bool) -> bool {
@@ -2304,6 +2316,35 @@ impl MatrixRoom {
         }
     }
 
+    pub async fn preload_restored_messages(&self) {
+        for _ in 0..RESTORED_HISTORY_MAX_PAGES {
+            let buffer_handle = self.buffer_handle();
+            let Ok(buffer) = buffer_handle.upgrade() else {
+                return;
+            };
+            let lines_before = buffer.num_lines();
+            drop(buffer);
+
+            self.get_messages().await;
+
+            let buffer_handle = self.buffer_handle();
+            let Ok(buffer) = buffer_handle.upgrade() else {
+                return;
+            };
+            let lines_after = buffer.num_lines();
+            drop(buffer);
+
+            let has_older_page = self.prev_batch.borrow().is_some();
+            if !should_continue_restored_history(
+                lines_before,
+                lines_after,
+                has_older_page,
+            ) {
+                break;
+            }
+        }
+    }
+
     pub async fn get_thread_messages(&self, thread_root: OwnedEventId) {
         if self.thread_history_loaded.borrow().contains(&thread_root)
             || !self
@@ -2937,6 +2978,15 @@ mod tests {
             history_page_marker(&HistoryPageResult::Unavailable),
             "matrix_history_page added=0 exhausted=1 state=unavailable"
         );
+    }
+
+    #[test]
+    fn restored_history_keeps_paging_until_it_is_useful() {
+        assert!(should_continue_restored_history(0, 13, true));
+        assert!(should_continue_restored_history(87, 99, true));
+        assert!(!should_continue_restored_history(99, 112, true));
+        assert!(!should_continue_restored_history(13, 13, true));
+        assert!(!should_continue_restored_history(0, 13, false));
     }
 
     #[test]

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -142,12 +142,12 @@ const HISTORY_PAGE_TAGS: [&str; 2] =
 const RESTORED_HISTORY_BATCH_SIZE: u16 = 25;
 const INTERACTIVE_HISTORY_BATCH_SIZE: u16 = 25;
 
-fn restored_prev_batch(prev_batch: Option<String>) -> Option<PrevBatch> {
-    // A restored SDK room does not always have a sync pagination token in its
-    // store. Matrix permits a backward /messages request without `from`, which
-    // starts at the newest visible event. Keep that request representable so a
-    // freshly restored room can still populate its WeeChat buffer.
-    Some(PrevBatch::Backwards(prev_batch))
+fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
+    // The SDK does not replay the stored sync timeline when a room is restored.
+    // Its last_prev_batch token points before that timeline, so using it here
+    // skips the newest messages entirely. Start at the current room end; the
+    // response's end token will drive older backward pagination afterwards.
+    Some(PrevBatch::Backwards(None))
 }
 
 fn has_history_page(prev_batch: &Option<PrevBatch>) -> bool {
@@ -2872,10 +2872,10 @@ mod tests {
     }
 
     #[test]
-    fn restored_rooms_fetch_history_backwards_from_prev_batch() {
+    fn restored_rooms_fetch_newest_history_before_older_pages() {
         assert_eq!(
             restored_prev_batch(Some("token".to_owned())),
-            Some(PrevBatch::Backwards(Some("token".to_owned())))
+            Some(PrevBatch::Backwards(None))
         );
     }
 
@@ -2996,8 +2996,8 @@ mod tests {
 
     #[test]
     fn reply_event_details_extract_sender_and_body() {
-        let event: AnySyncTimelineEvent = serde_json::from_value(
-            serde_json::json!({
+        let event: AnySyncTimelineEvent =
+            serde_json::from_value(serde_json::json!({
                 "type": "m.room.message",
                 "event_id": "$original:example.org",
                 "sender": "@alice:example.org",
@@ -3007,9 +3007,8 @@ mod tests {
                     "body": "original message"
                 },
                 "unsigned": {}
-            }),
-        )
-        .expect("valid Matrix event");
+            }))
+            .expect("valid Matrix event");
 
         assert_eq!(
             reply_event_details(event),

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -57,12 +57,14 @@ use matrix_sdk::{
     },
     deserialized_responses::AmbiguityChange,
     room::{
+        IncludeRelations, RelationsOptions,
         reply::{EnforceThread, Reply},
         Room,
     },
     ruma::{
+        api::Direction,
         events::{
-            relation::Thread,
+            relation::{RelationType, Thread},
             room::{
                 encrypted::{
                     EncryptedEventScheme, Relation as EncryptedRelation,
@@ -244,6 +246,8 @@ pub struct MatrixRoom {
         Rc<RefCell<HashMap<OwnedEventId, PendingEncryptedEvent>>>,
     pending_encrypted_recoveries:
         Rc<RefCell<HashSet<EncryptedMessageRecovery>>>,
+    thread_history_in_flight: Rc<RefCell<HashSet<OwnedEventId>>>,
+    thread_history_loaded: Rc<RefCell<HashSet<OwnedEventId>>>,
 
     outgoing_messages: MessageQueue,
 
@@ -492,6 +496,29 @@ fn rendered_root_to_seed<'a>(
     }
 }
 
+fn thread_root_from_timeline_event(
+    event: &AnyTimelineEvent,
+) -> Option<OwnedEventId> {
+    match event {
+        AnyTimelineEvent::MessageLike(event) => {
+            event.original_content().and_then(|content| match content {
+                AnyMessageLikeEventContent::RoomMessage(content) => {
+                    thread_root_from_content(&content).map(ToOwned::to_owned)
+                }
+                _ => None,
+            })
+        }
+        AnyTimelineEvent::State(_) => None,
+    }
+}
+
+fn thread_history_page_is_complete(
+    event_count: usize,
+    next_batch_token: Option<&str>,
+) -> bool {
+    event_count == 0 || next_batch_token.is_none()
+}
+
 impl RoomHandle {
     pub fn new(
         server_name: &str,
@@ -540,6 +567,8 @@ impl RoomHandle {
             latest_thread_event_ids: Rc::new(RefCell::new(HashMap::new())),
             pending_encrypted_events: Rc::new(RefCell::new(HashMap::new())),
             pending_encrypted_recoveries: Rc::new(RefCell::new(HashSet::new())),
+            thread_history_in_flight: Rc::new(RefCell::new(HashSet::new())),
+            thread_history_loaded: Rc::new(RefCell::new(HashSet::new())),
             own_user_id: own_user_id.into(),
             members,
             buffer,
@@ -842,8 +871,27 @@ impl MatrixRoom {
         self.send_message(content).await;
     }
 
+    pub fn open_thread_buffer(
+        &self,
+        thread_root: &EventId,
+    ) -> Option<BufferHandle> {
+        if !self.buffer.contains_event(thread_root) {
+            return None;
+        }
+
+        self.get_or_create_thread_buffer(thread_root)
+    }
+
     pub fn close_thread_buffer(&self, buffer: &Buffer) -> bool {
-        if self.buffer.remove_thread_buffer_for_buffer(buffer) {
+        if let Some(thread_root) = self.buffer.thread_root_for_buffer(buffer) {
+            self.buffer.remove_thread_buffer(&thread_root);
+            self.thread_history_in_flight
+                .borrow_mut()
+                .remove(&thread_root);
+            self.thread_history_loaded.borrow_mut().remove(&thread_root);
+            self.latest_thread_event_ids
+                .borrow_mut()
+                .remove(&thread_root);
             buffer.close();
             true
         } else {
@@ -1128,6 +1176,16 @@ impl MatrixRoom {
     ) -> Option<BufferHandle> {
         if let Some(handle) = self.buffer.thread_buffer(thread_root) {
             if handle.upgrade().is_ok() {
+                self.buffer.seed_open_thread_buffer(thread_root);
+                self.buffer.sort_thread_messages(thread_root);
+                if !self.thread_history_loaded.borrow().contains(thread_root)
+                    && !self
+                        .thread_history_in_flight
+                        .borrow()
+                        .contains(thread_root)
+                {
+                    self.fetch_thread_history(thread_root.to_owned());
+                }
                 return Some(handle);
             }
 
@@ -1188,7 +1246,17 @@ impl MatrixRoom {
         self.buffer
             .set_thread_buffer(thread_root.to_owned(), buffer_handle.clone());
 
+        self.fetch_thread_history(thread_root.to_owned());
+
         Some(buffer_handle)
+    }
+
+    fn fetch_thread_history(&self, thread_root: OwnedEventId) {
+        let room = self.clone();
+        Weechat::spawn(async move {
+            room.get_thread_messages(thread_root).await;
+        })
+        .detach();
     }
 
     fn print_rendered_event_for_relation(
@@ -2169,6 +2237,185 @@ impl MatrixRoom {
         }
     }
 
+    pub async fn get_thread_messages(&self, thread_root: OwnedEventId) {
+        if self.thread_history_loaded.borrow().contains(&thread_root)
+            || !self
+                .thread_history_in_flight
+                .borrow_mut()
+                .insert(thread_root.clone())
+        {
+            return;
+        }
+
+        let mut from = None;
+        let mut seen_tokens = HashSet::new();
+        let mut seen_event_ids = HashSet::new();
+        let mut newest_event_id = None;
+        let mut completed = false;
+        let mut request_attempts = 0u8;
+        let Some(connection) = self.connection.borrow().as_ref().cloned()
+        else {
+            self.thread_history_in_flight
+                .borrow_mut()
+                .remove(&thread_root);
+            return;
+        };
+
+        loop {
+            let options = RelationsOptions {
+                from: from.clone(),
+                dir: Direction::Backward,
+                limit: Some(UInt::from(100u8)),
+                include_relations: IncludeRelations::RelationsOfType(
+                    RelationType::Thread,
+                ),
+                recurse: false,
+            };
+
+            let room = self.room();
+            let relation_root = thread_root.clone();
+            let relations = match connection
+                .spawn(
+                    async move { room.relations(relation_root, options).await },
+                )
+                .await
+            {
+                Ok(relations) => relations,
+                Err(error) => {
+                    request_attempts += 1;
+                    if request_attempts < 3 {
+                        let delay = Duration::from_millis(
+                            250 * u64::from(request_attempts),
+                        );
+                        connection
+                            .spawn(
+                                async move { tokio::time::sleep(delay).await },
+                            )
+                            .await;
+                        continue;
+                    }
+                    Weechat::print(&format!(
+                            "{}: Error fetching thread history for {} after {} attempts: {}",
+                            Weechat::prefix(Prefix::Error),
+                            thread_root,
+                            request_attempts,
+                            error,
+                        ));
+                    break;
+                }
+            };
+            request_attempts = 0;
+
+            let room_id = self.room_id.as_ref().to_owned();
+            let mut new_event_count = 0;
+            for event in relations
+                .chunk
+                .iter()
+                .filter_map(|event| event.raw().deserialize().ok())
+            {
+                let event = event.into_full_event(room_id.clone());
+                if !seen_event_ids.insert(event.event_id().to_owned()) {
+                    continue;
+                }
+                new_event_count += 1;
+                if newest_event_id.is_none() {
+                    newest_event_id = Some(event.event_id().to_owned());
+                }
+                self.handle_thread_history_event(&thread_root, &event).await;
+            }
+
+            if thread_history_page_is_complete(
+                new_event_count,
+                relations.next_batch_token.as_deref(),
+            ) {
+                completed = true;
+                break;
+            }
+
+            let Some(next) = relations.next_batch_token else {
+                completed = true;
+                break;
+            };
+            if !seen_tokens.insert(next.clone()) {
+                Weechat::print(&format!(
+                    "{}: Thread history pagination repeated a token for {}",
+                    Weechat::prefix(Prefix::Error),
+                    thread_root,
+                ));
+                break;
+            }
+            from = Some(next);
+        }
+
+        self.thread_history_in_flight
+            .borrow_mut()
+            .remove(&thread_root);
+
+        if completed {
+            self.thread_history_loaded
+                .borrow_mut()
+                .insert(thread_root.clone());
+            if let Some(event_id) = newest_event_id {
+                self.latest_thread_event_ids
+                    .borrow_mut()
+                    .entry(thread_root.clone())
+                    .or_insert(event_id);
+            }
+            self.buffer.seed_open_thread_buffer(&thread_root);
+            self.buffer.sort_thread_messages(&thread_root);
+        }
+    }
+
+    async fn handle_thread_history_event(
+        &self,
+        thread_root: &EventId,
+        event: &AnyTimelineEvent,
+    ) {
+        if thread_root_from_timeline_event(event).as_deref()
+            != Some(thread_root)
+        {
+            return;
+        }
+
+        let AnyTimelineEvent::MessageLike(event) = event else {
+            return;
+        };
+
+        if event.is_edit()
+            || !should_render_event(
+                self.buffer
+                    .thread_contains_event(thread_root, event.event_id()),
+            )
+        {
+            return;
+        }
+
+        let sender =
+            self.members.get(event.sender()).await.expect(
+                "Rendering a message but the sender isn't in the nicklist",
+            );
+        let Some(content) = event.original_content() else {
+            tracing::error!("Unhandled redacted event: {event:?}");
+            return;
+        };
+
+        if let Some(rendered) = self
+            .render_message_content(
+                event.event_id(),
+                event.origin_server_ts(),
+                &sender,
+                &content,
+            )
+            .await
+        {
+            self.print_rendered_event_for_relation(
+                Some(event.event_id()),
+                Some(thread_root),
+                rendered,
+            );
+        }
+    }
+
     async fn handle_outgoing_message(
         &self,
         transaction_id: &TransactionId,
@@ -2424,6 +2671,8 @@ impl MatrixRoom {
     }
 
     pub async fn handle_room_event(&self, event: &AnyTimelineEvent) {
+        let thread_root = thread_root_from_timeline_event(event);
+
         match &event {
             AnyTimelineEvent::MessageLike(event) => {
                 let content = if let Some(content) = event.original_content() {
@@ -2448,13 +2697,19 @@ impl MatrixRoom {
                     );
                 }
 
+                let already_rendered = thread_root.as_ref().map_or_else(
+                    || self.buffer.contains_event(event.event_id()),
+                    |thread_root| {
+                        self.buffer.thread_contains_event(
+                            thread_root,
+                            event.event_id(),
+                        )
+                    },
+                );
+
                 // TODO: Only print out historical events if they aren't edits of
                 // other events.
-                if !event.is_edit()
-                    && should_render_event(
-                        self.buffer.contains_event(event.event_id()),
-                    )
-                {
+                if !event.is_edit() && should_render_event(already_rendered) {
                     let sender = self.members.get(event.sender()).await.expect(
                     "Rendering a message but the sender isn't in the nicklist",
                 );
@@ -2468,8 +2723,11 @@ impl MatrixRoom {
                         )
                         .await
                     {
-                        self.buffer.print_rendered_event(rendered);
-                        self.buffer.seed_open_thread_buffer(event.event_id());
+                        self.print_rendered_event_for_relation(
+                            Some(event.event_id()),
+                            thread_root.as_deref(),
+                            rendered,
+                        );
                     }
                 }
             }
@@ -2731,6 +2989,37 @@ mod tests {
     }
 
     #[test]
+    fn historical_thread_event_keeps_its_root() {
+        let event: AnyTimelineEvent =
+            serde_json::from_value(serde_json::json!({
+                "type": "m.room.message",
+                "room_id": "!room:example.org",
+                "sender": "@alice:example.org",
+                "origin_server_ts": 1,
+                "event_id": "$reply:example.org",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "thread reply",
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$root:example.org",
+                        "is_falling_back": true,
+                        "m.in_reply_to": {
+                            "event_id": "$root:example.org"
+                        }
+                    }
+                },
+                "unsigned": {}
+            }))
+            .unwrap();
+
+        assert_eq!(
+            thread_root_from_timeline_event(&event).as_deref(),
+            Some(EventId::parse("$root:example.org").unwrap().as_ref())
+        );
+    }
+
+    #[test]
     fn thread_reply_is_not_treated_as_another_thread_root() {
         let event_id = EventId::parse("$thread-reply:example.org").unwrap();
         let thread_root = EventId::parse("$thread-root:example.org").unwrap();
@@ -2832,6 +3121,14 @@ mod tests {
             EncryptedEventScheme::MegolmV1AesSha2(ref megolm)
                 if megolm.session_id == "session_id"
         ));
+    }
+
+    #[test]
+    fn empty_thread_history_page_finishes_pagination() {
+        assert!(thread_history_page_is_complete(0, Some("next")));
+        assert!(thread_history_page_is_complete(0, None));
+        assert!(thread_history_page_is_complete(8, None));
+        assert!(!thread_history_page_is_complete(8, Some("next")));
     }
 
     #[test]

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1187,14 +1187,14 @@ impl MatrixRoom {
                         .reply_full_quote_threshold();
                     let context = reply_context_for_distance(
                         threshold,
-                        self.buffer.reply_line_distance(event_id),
+                        self.buffer.reply_line_distance(&event_id),
                     );
 
                     let needs_remote_context = reply_sender.is_none()
                         || (context == ReplyContext::Full
                             && !rendered.has_reply_fallback());
                     let remote_context = if needs_remote_context {
-                        self.load_reply_context(event_id).await
+                        self.load_reply_context(&event_id).await
                     } else {
                         None
                     };
@@ -1216,7 +1216,7 @@ impl MatrixRoom {
                     };
 
                     rendered.add_reply_context(
-                        event_id,
+                        &event_id,
                         reply_sender.as_deref(),
                         context,
                         fetched_body,
@@ -1235,8 +1235,15 @@ impl MatrixRoom {
         &self,
         event_id: &EventId,
     ) -> Option<ResolvedReplyContext> {
-        let timeline_event =
-            self.room().load_or_fetch_event(event_id, None).await.ok()?;
+        let connection = self.connection.borrow().as_ref().cloned()?;
+        let room = self.room();
+        let event_id = event_id.to_owned();
+        let timeline_event = connection
+            .spawn(
+                async move { room.load_or_fetch_event(&event_id, None).await },
+            )
+            .await
+            .ok()?;
         let event = timeline_event.raw().deserialize().ok()?;
         let (sender_id, body) = reply_event_details(event)?;
         let sender = self

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -300,6 +300,29 @@ fn pending_encrypted_event_raw(
     .and_then(|json| Raw::from_json_string(json).ok())
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ResolvedReplyContext {
+    sender: String,
+    body: Option<String>,
+}
+
+fn reply_event_details(
+    event: AnySyncTimelineEvent,
+) -> Option<(OwnedUserId, Option<String>)> {
+    let AnySyncTimelineEvent::MessageLike(event) = event else {
+        return None;
+    };
+    let sender = event.sender().to_owned();
+    let body = match event {
+        AnySyncMessageLikeEvent::RoomMessage(
+            SyncMessageLikeEvent::Original(event),
+        ) => Some(event.content.msgtype.body().to_owned()),
+        _ => None,
+    };
+
+    Some((sender, body))
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct MessageQueue {
     queue: Rc<
@@ -1096,7 +1119,7 @@ impl MatrixRoom {
                             None => None,
                         };
 
-                        Some((&in_reply_to.event_id, sender))
+                        Some((in_reply_to.event_id.clone(), sender))
                     }
                     _ => None,
                 };
@@ -1144,7 +1167,7 @@ impl MatrixRoom {
                     _ => return None,
                 };
 
-                if let Some((event_id, sender)) = reply_to {
+                if let Some((event_id, mut reply_sender)) = reply_to {
                     let threshold = self
                         .config
                         .borrow()
@@ -1155,10 +1178,36 @@ impl MatrixRoom {
                         self.buffer.reply_line_distance(event_id),
                     );
 
+                    let needs_remote_context = reply_sender.is_none()
+                        || (context == ReplyContext::Full
+                            && !rendered.has_reply_fallback());
+                    let remote_context = if needs_remote_context {
+                        self.load_reply_context(event_id).await
+                    } else {
+                        None
+                    };
+
+                    if reply_sender.is_none() {
+                        reply_sender = remote_context
+                            .as_ref()
+                            .map(|context| context.sender.clone());
+                    }
+
+                    let fetched_body = if rendered.has_reply_fallback()
+                        || context == ReplyContext::Inline
+                    {
+                        None
+                    } else {
+                        remote_context
+                            .as_ref()
+                            .and_then(|context| context.body.as_deref())
+                    };
+
                     rendered.add_reply_context(
                         event_id,
-                        sender.as_deref(),
+                        reply_sender.as_deref(),
                         context,
+                        fetched_body,
                     )
                 } else {
                     rendered
@@ -1168,6 +1217,24 @@ impl MatrixRoom {
         };
 
         Some(rendered)
+    }
+
+    async fn load_reply_context(
+        &self,
+        event_id: &EventId,
+    ) -> Option<ResolvedReplyContext> {
+        let timeline_event =
+            self.room().load_or_fetch_event(event_id, None).await.ok()?;
+        let event = timeline_event.raw().deserialize().ok()?;
+        let (sender_id, body) = reply_event_details(event)?;
+        let sender = self
+            .members
+            .get(&sender_id)
+            .await
+            .map(|member| member.nick())
+            .unwrap_or_else(|| sender_id.as_str().to_owned());
+
+        Some(ResolvedReplyContext { sender, body })
     }
 
     fn get_or_create_thread_buffer(
@@ -2924,6 +2991,32 @@ mod tests {
         assert_eq!(
             reply.enforce_thread,
             EnforceThread::Threaded(ReplyWithinThread::No)
+        );
+    }
+
+    #[test]
+    fn reply_event_details_extract_sender_and_body() {
+        let event: AnySyncTimelineEvent = serde_json::from_value(
+            serde_json::json!({
+                "type": "m.room.message",
+                "event_id": "$original:example.org",
+                "sender": "@alice:example.org",
+                "origin_server_ts": 1,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "original message"
+                },
+                "unsigned": {}
+            }),
+        )
+        .expect("valid Matrix event");
+
+        assert_eq!(
+            reply_event_details(event),
+            Some((
+                UserId::parse("@alice:example.org").unwrap(),
+                Some("original message".to_owned())
+            ))
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -973,7 +973,7 @@ impl InnerServer {
                 // WeeChat's buffer_switch signal. Populate restored Matrix
                 // buffers proactively instead of waiting for a TUI-only hook.
                 Weechat::spawn(async move {
-                    buffer.get_messages().await;
+                    buffer.preload_restored_messages().await;
                     buffer.recover_logged_encrypted_events().await;
                 })
                 .detach();


### PR DESCRIPTION
## Summary

- keep historical `m.thread` replies out of the main room timeline
- load the complete relation history when a thread buffer opens
- paginate backwards with bounded retries, duplicate-event suppression, and repeated-token protection
- keep the root first and the replies chronological in the thread buffer
- preserve `m.thread` when `/reply` is used from a thread buffer
- add `/matrix thread <event-id>` for clients that need to open a specific thread
- resolve the referenced Matrix event when a reply is older than WeeChat's local buffer, so reply context has the real sender and quoted body
- run remote reply-context lookups on the Matrix connection runtime instead of polling Matrix SDK network futures on WeeChat's main-thread executor
- expose reply header/quote roles, sender, and target event as structured WeeChat tags while retaining readable text for ordinary WeeChat clients
- restore room history from the newest visible event after a plugin reload, then preload older pages until the buffer has a useful history window

## Why

Thread buffers previously contained only replies seen during the current sync. Older replies loaded through room history were treated as ordinary room events, so they could appear in the main room while the corresponding thread buffer stayed empty or incomplete.

There was a second routing gap: `/reply` always created a plain `m.in_reply_to` relation. When a relay client invoked it from a thread buffer, the reply was therefore posted to the main room instead of the thread.

Reply presentation had a separate history-bound failure. The plugin looked up the referenced sender only in the current WeeChat buffer and fell back to a raw `$event_id` when that line was no longer present. It now loads the referenced event through the Matrix SDK cache or homeserver when needed, then emits optional `matrix_reply_header`, `matrix_reply_quote`, `matrix_reply_sender_hex_*`, and `matrix_reply_id_*` tags. The existing human-readable `Reply to ...` and `> ...` lines remain available to clients that ignore those tags.

The Matrix SDK lookup may perform network I/O and therefore requires a Tokio reactor. Polling it directly from rust-weechat's main-thread executor produced `there is no reactor running` panics while restored reply history was rendered. The lookup now runs through the room's Matrix connection runtime and returns its result to the WeeChat-thread renderer.

Restored rooms also started backward pagination at the SDK's `last_prev_batch` token. That token points before the stored sync timeline, but the SDK does not replay that timeline into a newly restored WeeChat buffer. The result was an old or nearly empty buffer after reload. Restored rooms now request backward history from the current room end first and use the returned `end` token for older pages. Because homeservers may return much less than the requested limit, restoration continues for up to ten bounded pages until the buffer contains at least 100 lines, stopping early at the end or when a request makes no progress.

The thread buffer requests the Matrix relations endpoint for its root and routes both relation history and ordinary room-history events according to their `m.thread` relation. Explicit replies inherit the current thread root while retaining the selected event as their fallback reply target.

This builds on the thread buffers introduced by [poljar/weechat-matrix-rs#206](https://github.com/poljar/weechat-matrix-rs/pull/206) and preserves the root ordering fixes from [poljar/weechat-matrix-rs#255](https://github.com/poljar/weechat-matrix-rs/pull/255). The structured tags are consumed by the optional native presentation in [rnocx/WeeChatRS#15](https://github.com/rnocx/WeeChatRS/pull/15).

## Validation

- `git diff --check`
- Rust 1.96.1 Bookworm container against WeeChat plugin API `20260530-01`: `cargo test --locked --lib` (97 passed)
- focused tests cover newest-first bounded restored history, remote sender/body extraction, fetched-body fallback, structured reply tags, thread pagination, and thread-preserving `/reply`
- manual relay smoke test with a nine-event Matrix thread: one root and eight replies appeared once, in chronological order, while the main room retained only the root
