### PR TITLE
Fix /topic runtime panic

### DIFF
--- a/src/commands/topic.rs
+++ b/src/commands/topic.rs
@@ -2,7 +2,7 @@ use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg};
 use weechat::{
     buffer::Buffer,
     hooks::{Command, CommandCallback, CommandSettings},
-    Args, Prefix, Weechat,
+    Args, Weechat,
 };
 
 use super::parse_and_run;
@@ -87,18 +87,7 @@ impl TopicCommand {
 
     fn set_topic(&self, buffer: &Buffer, topic: String) {
         if let Some(room) = self.servers.find_room(buffer) {
-            let room = room.room().clone();
-
-            Weechat::spawn(async move {
-                if let Err(error) = room.set_room_topic(&topic).await {
-                    Weechat::print(&format!(
-                        "{}Failed to set room topic: {}",
-                        Weechat::prefix(Prefix::Error),
-                        error
-                    ));
-                }
-            })
-            .detach();
+            Weechat::spawn(async move { room.set_topic(topic).await }).detach();
         } else {
             Weechat::print(
                 "The /topic command needs to be run in a Matrix room buffer.",

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1538,7 +1538,7 @@ impl MatrixRoom {
             .spawn(async move { room.set_room_topic(&topic).await })
             .await
         {
-            Ok(()) => (),
+            Ok(_) => (),
             Err(error) => self
                 .print_error(&format!("Failed to set room topic: {}", error)),
         }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1526,6 +1526,24 @@ impl MatrixRoom {
         }
     }
 
+    pub async fn set_topic(&self, topic: String) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error("Not connected. Please connect first.");
+            return;
+        };
+
+        let room = self.room().clone();
+
+        match connection
+            .spawn(async move { room.set_room_topic(&topic).await })
+            .await
+        {
+            Ok(()) => (),
+            Err(error) => self
+                .print_error(&format!("Failed to set room topic: {}", error)),
+        }
+    }
+
     pub async fn ban_user(&self, user_id: OwnedUserId, reason: Option<String>) {
         let Some(connection) = self.connection.borrow().clone() else {
             self.print_error("Not connected. Please connect first.");


### PR DESCRIPTION
Fixes #266.

The /topic command used to call Matrix SDK room.set_room_topic() from the WeeChat executor. That can panic because the SDK HTTP path expects the Matrix Tokio runtime.

This adds a MatrixRoom::set_topic() helper that routes the SDK call through the room connection runtime, matching the existing send/redact runtime boundary.

Local verification:
- rustfmt --edition 2021 --check src/commands/topic.rs src/room/mod.rs
- git diff --check

Note: full cargo check/test is blocked on my local host by openssl-sys rejecting system OpenSSL 4.0.1 before crate compilation.