### PR TITLE
Show read marker error details

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1761,8 +1761,10 @@ impl MatrixRoom {
                     }
                     Err(e) => {
                         Weechat::print(&format!(
-                            "{}: Failed to mark room as read: {}",
-                            PLUGIN_NAME, e
+                            "{}{}: Failed to mark room as read: {:?}",
+                            Weechat::prefix(Prefix::Error),
+                            PLUGIN_NAME,
+                            e
                         ));
                     }
                 }


### PR DESCRIPTION
Fixes #276.

Read marker failures were printed as a plain plugin line and used Display formatting, which often collapses Matrix SDK/reqwest failures to a generic "error sending request for url" message.

This marks the message with WeeChat's error prefix and prints the debug error so the underlying request failure is visible in the buffer.

Local verification:
- rustfmt --edition 2021 --check src/room/mod.rs
- git diff --check

Note: full cargo check/test is blocked on my local host by openssl-sys rejecting system OpenSSL 4.0.1 before crate compilation.