### PR TITLE
Use short room names for Matrix log buffers

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -549,7 +549,8 @@ impl RoomHandle {
             room,
         };
 
-        let buffer_name = format!("{}.{}", server_name, room_id);
+        let buffer_name =
+            format!("{}.{}", server_name, room.buffer.calculate_buffer_name());
 
         let buffer_handle = BufferBuilderAsync::new(&buffer_name)
             .input_callback(room.clone())


### PR DESCRIPTION
Fixes #282.

New Matrix room buffers now use `<server>.<short room name>` as the WeeChat buffer name instead of `<server>.<room id>`, so WeeChat log filenames remain human-readable while still keeping the server/account namespace.

Validation:
- `cargo fmt`
- `git diff --check`
- `cargo test --lib` in `rust:1.97-bookworm` container: 130 passed, 0 failed