### PR TITLE
fix: complete room nicks in thread buffers

### DIFF
--- a/src/completions.rs
+++ b/src/completions.rs
@@ -19,6 +19,7 @@ pub struct Completions {
     servers: CompletionHook,
     users: CompletionHook,
     media: CompletionHook,
+    nicks: CompletionHook,
 }
 
 impl Completions {
@@ -29,7 +30,8 @@ impl Completions {
             )?,
             servers: ServersCompletion::create(servers.clone())?,
             users: UsersCompletion::create(servers.clone())?,
-            media: MediaCompletion::create(servers)?,
+            media: MediaCompletion::create(servers.clone())?,
+            nicks: NicksCompletion::create(servers)?,
         })
     }
 }
@@ -156,6 +158,56 @@ impl CompletionCallback for UsersCompletion {
                         CompletionPosition::Sorted,
                     )
                 }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Feed room member nicks into WeeChat's built-in "nicks" completion.
+///
+/// Thread buffers keep an empty nicklist, so the built-in fallback of
+/// completing from the current buffer's nicklist finds no candidates
+/// there. Adding the parent room's members here makes nick completion
+/// work in thread buffers, while room buffers keep using the built-in
+/// nicklist completion (this hook adds nothing for them, so WeeChat
+/// falls back to it).
+struct NicksCompletion {
+    servers: Servers,
+}
+
+impl NicksCompletion {
+    fn create(servers: Servers) -> Result<CompletionHook, ()> {
+        let comp = NicksCompletion { servers };
+
+        CompletionHook::new(
+            "nick",
+            "Completion for Matrix room member nicks",
+            comp,
+        )
+    }
+}
+
+impl CompletionCallback for NicksCompletion {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        _: Cow<str>,
+        completion: &Completion,
+    ) -> Result<(), ()> {
+        if buffer.get_localvar("thread_root").is_none() {
+            return Ok(());
+        }
+
+        if let Some(room) = self.servers.find_room(buffer) {
+            for nick in room.names() {
+                completion.add_with_options(
+                    &nick,
+                    true,
+                    CompletionPosition::Sorted,
+                )
             }
         }
 

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -197,22 +197,42 @@ impl CompletionCallback for NicksCompletion {
         _: Cow<str>,
         completion: &Completion,
     ) -> Result<(), ()> {
-        if buffer.get_localvar("thread_root").is_none() {
-            return Ok(());
-        }
+        let room_names = self
+            .servers
+            .find_room(buffer)
+            .map(|room| room.names())
+            .unwrap_or_default();
 
-        if let Some(room) = self.servers.find_room(buffer) {
-            for nick in room.names() {
-                completion.add_with_options(
-                    &nick,
-                    true,
-                    CompletionPosition::Sorted,
-                )
-            }
+        for nick in nick_completion_candidates(
+            buffer.get_localvar("thread_root").is_some(),
+            room_names,
+        ) {
+            completion.add_with_options(
+                &nick,
+                true,
+                CompletionPosition::Sorted,
+            )
         }
 
         Ok(())
     }
+}
+
+/// Nick completion candidates for the given matrix buffer context.
+///
+/// Only thread buffers contribute candidates (the parent room's members);
+/// every other buffer contributes nothing so WeeChat keeps using its
+/// built-in nicklist-based completion there.
+fn nick_completion_candidates(
+    is_thread_buffer: bool,
+    room_names: Vec<String>,
+) -> Vec<String> {
+    if !is_thread_buffer {
+        return Vec::new();
+    }
+    let mut names = room_names;
+    names.sort_unstable();
+    names
 }
 
 struct MediaCompletion {
@@ -328,6 +348,44 @@ mod tests {
                 "list".to_owned(),
             ]),
             BTreeSet::from(["#matrix:example.org".to_owned()]),
+        );
+    }
+
+    #[test]
+    fn thread_buffers_contribute_sorted_room_member_nicks() {
+        assert_eq!(
+            nick_completion_candidates(
+                true,
+                vec![
+                    "Bob".to_owned(),
+                    "Alice".to_owned(),
+                    "Ada (ada@example.org)".to_owned(),
+                ],
+            ),
+            vec![
+                "Ada (ada@example.org)".to_owned(),
+                "Alice".to_owned(),
+                "Bob".to_owned(),
+            ],
+        );
+    }
+
+    #[test]
+    fn thread_buffers_without_a_room_contribute_nothing() {
+        assert_eq!(nick_completion_candidates(true, vec![]), Vec::<String>::new());
+    }
+
+    #[test]
+    fn non_thread_buffers_keep_the_builtin_nicklist_completion() {
+        assert_eq!(
+            nick_completion_candidates(
+                false,
+                vec![
+                    "Alice".to_owned(),
+                    "Bob".to_owned(),
+                ],
+            ),
+            Vec::<String>::new(),
         );
     }
 }


### PR DESCRIPTION
Fixes #279

## Problem

TAB-completion of room member nicks does not work in Matrix thread buffers, while it works in regular room buffers.

WeeChat's built-in `nicks` completion (`weechat-completion.c`, `completion_list_add_nicks_cb`) first runs plugin hooks named `nick`; if none add candidates, it falls back to iterating the current buffer's nicklist. Thread buffers are created with an empty nicklist (`Room::get_or_create_thread_buffer` in `src/room/mod.rs`), so there are no candidates to complete from.

## Change

Hook the `nick` completion item in `src/completions.rs`. For thread buffers (detected via the `thread_root` localvar) it adds the parent room's members through the existing `Servers::find_room` / `RoomHandle::names` path, which resolves thread buffers to their parent room.

For all other buffers the hook adds nothing, so WeeChat falls back to the built-in nicklist-based completion, leaving room-buffer behavior unchanged. The IRC plugin's own `nick` hook already coexists with this mechanism (it guards on IRC buffers), so no interference is expected.

## Verification

- `cargo check --all-targets` passes.
- `cargo test` passes (108 tests).
- Behavior is only additive: candidates are contributed for thread buffers, and only via the existing members data.

Not done: thread buffers still keep an empty nicklist (no sidebar), matching current UI; only their completion is fed from the parent room.
