### PR TITLE
Add headless Matrix history paging command

### DIFF
--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::{
     commands::{DevicesCommand, KeysCommand, MediaCommand, VerifyCommand},
     config::ConfigHandle,
+    room::HistoryPageResult,
     MatrixServer, Servers, PLUGIN_NAME,
 };
 
@@ -45,6 +46,7 @@ impl MatrixCommand {
             .add_argument("disconnect <server-name>")
             .add_argument("reconnect <server-name>")
             .add_argument("sso-complete <server-name> <login-token>")
+            .add_argument("history")
             .add_argument("read")
             .add_argument("version")
             .add_argument("help <matrix-command> [<matrix-subcommand>]")
@@ -55,6 +57,7 @@ impl MatrixCommand {
    reconnect: Reconnect to server(s).
         join: Join a Matrix room by ID or alias.
 sso-complete: Finish SSO login with a copied loginToken.
+     history: Load an older page of messages in the current room.
         read: Mark the current room as read.
      version: Show version information about weechat-matrix.
      devices: {}
@@ -302,6 +305,29 @@ Use /matrix [command] help to find out more.\n",
                     room.mark_as_read();
                 }
             }
+            ("history", _) => {
+                let Some(room) = self.servers.find_room(buffer) else {
+                    Weechat::print(&format!(
+                        "{}{}: /matrix history needs to be run in a Matrix room buffer.",
+                        Weechat::prefix(Prefix::Error),
+                        PLUGIN_NAME,
+                    ));
+                    return;
+                };
+
+                if !room.has_history_page() {
+                    room.print_history_page_result(
+                        HistoryPageResult::Unavailable,
+                    );
+                    return;
+                }
+
+                Weechat::spawn(async move {
+                    let result = room.get_messages().await;
+                    room.print_history_page_result(result);
+                })
+                .detach();
+            }
             ("version", _) => {
                 Weechat::print(&format!(
                     "{}: weechat-matrix version {} ({})",
@@ -435,6 +461,11 @@ impl CommandCallback for MatrixCommand {
             .subcommand(
                 SubCommand::with_name("read")
                     .about("Mark the current room as read."),
+            )
+            .subcommand(
+                SubCommand::with_name("history").about(
+                    "Load an older page of messages in the current room.",
+                ),
             )
             .subcommand(
                 SubCommand::with_name("version")

--- a/src/commands/matrix.rs
+++ b/src/commands/matrix.rs
@@ -323,7 +323,7 @@ Use /matrix [command] help to find out more.\n",
                 }
 
                 Weechat::spawn(async move {
-                    let result = room.get_messages().await;
+                    let result = room.get_interactive_history_page().await;
                     room.print_history_page_result(result);
                 })
                 .detach();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -62,7 +62,6 @@ use crate::{
 
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const SSO_CALLBACK_PORT: u16 = 29_325;
-const HISTORY_BATCH_SIZE: u16 = 200;
 
 pub struct InteractiveAuthInfo {
     pub user: String,
@@ -261,6 +260,7 @@ impl Connection {
         &self,
         room: Room,
         prev_batch: PrevBatch,
+        limit: u16,
     ) -> MatrixResult<Messages> {
         self.spawn(async move {
             let mut request = match &prev_batch {
@@ -271,7 +271,7 @@ impl Connection {
                     MessagesOptions::forward().from(Some(t.as_ref()))
                 }
             };
-            request.limit = HISTORY_BATCH_SIZE.into();
+            request.limit = limit.into();
 
             room.messages(request).await
         })

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -117,12 +117,47 @@ pub enum PrevBatch {
     Backwards(Option<String>),
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum HistoryPageResult {
+    Page { added: usize, exhausted: bool },
+    Unavailable,
+    Busy,
+    Failed,
+}
+
+const HISTORY_PAGE_TAGS: [&str; 2] =
+    ["matrix_history_page", "matrix_smart_filter"];
+
 fn restored_prev_batch(prev_batch: Option<String>) -> Option<PrevBatch> {
     // A restored SDK room does not always have a sync pagination token in its
     // store. Matrix permits a backward /messages request without `from`, which
     // starts at the newest visible event. Keep that request representable so a
     // freshly restored room can still populate its WeeChat buffer.
     Some(PrevBatch::Backwards(prev_batch))
+}
+
+fn has_history_page(prev_batch: &Option<PrevBatch>) -> bool {
+    prev_batch.is_some()
+}
+
+fn history_page_marker(result: &HistoryPageResult) -> String {
+    match result {
+        HistoryPageResult::Page { added, exhausted } => format!(
+            "matrix_history_page added={} exhausted={}",
+            added,
+            u8::from(*exhausted),
+        ),
+        HistoryPageResult::Unavailable => {
+            "matrix_history_page added=0 exhausted=1 state=unavailable"
+                .to_owned()
+        }
+        HistoryPageResult::Busy => {
+            "matrix_history_page added=0 exhausted=0 state=busy".to_owned()
+        }
+        HistoryPageResult::Failed => {
+            "matrix_history_page added=0 exhausted=0 state=failed".to_owned()
+        }
+    }
 }
 
 fn should_render_event(already_rendered: bool) -> bool {
@@ -1751,6 +1786,10 @@ impl MatrixRoom {
         self.messages_in_flight.locked()
     }
 
+    pub fn has_history_page(&self) -> bool {
+        has_history_page(&self.prev_batch.borrow())
+    }
+
     pub fn reset_prev_batch(&self) {
         // TODO: we'll want to be able to scroll up again after we clear the
         // buffer.
@@ -1822,7 +1861,7 @@ impl MatrixRoom {
         self.mark_latest_event_as_read(false);
     }
 
-    pub async fn get_messages(&self) {
+    pub async fn get_messages(&self) -> HistoryPageResult {
         let messages_lock = self.messages_in_flight.clone();
 
         let connection = self.connection.borrow().as_ref().cloned();
@@ -1831,23 +1870,26 @@ impl MatrixRoom {
             if let Some(p) = self.prev_batch.borrow().as_ref().cloned() {
                 p
             } else {
-                return;
+                return HistoryPageResult::Unavailable;
             };
 
         let guard = if let Ok(l) = messages_lock.try_lock() {
             l
         } else {
-            return;
+            return HistoryPageResult::Busy;
         };
 
         Weechat::bar_item_update("buffer_modes");
         Weechat::bar_item_update("matrix_modes");
 
-        if let Some(connection) = connection {
+        let result = if let Some(connection) = connection {
             let room = self.room();
             let room_id = room.room_id().to_owned();
 
             if let Ok(r) = connection.room_messages(room, prev_batch).await {
+                let added = r.chunk.len();
+                let exhausted = r.chunk.is_empty() || r.end.is_none();
+
                 for event in
                     r.chunk.iter().filter_map(|e| e.raw().deserialize().ok())
                 {
@@ -1879,13 +1921,31 @@ impl MatrixRoom {
                         r.end.map(|token| PrevBatch::Backwards(Some(token)));
                     self.buffer.sort_messages();
                 }
+
+                HistoryPageResult::Page { added, exhausted }
+            } else {
+                HistoryPageResult::Failed
             }
-        }
+        } else {
+            HistoryPageResult::Failed
+        };
 
         drop(guard);
 
         Weechat::bar_item_update("buffer_modes");
         Weechat::bar_item_update("matrix_modes");
+
+        result
+    }
+
+    pub fn print_history_page_result(&self, result: HistoryPageResult) {
+        if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
+            buffer.print_date_tags(
+                0,
+                &HISTORY_PAGE_TAGS,
+                &history_page_marker(&result),
+            );
+        }
     }
 
     pub async fn get_messages_if_empty(&self) {
@@ -1895,7 +1955,7 @@ impl MatrixRoom {
         };
 
         if buffer.num_lines() == 0 {
-            self.get_messages().await;
+            let _ = self.get_messages().await;
         }
     }
 
@@ -2302,6 +2362,37 @@ mod tests {
     #[test]
     fn restored_rooms_without_prev_batch_fetch_history_from_end() {
         assert_eq!(restored_prev_batch(None), Some(PrevBatch::Backwards(None)));
+    }
+
+    #[test]
+    fn history_paging_requires_an_available_cursor() {
+        assert!(!has_history_page(&None));
+        assert!(has_history_page(&Some(PrevBatch::Backwards(None))));
+        assert!(has_history_page(&Some(PrevBatch::Backwards(Some(
+            "token".to_owned()
+        )))));
+        assert!(has_history_page(&Some(PrevBatch::Forward(
+            "token".to_owned()
+        ))));
+    }
+
+    #[test]
+    fn history_page_markers_are_machine_readable_and_hideable() {
+        assert_eq!(
+            HISTORY_PAGE_TAGS,
+            ["matrix_history_page", "matrix_smart_filter"]
+        );
+        assert_eq!(
+            history_page_marker(&HistoryPageResult::Page {
+                added: 25,
+                exhausted: false,
+            }),
+            "matrix_history_page added=25 exhausted=0"
+        );
+        assert_eq!(
+            history_page_marker(&HistoryPageResult::Unavailable),
+            "matrix_history_page added=0 exhausted=1 state=unavailable"
+        );
     }
 
     #[test]

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -127,6 +127,8 @@ pub enum HistoryPageResult {
 
 const HISTORY_PAGE_TAGS: [&str; 2] =
     ["matrix_history_page", "matrix_smart_filter"];
+const RESTORED_HISTORY_BATCH_SIZE: u16 = 25;
+const INTERACTIVE_HISTORY_BATCH_SIZE: u16 = 25;
 
 fn restored_prev_batch(prev_batch: Option<String>) -> Option<PrevBatch> {
     // A restored SDK room does not always have a sync pagination token in its
@@ -1862,6 +1864,16 @@ impl MatrixRoom {
     }
 
     pub async fn get_messages(&self) -> HistoryPageResult {
+        self.get_messages_with_limit(RESTORED_HISTORY_BATCH_SIZE)
+            .await
+    }
+
+    pub async fn get_interactive_history_page(&self) -> HistoryPageResult {
+        self.get_messages_with_limit(INTERACTIVE_HISTORY_BATCH_SIZE)
+            .await
+    }
+
+    async fn get_messages_with_limit(&self, limit: u16) -> HistoryPageResult {
         let messages_lock = self.messages_in_flight.clone();
 
         let connection = self.connection.borrow().as_ref().cloned();
@@ -1886,7 +1898,9 @@ impl MatrixRoom {
             let room = self.room();
             let room_id = room.room_id().to_owned();
 
-            if let Ok(r) = connection.room_messages(room, prev_batch).await {
+            if let Ok(r) =
+                connection.room_messages(room, prev_batch, limit).await
+            {
                 let added = r.chunk.len();
                 let exhausted = r.chunk.is_empty() || r.end.is_none();
 
@@ -2374,6 +2388,12 @@ mod tests {
         assert!(has_history_page(&Some(PrevBatch::Forward(
             "token".to_owned()
         ))));
+    }
+
+    #[test]
+    fn interactive_history_pages_are_bounded() {
+        assert_eq!(INTERACTIVE_HISTORY_BATCH_SIZE, 25);
+        assert_eq!(RESTORED_HISTORY_BATCH_SIZE, 25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `/matrix history` to fetch one older room page without requiring a WeeChat window
- emit a hidden, machine-readable completion line with the added count and exhaustion state
- keep unavailable, busy, and failed outcomes explicit so relay GUIs can stop or retry safely
- bound restored and interactive requests to 25 events per call so relay GUIs can request further pages explicitly

## Why

Relay-native frontends do not own a real WeeChat window, so `/window page_up` cannot drive Matrix pagination. This command gives them a buffer-scoped paging primitive while preserving the existing interactive behavior.

The companion GUI integration is rnocx/WeeChatRS#18.

## Validation

- `WEECHAT_BUNDLED=1 cargo test --locked`: 94 passed
- `rustfmt --edition 2018 --check src/commands/matrix.rs src/room/mod.rs`
- `git diff --check`

No Matrix message was sent during validation.

## Update: empty history pages

- Keep back-pagination available when Matrix returns an empty chunk with a new `end` cursor instead of treating every empty chunk as exhausted.
- Stop cleanly when the server omits the next cursor or repeats the current cursor, including the non-empty repeated-cursor case that could otherwise replay forever.
- Added focused cursor-state regressions. The integrated backend composite containing this change passed all 101 tests, and all four exact-head build-test-release jobs are green.