### PR TITLE
build: improve git describe handling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,9 @@ enum WeechatApiVersions {
 
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=.git/HEAD");
+    println!("cargo::rerun-if-changed=.git/refs");
+    println!("cargo::rerun-if-changed=.git/packed-refs");
     println!("cargo::rerun-if-env-changed=WEECHAT_BUNDLED");
     println!("cargo::rerun-if-env-changed=WEECHAT_PLUGIN_FILE");
     println!("cargo::rustc-check-cfg=cfg(weechat410)");
@@ -37,6 +40,9 @@ fn main() {
         if output.status.success() {
             let describe = String::from_utf8_lossy(&output.stdout).trim().to_string();
             println!("cargo::rustc-env=GIT_DESCRIBE={}", describe);
+            println!("cargo::warning=weechat-matrix git describe: {}", describe);
+        } else {
+            println!("cargo::warning=weechat-matrix: git describe failed");
         }
     }
 }


### PR DESCRIPTION
Re-run the build script when git state changes (HEAD, refs,
packed-refs) so the embedded GIT_DESCRIBE stays in sync with
branch switches, new commits and tags.

Print the git describe output as a Cargo warning on success so the
version string is visible during builds, and emit a warning when
git describe fails (e.g. building from a tarball without .git).

Also uses the modern `cargo::warning=` build-script syntax.