### PR TITLE
Expose Matrix media metadata to relay clients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crate-type = ["cdylib"]
 default = []
 
 [dependencies]
+base64 = "0.22"
 clap = "2.34.0"
 base64 = "0.22"
 chrono = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ crate-type = ["cdylib"]
 default = []
 
 [dependencies]
-base64 = "0.22"
 clap = "2.34.0"
 base64 = "0.22"
 chrono = "0.4.22"

--- a/src/commands/media.rs
+++ b/src/commands/media.rs
@@ -50,7 +50,7 @@ impl MediaCommand {
 
                 let file = args
                     .value_of("file")
-                    .map(|file| PathBuf::from(Weechat::expand_home(file)))
+                    .map(normalize_download_file)
                     .or_else(|| default_download_file(&uri, &download_prefix));
                 let file = match file {
                     Some(file) => file,
@@ -94,6 +94,22 @@ impl MediaCommand {
         ArgParseSettings::VersionlessSubcommands,
         ArgParseSettings::SubcommandRequiredElseHelp,
     ];
+}
+
+fn normalize_download_file(file: &str) -> PathBuf {
+    PathBuf::from(Weechat::expand_home(strip_download_file_quotes(file)))
+}
+
+fn strip_download_file_quotes(file: &str) -> &str {
+    let file = file.trim();
+    file
+        .strip_prefix('"')
+        .and_then(|file| file.strip_suffix('"'))
+        .or_else(|| {
+            file.strip_prefix('\'')
+                .and_then(|file| file.strip_suffix('\''))
+        })
+        .unwrap_or(file)
 }
 
 fn default_download_file(uri: &MxcUri, prefix: &str) -> Option<PathBuf> {
@@ -179,6 +195,18 @@ mod tests {
         assert_eq!(
             Some(PathBuf::from("matrix-media-some-media-id")),
             default_download_file(&uri, "matrix-media-")
+        );
+    }
+
+    #[test]
+    fn strips_weechat_preserved_quotes_from_download_file() {
+        assert_eq!(
+            "/tmp/a path/image.png",
+            strip_download_file_quotes("\"/tmp/a path/image.png\"")
+        );
+        assert_eq!(
+            "/tmp/a path/image.png",
+            strip_download_file_quotes("'/tmp/a path/image.png'")
         );
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use url::Url;
 
 use matrix_sdk::{
@@ -525,9 +526,33 @@ fn media_download_message<C: HasUrlOrFile>(content: &C) -> Option<String> {
     })
 }
 
+fn media_tags<C: HasUrlOrFile>(content: &C) -> Vec<String> {
+    let mut tags = vec![
+        "matrix_media".to_owned(),
+        format!("matrix_media_kind_{}", content.media_kind()),
+        format!(
+            "matrix_media_name_{}",
+            URL_SAFE_NO_PAD.encode(content.body())
+        ),
+    ];
+
+    if let MediaSource::Plain(uri) = content.source() {
+        tags.push(format!(
+            "matrix_media_uri_{}",
+            URL_SAFE_NO_PAD.encode(uri.as_str())
+        ));
+    }
+
+    tags
+}
+
 impl<C: HasUrlOrFile> Render for C {
     type RenderContext = Url;
     const TAGS: &'static [&'static str] = &["matrix_media"];
+
+    fn tags(&self) -> Vec<String> {
+        media_tags(self)
+    }
 
     fn render(&self, homeserver: &Self::RenderContext) -> RenderedContent {
         // Convert MXC to HTTP(s) or EMXC, but fallback to MXC if unable to.
@@ -1317,6 +1342,8 @@ has_formatted_body!(TextMessageEventContent);
 pub trait HasUrlOrFile {
     fn body(&self) -> &str;
 
+    fn media_kind(&self) -> &'static str;
+
     #[inline]
     fn resolve_url(&self) -> &MxcUri {
         match self.source() {
@@ -1333,10 +1360,14 @@ pub trait HasUrlOrFile {
 // Same as above: a simple macro to implement the trait for structs with `url`
 // and `file` fields.
 macro_rules! has_url_or_file {
-    ($content: ident) => {
+    ($content: ident, $kind: literal) => {
         impl HasUrlOrFile for $content {
             fn body(&self) -> &str {
                 &self.body
+            }
+
+            fn media_kind(&self) -> &'static str {
+                $kind
             }
 
             fn source(&self) -> &MediaSource {
@@ -1353,10 +1384,10 @@ macro_rules! has_url_or_file {
     };
 }
 
-has_url_or_file!(AudioMessageEventContent);
-has_url_or_file!(FileMessageEventContent);
-has_url_or_file!(ImageMessageEventContent);
-has_url_or_file!(VideoMessageEventContent);
+has_url_or_file!(AudioMessageEventContent, "audio");
+has_url_or_file!(FileMessageEventContent, "file");
+has_url_or_file!(ImageMessageEventContent, "image");
+has_url_or_file!(VideoMessageEventContent, "video");
 
 /// Rendering implementation for membership events (joins, leaves, bans, profile
 /// changes, etc).
@@ -1594,6 +1625,24 @@ mod tests {
                     .to_owned()
             ),
             media_download_message(&content)
+        );
+    }
+
+    #[test]
+    fn plain_image_exposes_structured_media_tags() {
+        let content = ImageMessageEventContent::plain(
+            "image.png".to_owned(),
+            OwnedMxcUri::from("mxc://matrix.org/some-media-id"),
+        );
+
+        assert_eq!(
+            vec![
+                "matrix_media",
+                "matrix_media_kind_image",
+                "matrix_media_name_aW1hZ2UucG5n",
+                "matrix_media_uri_bXhjOi8vbWF0cml4Lm9yZy9zb21lLW1lZGlhLWlk",
+            ],
+            content.tags()
         );
     }
 


### PR DESCRIPTION
## Summary

- attach structured media kind, filename, and MXC URI tags to rendered Matrix media
- encode tag payloads with unpadded URL-safe base64 so relay clients can decode them without delimiter ambiguity
- preserve the existing human-readable authenticated download command
- accept a quoted download destination without writing the quote characters into the filename

## Why

Native relay clients currently receive only the rendered media text. They cannot reliably distinguish an image attachment from an ordinary message or recover the authenticated MXC source needed for an inline preview.

Structured tags let clients render plain Matrix media without scraping presentation text. Normalizing the optional destination also makes relay-issued download commands safe for cache paths containing spaces.

This complements the authenticated media download command from poljar/weechat-matrix-rs#156.

## Validation

- `git diff --check`
- Rust 1.96 Bookworm container with bundled WeeChat: `cargo test --locked --lib` (93 passed)
