### PR TITLE
fix: follow Matrix room upgrades

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -69,6 +69,7 @@ const SEND_RETRY_DELAYS: [Duration; 4] = [
 ];
 const SYNC_RETRY_INITIAL_DELAY: Duration = Duration::from_secs(1);
 const SYNC_RETRY_MAX_DELAY: Duration = Duration::from_secs(60);
+const ROOM_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 const SSO_CALLBACK_PORT: u16 = 29_325;
 
 fn is_retryable_network_error(error: &matrix_sdk::Error) -> bool {
@@ -126,6 +127,11 @@ pub enum ClientMessage {
         Option<AmbiguityChange>,
     ),
     RestoredRoom(OwnedRoomId),
+    RoomMetadata {
+        room_id: OwnedRoomId,
+        is_direct: bool,
+        display_name: Option<String>,
+    },
 }
 
 /// Struct representing an active connection to the homeserver.
@@ -468,6 +474,37 @@ impl Connection {
         }
     }
 
+    fn queue_room_metadata(
+        channel: Sender<Result<ClientMessage, String>>,
+        room: Room,
+    ) {
+        tokio::spawn(async move {
+            let room_id = room.room_id().to_owned();
+            let is_direct =
+                tokio::time::timeout(ROOM_METADATA_TIMEOUT, room.is_direct())
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or(false);
+            let display_name = tokio::time::timeout(
+                ROOM_METADATA_TIMEOUT,
+                room.display_name(),
+            )
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .map(|name| name.to_string());
+
+            let _ = channel
+                .send(Ok(ClientMessage::RoomMetadata {
+                    room_id,
+                    is_direct,
+                    display_name,
+                }))
+                .await;
+        });
+    }
+
     /// Response receiver loop.
     /// This runs on the main Weechat thread and listens for responses coming
     /// from the client running in the tokio executor.
@@ -503,6 +540,15 @@ impl Connection {
                     ClientMessage::RestoredRoom(room_id) => {
                         server.restore_room_by_id(room_id).await
                     }
+                    ClientMessage::RoomMetadata {
+                        room_id,
+                        is_direct,
+                        display_name,
+                    } => server.receive_room_metadata(
+                        room_id,
+                        is_direct,
+                        display_name,
+                    ),
                     ClientMessage::ToDeviceEvent(e) => {
                         server.receive_to_device_event(e).await
                     }
@@ -605,6 +651,7 @@ impl Connection {
                 return;
             }
             for room in client.joined_rooms() {
+                Self::queue_room_metadata(channel.clone(), room.clone());
                 if channel
                     .send(Ok(ClientMessage::RestoredRoom(
                         room.room_id().to_owned(),
@@ -743,6 +790,7 @@ impl Connection {
 
             if !first_login {
                 for room in client.joined_rooms() {
+                    Self::queue_room_metadata(channel.clone(), room.clone());
                     if channel
                         .send(Ok(ClientMessage::RestoredRoom(
                             room.room_id().to_owned(),
@@ -863,6 +911,12 @@ impl Connection {
                 }
 
                 for (room_id, room) in response.rooms.joined {
+                    if let Some(room) = client_ref.get_room(&room_id) {
+                        Self::queue_room_metadata(
+                            sync_channel.clone(),
+                            room.clone(),
+                        );
+                    }
                     let state_events = match &room.state {
                         State::Before(state) | State::After(state) => state,
                     };

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -235,6 +235,21 @@ impl Connection {
             .map_err(|error| error.to_string())
     }
 
+    /// Bound upgrade joins while polling both the timer and SDK on Tokio.
+    pub async fn join_room_with_timeout(
+        &self,
+        room_id: OwnedRoomId,
+        timeout: std::time::Duration,
+    ) -> Result<Result<Room, matrix_sdk::Error>, tokio::time::error::Elapsed>
+    {
+        let client = self.client().clone();
+        self.spawn(async move {
+            tokio::time::timeout(timeout, client.join_room_by_id(&room_id))
+                .await
+        })
+        .await
+    }
+
     pub fn shutdown(&self) {
         let runtime = self.runtime();
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -642,8 +642,7 @@ impl RoomBuffer {
         let Some(room) = maybe_active_room(&self.room) else {
             return self.short_name();
         };
-        let is_direct =
-            self.runtime.block_on(room.is_direct()).unwrap_or(false);
+        let is_direct = false;
         let is_space = room.is_space();
 
         let room_name = room
@@ -653,12 +652,6 @@ impl RoomBuffer {
             .or_else(|| {
                 room.canonical_alias()
                     .and_then(|alias| non_empty_room_name(alias.alias()))
-            })
-            .or_else(|| {
-                self.runtime
-                    .block_on(room.display_name())
-                    .ok()
-                    .and_then(|name| non_empty_room_name(&name.to_string()))
             })
             .unwrap_or_else(|| room.room_id().to_string());
 

--- a/src/room/buffer.rs
+++ b/src/room/buffer.rs
@@ -26,6 +26,7 @@ pub struct RoomBuffer {
     room: SharedRoom,
     runtime: Handle,
     pub(super) inner: Rc<RefCell<Option<BufferHandle>>>,
+    room_metadata: Rc<RefCell<Option<(bool, Option<String>)>>>,
     thread_buffers: Rc<RefCell<HashMap<OwnedEventId, BufferHandle>>>,
     space_children: Rc<RefCell<Vec<SpaceChildInfo>>>,
 }
@@ -56,6 +57,7 @@ impl RoomBuffer {
             room,
             runtime,
             inner: Rc::new(RefCell::new(None)),
+            room_metadata: Rc::new(RefCell::new(None)),
             thread_buffers: Rc::new(RefCell::new(HashMap::new())),
             space_children: Rc::new(RefCell::new(Vec::new())),
         }
@@ -642,20 +644,26 @@ impl RoomBuffer {
         let Some(room) = maybe_active_room(&self.room) else {
             return self.short_name();
         };
-        let is_direct = false;
+        let (is_direct, metadata_name) =
+            self.room_metadata.borrow().clone().unwrap_or_default();
         let is_space = room.is_space();
 
-        let room_name = room
-            .name()
-            .as_deref()
-            .and_then(non_empty_room_name)
-            .or_else(|| {
-                room.canonical_alias()
-                    .and_then(|alias| non_empty_room_name(alias.alias()))
-            })
-            .unwrap_or_else(|| room.room_id().to_string());
+        let room_name = room_display_name(
+            room.name().as_deref(),
+            room.canonical_alias().as_deref().map(|alias| alias.alias()),
+            metadata_name.as_deref(),
+            room.room_id().as_str(),
+        );
 
         format_buffer_name(&room_name, is_direct, is_space)
+    }
+
+    pub fn set_room_metadata(
+        &self,
+        is_direct: bool,
+        display_name: Option<String>,
+    ) {
+        *self.room_metadata.borrow_mut() = Some((is_direct, display_name));
     }
 
     pub fn calculate_thread_buffer_name(
@@ -915,6 +923,19 @@ fn non_empty_room_name(name: &str) -> Option<String> {
     }
 }
 
+fn room_display_name(
+    explicit_name: Option<&str>,
+    alias: Option<&str>,
+    metadata_name: Option<&str>,
+    room_id: &str,
+) -> String {
+    explicit_name
+        .and_then(non_empty_room_name)
+        .or_else(|| alias.and_then(non_empty_room_name))
+        .or_else(|| metadata_name.and_then(non_empty_room_name))
+        .unwrap_or_else(|| room_id.to_owned())
+}
+
 fn format_buffer_name(
     room_name: &str,
     is_direct: bool,
@@ -1068,9 +1089,9 @@ mod tests {
 
     use super::{
         filter_space_children, format_buffer_name, format_thread_buffer_name,
-        line_sort_key, reply_sender_id_from_tags, sanitize_thread_id,
-        select_space_child, space_child_selection, RoomBuffer, SpaceChildInfo,
-        SpaceChildSelection,
+        line_sort_key, reply_sender_id_from_tags, room_display_name,
+        sanitize_thread_id, select_space_child, space_child_selection,
+        RoomBuffer, SpaceChildInfo, SpaceChildSelection,
     };
 
     fn space_child(
@@ -1135,6 +1156,38 @@ mod tests {
 
         assert!(
             line_sort_key(100, &tags, None) < line_sort_key(200, &tags, None)
+        );
+    }
+
+    #[test]
+    fn async_display_name_fills_unnamed_room_without_overriding_explicit_names()
+    {
+        assert_eq!(
+            room_display_name(
+                None,
+                None,
+                Some("Orbit"),
+                "!fallback:example.org"
+            ),
+            "Orbit"
+        );
+        assert_eq!(
+            room_display_name(
+                Some("Named"),
+                Some("#alias"),
+                Some("Orbit"),
+                "!fallback:example.org"
+            ),
+            "Named"
+        );
+        assert_eq!(
+            room_display_name(
+                None,
+                Some("#alias"),
+                Some("Orbit"),
+                "!fallback:example.org"
+            ),
+            "#alias"
         );
     }
 

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -161,6 +161,11 @@ fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
     Some(PrevBatch::Backwards(None))
 }
 
+fn non_empty_metadata_name(name: &str) -> Option<&str> {
+    let name = name.trim();
+    (!name.is_empty()).then_some(name)
+}
+
 fn has_history_page(prev_batch: &Option<PrevBatch>) -> bool {
     prev_batch.is_some()
 }
@@ -841,14 +846,6 @@ impl RoomHandle {
             room.buffer.refresh_space_children();
         }
 
-        if let Some(successor) = sdk_room.successor_room() {
-            let room = room.clone();
-            Weechat::spawn(async move {
-                room.follow_successor_room(successor.room_id).await
-            })
-            .detach();
-        }
-
         Self { inner: room }
     }
 
@@ -885,40 +882,44 @@ impl RoomHandle {
         // newer cursor which is then overwritten with the saved one.
         *room_buffer.prev_batch.borrow_mut() = restored_prev_batch(prev_batch);
 
-        let matrix_members = runtime
-            .spawn(async move {
-                tokio::time::timeout(
-                    ROOM_MEMBER_RESTORE_TIMEOUT,
-                    room.joined_user_ids(),
-                )
-                .await
-            })
-            .await
-            .expect("Couldn't get the joined user ids");
-
-        match matrix_members {
-            Ok(Ok(matrix_members)) => {
-                for user_id in matrix_members {
-                    trace!("Restoring member {}", &user_id);
-                    room_buffer.members.restore_member(user_id).await;
-                }
-                room_buffer.members.update_member_localvars();
-            }
-            Ok(Err(error)) => warn!(
-                "Couldn't restore room members for {}: {}",
-                room_id, error
-            ),
-            Err(_) => warn!(
-                "Timed out restoring room members for {} after {} seconds",
-                room_id,
-                ROOM_MEMBER_RESTORE_TIMEOUT.as_secs()
-            ),
-        }
-
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();
         room_buffer.buffer.update_parent_spaces();
         room_buffer.buffer.refresh_space_children();
+
+        let members_room = room_buffer.clone();
+        Weechat::spawn(async move {
+            let matrix_members = runtime
+                .spawn(async move {
+                    tokio::time::timeout(
+                        ROOM_MEMBER_RESTORE_TIMEOUT,
+                        room.joined_user_ids(),
+                    )
+                    .await
+                })
+                .await
+                .expect("Couldn't get the joined user ids");
+
+            match matrix_members {
+                Ok(Ok(matrix_members)) => {
+                    for user_id in matrix_members {
+                        trace!("Restoring member {}", &user_id);
+                        members_room.members.restore_member(user_id).await;
+                    }
+                    members_room.members.update_member_localvars();
+                }
+                Ok(Err(error)) => warn!(
+                    "Couldn't restore room members for {}: {}",
+                    room_id, error
+                ),
+                Err(_) => warn!(
+                    "Timed out restoring room members for {} after {} seconds",
+                    room_id,
+                    ROOM_MEMBER_RESTORE_TIMEOUT.as_secs()
+                ),
+            }
+        })
+        .detach();
 
         Ok(room_buffer)
     }
@@ -1221,6 +1222,28 @@ impl MatrixRoom {
             .runtime
             .block_on(room.is_direct())
             .unwrap_or_default()
+    }
+
+    pub fn apply_room_metadata(
+        &self,
+        is_direct: bool,
+        display_name: Option<String>,
+    ) {
+        let buffer_handle = self.buffer_handle();
+        let Ok(buffer) = buffer_handle.upgrade() else {
+            return;
+        };
+
+        if is_direct {
+            buffer.set_localvar("type", "private");
+            if let Some(display_name) =
+                display_name.as_deref().and_then(non_empty_metadata_name)
+            {
+                buffer.set_short_name(display_name);
+            }
+        } else {
+            buffer.set_localvar("type", "channel");
+        }
     }
 
     pub fn alias(&self) -> Option<OwnedRoomAliasId> {
@@ -1971,7 +1994,9 @@ impl MatrixRoom {
             return;
         };
         let Some(server) = self.server() else {
-            if let Err(error) = self.send_message_direct(self.room(), content).await {
+            if let Err(error) =
+                self.send_message_direct(self.room(), content).await
+            {
                 self.print_error(&error);
             }
             return;
@@ -2002,7 +2027,9 @@ impl MatrixRoom {
                     self.adopt_thread_buffer(&source_root, &room, &thread_root);
                     retarget_thread_content(&mut content, thread_root);
                 }
-                if let Err(error) = room.send_message_direct(room.room(), content).await {
+                if let Err(error) =
+                    room.send_message_direct(room.room(), content).await
+                {
                     self.print_error(&error);
                 }
             }

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -57,9 +57,8 @@ use matrix_sdk::{
     },
     deserialized_responses::AmbiguityChange,
     room::{
-        IncludeRelations, RelationsOptions,
         reply::{EnforceThread, Reply},
-        Room,
+        IncludeRelations, RelationsOptions, Room,
     },
     ruma::{
         api::Direction,
@@ -727,14 +726,14 @@ impl RoomHandle {
 
         let buffer_handle = build_room_buffer(&buffer_name, room.clone())
             .or_else(|_| {
-                if retire_stale_matrix_buffer(&buffer_name, room_id) {
+                if retire_stale_matrix_buffer(&buffer_name, &room_id) {
                     build_room_buffer(&buffer_name, room.clone())
                 } else {
                     Err(())
                 }
             })
             .or_else(|_| {
-                let suffix = room_id_buffer_suffix(room_id);
+                let suffix = room_id_buffer_suffix(&room_id);
                 let fallback_name = if suffix.is_empty() {
                     format!("{buffer_name}.room")
                 } else {
@@ -1084,15 +1083,8 @@ impl MatrixRoom {
 
         self.print_network(&format!("Following room upgrade to {room_id}..."));
 
-        let client = connection.client().clone();
-        let target = room_id.clone();
         let result = connection
-            .spawn(async move {
-                tokio::time::timeout(SPACE_JOIN_TIMEOUT, async move {
-                    client.join_room_by_id(&target).await
-                })
-                .await
-            })
+            .join_room_with_timeout(room_id.clone(), SPACE_JOIN_TIMEOUT)
             .await;
 
         match result {
@@ -2113,15 +2105,11 @@ impl MatrixRoom {
                 "Following room upgrade to {successor_room_id}..."
             ));
 
-            let client = connection.client().clone();
-            let target = successor_room_id.clone();
             match connection
-                .spawn(async move {
-                    tokio::time::timeout(SPACE_JOIN_TIMEOUT, async move {
-                        client.join_room_by_id(&target).await
-                    })
-                    .await
-                })
+                .join_room_with_timeout(
+                    successor_room_id.clone(),
+                    SPACE_JOIN_TIMEOUT,
+                )
                 .await
             {
                 Ok(Ok(successor_room)) => room = successor_room,

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -77,6 +77,7 @@ use matrix_sdk::{
                     RoomMessageEventContent, TextMessageEventContent,
                 },
                 redaction::SyncRoomRedactionEvent,
+                tombstone::RoomTombstoneEventContent,
             },
             AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
             AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
@@ -161,6 +162,61 @@ fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
 
 fn has_history_page(prev_batch: &Option<PrevBatch>) -> bool {
     prev_batch.is_some()
+}
+
+fn tombstone_replacement_room_id(
+    event: &SyncStateEvent<RoomTombstoneEventContent>,
+) -> Option<OwnedRoomId> {
+    event
+        .as_original()
+        .map(|event| event.content.replacement_room.clone())
+}
+
+fn build_room_buffer(
+    buffer_name: &str,
+    room: MatrixRoom,
+) -> Result<BufferHandle, ()> {
+    BufferBuilderAsync::new(buffer_name)
+        .input_callback(room)
+        .close_callback(|_weechat: &Weechat, _buffer: &Buffer| {
+            // TODO: remove the roombuffer from the server here.
+            // TODO: leave the room if the plugin isn't unloading.
+            Ok(())
+        })
+        .build()
+}
+
+fn retire_stale_matrix_buffer(buffer_name: &str, room_id: &RoomId) -> bool {
+    let Some(buffer) =
+        (unsafe { Weechat::weechat() }).buffer_search("==", buffer_name)
+    else {
+        return false;
+    };
+
+    let Some(existing_room_id) = buffer.get_localvar("room_id") else {
+        return false;
+    };
+
+    if existing_room_id.as_ref() == room_id.as_str() {
+        return false;
+    }
+
+    let suffix = existing_room_id
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .take(12)
+        .collect::<String>();
+    let stale_name = if suffix.is_empty() {
+        format!("{buffer_name}.stale")
+    } else {
+        format!("{buffer_name}.stale.{suffix}")
+    };
+
+    buffer.set_full_name(&stale_name);
+    buffer.set_short_name(&format!("stale.{}", buffer.short_name()));
+    buffer.close();
+
+    true
 }
 
 fn history_page_marker(result: &HistoryPageResult) -> String {
@@ -657,22 +713,27 @@ impl RoomHandle {
             server,
         };
 
-        let buffer_name = format!("{}.{}", server_name, room_id);
+        let room_short_name = room.buffer.calculate_buffer_name();
+        let buffer_name = format!("{server_name}.{room_short_name}");
 
-        let buffer_handle = BufferBuilderAsync::new(&buffer_name)
-            .input_callback(room.clone())
-            .close_callback(|_weechat: &Weechat, _buffer: &Buffer| {
-                // TODO: remove the roombuffer from the server here.
-                // TODO: leave the room if the plugin isn't unloading.
-                Ok(())
+        let buffer_handle = build_room_buffer(&buffer_name, room.clone())
+            .or_else(|_| {
+                if retire_stale_matrix_buffer(&buffer_name, room_id) {
+                    build_room_buffer(&buffer_name, room.clone())
+                } else {
+                    Err(())
+                }
             })
-            .build()
             .expect("Can't create new room buffer");
 
         let buffer = buffer_handle
             .upgrade()
             .expect("Can't upgrade newly created buffer");
         buffer.set_short_name(&room.buffer.calculate_buffer_name());
+
+        if buffer.short_name() != room_short_name {
+            buffer.set_short_name(&room_short_name);
+        }
 
         buffer
             .add_nicklist_group(
@@ -769,6 +830,14 @@ impl RoomHandle {
             buffer.disable_multiline();
             buffer.disable_log();
             room.buffer.refresh_space_children();
+        }
+
+        if let Some(successor) = sdk_room.successor_room() {
+            let room = room.clone();
+            Weechat::spawn(async move {
+                room.follow_successor_room(successor.room_id).await
+            })
+            .detach();
         }
 
         Self { inner: room }
@@ -968,6 +1037,46 @@ impl MatrixRoom {
                 target,
                 SPACE_JOIN_TIMEOUT.as_secs(),
                 error
+            )),
+        }
+    }
+
+    async fn follow_successor_room(&self, room_id: OwnedRoomId) {
+        let Some(connection) = self.connection.borrow().clone() else {
+            self.print_error(&format!(
+                "Room was upgraded to {room_id}, but Matrix is not connected."
+            ));
+            return;
+        };
+
+        if connection.client().get_room(&room_id).is_some() {
+            return;
+        }
+
+        self.print_network(&format!("Following room upgrade to {room_id}..."));
+
+        let client = connection.client().clone();
+        let target = room_id.clone();
+        let result = connection
+            .spawn(async move {
+                tokio::time::timeout(SPACE_JOIN_TIMEOUT, async move {
+                    client.join_room_by_id(&target).await
+                })
+                .await
+            })
+            .await;
+
+        match result {
+            Ok(Ok(room)) => self.print_network(&format!(
+                "Successfully joined upgraded room {}",
+                room.room_id()
+            )),
+            Ok(Err(error)) => self.print_error(&format!(
+                "Failed to join upgraded room {room_id}: {error}"
+            )),
+            Err(error) => self.print_error(&format!(
+                "Timed out joining upgraded room {room_id} after {} seconds: {error}",
+                SPACE_JOIN_TIMEOUT.as_secs()
             )),
         }
     }
@@ -1827,13 +1936,14 @@ impl MatrixRoom {
         let Some(source_root) =
             thread_root_from_content(&content).map(ToOwned::to_owned)
         else {
-            if let Err(error) = self.send_message_direct(content).await {
+            let room = self.latest_send_room().await;
+            if let Err(error) = self.send_message_direct(room, content).await {
                 self.print_error(&error);
             }
             return;
         };
         let Some(server) = self.server() else {
-            if let Err(error) = self.send_message_direct(content).await {
+            if let Err(error) = self.send_message_direct(self.room(), content).await {
                 self.print_error(&error);
             }
             return;
@@ -1864,7 +1974,7 @@ impl MatrixRoom {
                     self.adopt_thread_buffer(&source_root, &room, &thread_root);
                     retarget_thread_content(&mut content, thread_root);
                 }
-                if let Err(error) = room.send_message_direct(content).await {
+                if let Err(error) = room.send_message_direct(room.room(), content).await {
                     self.print_error(&error);
                 }
             }
@@ -1885,7 +1995,7 @@ impl MatrixRoom {
                 // before sending, but the homeserver event and local mapping
                 // cannot be committed atomically without persisting the full
                 // arbitrary user payload as a recovery journal.
-                match room.send_message_direct(content).await {
+                match room.send_message_direct(room.room(), content).await {
                     Ok(target_root) => {
                         let target_key =
                             ThreadKey::new(room.room_id(), &target_root);
@@ -1911,8 +2021,80 @@ impl MatrixRoom {
         }
     }
 
+    async fn latest_send_room(&self) -> Room {
+        let mut room = self.room();
+        let mut seen_room_ids = HashSet::new();
+
+        for _ in 0..32 {
+            if !seen_room_ids.insert(room.room_id().to_owned()) {
+                self.print_error(&format!(
+                    "Room upgrade cycle detected at {}.",
+                    room.room_id()
+                ));
+                return room;
+            }
+
+            let Some(successor_room_id) =
+                room.successor_room().map(|successor| successor.room_id)
+            else {
+                return room;
+            };
+
+            let Some(connection) = self.connection.borrow().clone() else {
+                self.print_error(&format!(
+                    "Room was upgraded to {successor_room_id}, but Matrix is not connected."
+                ));
+                return room;
+            };
+
+            if let Some(successor_room) =
+                connection.client().get_room(&successor_room_id)
+            {
+                room = successor_room;
+                continue;
+            }
+
+            self.print_network(&format!(
+                "Following room upgrade to {successor_room_id}..."
+            ));
+
+            let client = connection.client().clone();
+            let target = successor_room_id.clone();
+            match connection
+                .spawn(async move {
+                    tokio::time::timeout(SPACE_JOIN_TIMEOUT, async move {
+                        client.join_room_by_id(&target).await
+                    })
+                    .await
+                })
+                .await
+            {
+                Ok(Ok(successor_room)) => room = successor_room,
+                Ok(Err(error)) => {
+                    self.print_error(&format!(
+                        "Failed to join upgraded room {successor_room_id}: {error}"
+                    ));
+                    return room;
+                }
+                Err(error) => {
+                    self.print_error(&format!(
+                        "Timed out joining upgraded room {successor_room_id} after {} seconds: {error}",
+                        SPACE_JOIN_TIMEOUT.as_secs()
+                    ));
+                    return room;
+                }
+            }
+        }
+
+        self.print_error("Room upgrade chain exceeded 32 rooms.");
+        room
+    }
+
+    // Thread continuation already resolved its room and root together. Do not
+    // independently follow room upgrades after that routing decision.
     async fn send_message_direct(
         &self,
+        room: Room,
         content: RoomMessageEventContent,
     ) -> Result<OwnedEventId, String> {
         let transaction_id = TransactionId::new();
@@ -1923,7 +2105,7 @@ impl MatrixRoom {
             self.queue_outgoing_message(&transaction_id, &content).await;
             match c
                 .send_message(
-                    self.room(),
+                    room,
                     AnyMessageLikeEventContent::RoomMessage(content),
                     Some(transaction_id.clone()),
                 )
@@ -3194,16 +3376,20 @@ impl MatrixRoom {
                 self.buffer.set_alias();
                 self.buffer.update_buffer_name();
             }
-            AnySyncStateEvent::RoomTombstone(_) => {
+            AnySyncStateEvent::RoomTombstone(tombstone) => {
+                let replacement_room_id =
+                    tombstone_replacement_room_id(tombstone);
                 if let Ok(buffer) = self.buffer.buffer_handle().upgrade() {
                     buffer.set_localvar(
                         "matrix_replacement_room_id",
-                        self.room()
-                            .successor_room()
+                        replacement_room_id
                             .as_ref()
-                            .map(|successor| successor.room_id.as_str())
+                            .map(|room_id| room_id.as_str())
                             .unwrap_or_default(),
                     );
+                }
+                if let Some(room_id) = replacement_room_id {
+                    self.follow_successor_room(room_id).await;
                 }
             }
             AnySyncStateEvent::SpaceParent(_) => {
@@ -3268,6 +3454,34 @@ mod tests {
     #[test]
     fn restored_rooms_without_prev_batch_fetch_history_from_end() {
         assert_eq!(restored_prev_batch(None), Some(PrevBatch::Backwards(None)));
+    }
+
+    #[test]
+    fn tombstone_state_event_exposes_replacement_room_id() {
+        let event: AnySyncStateEvent =
+            serde_json::from_value(serde_json::json!({
+                "type": "m.room.tombstone",
+                "event_id": "$tombstone:example.org",
+                "sender": "@alice:example.org",
+                "origin_server_ts": 1,
+                "state_key": "",
+                "content": {
+                    "body": "This room has been replaced.",
+                    "replacement_room": "!new:example.org"
+                }
+            }))
+            .expect("valid tombstone event");
+
+        let AnySyncStateEvent::RoomTombstone(tombstone) = event else {
+            panic!("expected tombstone event");
+        };
+
+        assert_eq!(
+            tombstone_replacement_room_id(&tombstone)
+                .as_deref()
+                .map(RoomId::as_str),
+            Some("!new:example.org")
+        );
     }
 
     #[test]

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -30,7 +30,7 @@ use buffer::{print_rendered_event_to_buffer, RoomBuffer, SpaceChildSelection};
 use members::Members;
 pub use members::WeechatRoomMember;
 use tokio::runtime::Handle;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use verification::Verification;
 
 use std::{
@@ -151,6 +151,7 @@ const INTERACTIVE_HISTORY_MAX_PAGES: usize = 50;
 // messages in the room the user is actually viewing.
 const RESTORED_HISTORY_TARGET_LINES: i32 = 1;
 const RESTORED_HISTORY_MAX_PAGES: usize = 10;
+const ROOM_MEMBER_RESTORE_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
     // The SDK does not replay the stored sync timeline when a room is restored.
@@ -214,9 +215,17 @@ fn retire_stale_matrix_buffer(buffer_name: &str, room_id: &RoomId) -> bool {
 
     buffer.set_full_name(&stale_name);
     buffer.set_short_name(&format!("stale.{}", buffer.short_name()));
-    buffer.close();
 
     true
+}
+
+fn room_id_buffer_suffix(room_id: &RoomId) -> String {
+    room_id
+        .as_str()
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .take(12)
+        .collect()
 }
 
 fn history_page_marker(result: &HistoryPageResult) -> String {
@@ -671,12 +680,7 @@ impl RoomHandle {
             buffer.clone(),
         );
 
-        let own_nick = runtime
-            .block_on(sdk_room.get_member_no_sync(own_user_id))
-            .ok()
-            .flatten()
-            .map(|m| m.name().to_owned())
-            .unwrap_or_else(|| own_user_id.localpart().to_owned());
+        let own_nick = own_user_id.localpart().to_owned();
 
         let own_user_id = own_user_id.to_owned();
         let room_id = room_id.to_owned();
@@ -723,6 +727,15 @@ impl RoomHandle {
                 } else {
                     Err(())
                 }
+            })
+            .or_else(|_| {
+                let suffix = room_id_buffer_suffix(room_id);
+                let fallback_name = if suffix.is_empty() {
+                    format!("{buffer_name}.room")
+                } else {
+                    format!("{buffer_name}.{suffix}")
+                };
+                build_room_buffer(&fallback_name, room.clone())
             })
             .expect("Can't create new room buffer");
 
@@ -811,11 +824,7 @@ impl RoomHandle {
                 .map(|uri| uri.as_str())
                 .unwrap_or_default(),
         );
-        if room.is_direct() {
-            buffer.set_localvar("type", "private")
-        } else {
-            buffer.set_localvar("type", "channel")
-        }
+        buffer.set_localvar("type", "channel");
 
         if let Some(alias) = room.alias() {
             buffer.set_localvar("alias", alias.as_str());
@@ -853,7 +862,7 @@ impl RoomHandle {
         homeserver: Url,
     ) -> Result<Self, StoreError> {
         let room_clone = room.clone();
-        let room_id = room.room_id();
+        let room_id = room.room_id().to_owned();
         let own_user_id = room.own_user_id();
         let prev_batch = room.last_prev_batch();
 
@@ -865,7 +874,7 @@ impl RoomHandle {
             config,
             room_clone,
             homeserver,
-            room_id,
+            &room_id,
             own_user_id,
         );
 
@@ -877,15 +886,34 @@ impl RoomHandle {
         *room_buffer.prev_batch.borrow_mut() = restored_prev_batch(prev_batch);
 
         let matrix_members = runtime
-            .spawn(async move { room.joined_user_ids().await })
+            .spawn(async move {
+                tokio::time::timeout(
+                    ROOM_MEMBER_RESTORE_TIMEOUT,
+                    room.joined_user_ids(),
+                )
+                .await
+            })
             .await
-            .expect("Couldn't get the joined user ids")?;
+            .expect("Couldn't get the joined user ids");
 
-        for user_id in matrix_members {
-            trace!("Restoring member {}", &user_id);
-            room_buffer.members.restore_member(user_id).await;
+        match matrix_members {
+            Ok(Ok(matrix_members)) => {
+                for user_id in matrix_members {
+                    trace!("Restoring member {}", &user_id);
+                    room_buffer.members.restore_member(user_id).await;
+                }
+                room_buffer.members.update_member_localvars();
+            }
+            Ok(Err(error)) => warn!(
+                "Couldn't restore room members for {}: {}",
+                room_id, error
+            ),
+            Err(_) => warn!(
+                "Timed out restoring room members for {} after {} seconds",
+                room_id,
+                ROOM_MEMBER_RESTORE_TIMEOUT.as_secs()
+            ),
         }
-        room_buffer.members.update_member_localvars();
 
         room_buffer.buffer.update_buffer_name();
         room_buffer.buffer.set_topic();

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -160,11 +160,6 @@ fn restored_prev_batch(_prev_batch: Option<String>) -> Option<PrevBatch> {
     Some(PrevBatch::Backwards(None))
 }
 
-fn non_empty_metadata_name(name: &str) -> Option<&str> {
-    let name = name.trim();
-    (!name.is_empty()).then_some(name)
-}
-
 fn has_history_page(prev_batch: &Option<PrevBatch>) -> bool {
     prev_batch.is_some()
 }
@@ -1226,15 +1221,14 @@ impl MatrixRoom {
             return;
         };
 
+        self.buffer.set_room_metadata(is_direct, display_name);
+
         if is_direct {
             buffer.set_localvar("type", "private");
-            if let Some(display_name) =
-                display_name.as_deref().and_then(non_empty_metadata_name)
-            {
-                buffer.set_short_name(display_name);
-            }
+            buffer.set_short_name(&self.buffer.calculate_buffer_name());
         } else {
             buffer.set_localvar("type", "channel");
+            buffer.set_short_name(&self.buffer.calculate_buffer_name());
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -89,8 +89,8 @@ use matrix_sdk::{
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
         OwnedDeviceId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
-        OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
-        RoomId, UserId,
+        OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId, RoomId,
+        UserId,
     },
     Client, Error, RoomState, SessionTokens,
 };
@@ -235,6 +235,8 @@ pub struct InnerServer {
     servers: Servers,
     server_name: Rc<str>,
     rooms: Rc<RefCell<HashMap<OwnedRoomId, RoomHandle>>>,
+    pending_room_metadata:
+        RefCell<HashMap<OwnedRoomId, (bool, Option<String>)>>,
     settings: Rc<RefCell<ServerSettings>>,
     current_settings: Rc<RefCell<ServerSettings>>,
     config: ConfigHandle,
@@ -272,6 +274,7 @@ impl MatrixServer {
             servers,
             server_name: server_name.clone(),
             rooms: Rc::new(RefCell::new(HashMap::new())),
+            pending_room_metadata: RefCell::new(HashMap::new()),
             settings: Rc::new(RefCell::new(ServerSettings::new())),
             current_settings: Rc::new(RefCell::new(ServerSettings::new())),
             config: config.clone(),
@@ -330,7 +333,9 @@ impl MatrixServer {
                 if !self.rooms.borrow().contains_key(&room_id) {
                     self.restore_room(room).await;
                 }
-                if let Some(room) = self.rooms.borrow().get(&room_id) {
+                let room = self.rooms.borrow().get(&room_id).cloned();
+                if let Some(room) = room {
+                    let room = self.latest_room_for(&room).await;
                     if let Ok(buffer) = room.buffer_handle().upgrade() {
                         buffer.switch_to();
                     }
@@ -1283,6 +1288,111 @@ impl InnerServer {
         }
     }
 
+    async fn latest_room_for(&self, room: &RoomHandle) -> RoomHandle {
+        let Some(successor_room_id) = room
+            .room()
+            .successor_room()
+            .map(|successor| successor.room_id)
+        else {
+            return room.clone();
+        };
+
+        self.latest_successor_room_handle(successor_room_id)
+            .await
+            .unwrap_or_else(|| room.clone())
+    }
+
+    fn latest_restored_successor_room(
+        &self,
+        room: &RoomHandle,
+    ) -> Option<RoomHandle> {
+        let mut next_room_id = room
+            .room()
+            .successor_room()
+            .map(|successor| successor.room_id)?;
+        let mut seen_room_ids = HashSet::new();
+        let mut latest = None;
+
+        for _ in 0..ROOM_UPGRADE_CHAIN_LIMIT {
+            if !seen_room_ids.insert(next_room_id.clone()) {
+                self.print_error(&format!(
+                    "Room upgrade cycle detected at {next_room_id}."
+                ));
+                return None;
+            }
+
+            let Some(room) = self.rooms.borrow().get(&next_room_id).cloned()
+            else {
+                return latest;
+            };
+            next_room_id = match room
+                .room()
+                .successor_room()
+                .map(|successor| successor.room_id)
+            {
+                Some(successor_room_id) => successor_room_id,
+                None => return Some(room),
+            };
+            latest = Some(room);
+        }
+
+        self.print_error(&format!(
+            "Room upgrade chain exceeded {ROOM_UPGRADE_CHAIN_LIMIT} rooms."
+        ));
+        latest
+    }
+
+    fn switch_current_room_to_restored_successor(
+        &self,
+        current_room: &RoomHandle,
+        successor_room: &RoomHandle,
+    ) {
+        if !Self::room_buffer_is_current(current_room) {
+            return;
+        }
+
+        if let Ok(buffer) = successor_room.buffer_handle().upgrade() {
+            buffer.switch_to();
+        }
+    }
+
+    fn switch_restored_upgrade_chain(&self, restored_room: &RoomHandle) {
+        if let Some(successor_room) =
+            self.latest_restored_successor_room(restored_room)
+        {
+            self.switch_current_room_to_restored_successor(
+                restored_room,
+                &successor_room,
+            );
+        }
+
+        let restored_room_id = restored_room.room_id().to_owned();
+        let rooms = self.rooms.borrow().values().cloned().collect::<Vec<_>>();
+        for room in rooms {
+            if room.room_id() == restored_room_id {
+                continue;
+            }
+
+            let Some(successor_room_id) = room
+                .room()
+                .successor_room()
+                .map(|successor| successor.room_id)
+            else {
+                continue;
+            };
+
+            if successor_room_id == restored_room_id {
+                let successor_room = self
+                    .latest_restored_successor_room(&room)
+                    .unwrap_or_else(|| restored_room.clone());
+                self.switch_current_room_to_restored_successor(
+                    &room,
+                    &successor_room,
+                );
+            }
+        }
+    }
+
     pub async fn restore_room(&self, room: Room) {
         let homeserver = self
             .settings
@@ -1306,6 +1416,14 @@ impl InnerServer {
                 let room_id = buffer.room_id().to_owned();
 
                 self.rooms.borrow_mut().insert(room_id, buffer.clone());
+                if let Some((is_direct, display_name)) = self
+                    .pending_room_metadata
+                    .borrow_mut()
+                    .remove(buffer.room_id())
+                {
+                    buffer.apply_room_metadata(is_direct, display_name);
+                }
+                self.switch_restored_upgrade_chain(&buffer);
 
                 // Relay-native frontends select buffers without triggering
                 // WeeChat's buffer_switch signal. Populate restored Matrix
@@ -1826,6 +1944,21 @@ impl InnerServer {
         }
 
         self.print_network("Persisted refreshed Matrix session");
+    }
+
+    pub fn receive_room_metadata(
+        &self,
+        room_id: OwnedRoomId,
+        is_direct: bool,
+        display_name: Option<String>,
+    ) {
+        if let Some(room) = self.rooms.borrow().get(&room_id) {
+            room.apply_room_metadata(is_direct, display_name);
+        } else {
+            self.pending_room_metadata
+                .borrow_mut()
+                .insert(room_id, (is_direct, display_name));
+        }
     }
 
     pub fn receive_sso_url(&self, url: &str) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -89,7 +89,8 @@ use matrix_sdk::{
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
         OwnedDeviceId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
-        OwnedRoomOrAliasId, OwnedUserId, RoomAliasId, RoomId, UserId,
+        OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
+        RoomId, UserId,
     },
     Client, Error, RoomState, SessionTokens,
 };
@@ -325,9 +326,18 @@ impl MatrixServer {
 
         match result {
             Ok(Ok(room)) => {
+                let room_id = room.room_id().to_owned();
+                if !self.rooms.borrow().contains_key(&room_id) {
+                    self.restore_room(room).await;
+                }
+                if let Some(room) = self.rooms.borrow().get(&room_id) {
+                    if let Ok(buffer) = room.buffer_handle().upgrade() {
+                        buffer.switch_to();
+                    }
+                }
                 self.print_network(&format!(
                     "Successfully joined room {}",
-                    room.room_id()
+                    room_id
                 ));
             }
             Ok(Err(error)) => {
@@ -737,14 +747,27 @@ fn create_room_request(alias_localpart: String) -> CreateRoomRequest {
     request
 }
 
+fn room_id_join_servers(room_id: &RoomId) -> Vec<OwnedServerName> {
+    room_id
+        .server_name()
+        .map(|server_name| vec![server_name.to_owned()])
+        .unwrap_or_default()
+}
+
 async fn join_room_or_create_local_alias(
     client: &Client,
     room_id_or_alias: &OwnedRoomOrAliasId,
 ) -> Result<Room, String> {
     let Ok(alias) = room_id_or_alias.as_str().parse::<OwnedRoomAliasId>()
     else {
+        let via = room_id_or_alias
+            .as_str()
+            .parse::<OwnedRoomId>()
+            .map(|room_id| room_id_join_servers(&room_id))
+            .unwrap_or_default();
+
         return client
-            .join_room_by_id_or_alias(room_id_or_alias, &[])
+            .join_room_by_id_or_alias(room_id_or_alias, &via)
             .await
             .map_err(|error| {
                 format_join_error(&error, room_id_or_alias.as_str())
@@ -752,12 +775,22 @@ async fn join_room_or_create_local_alias(
     };
 
     match client.resolve_room_alias(&alias).await {
-        Ok(response) => client
-            .join_room_by_id_or_alias(room_id_or_alias, &response.servers)
-            .await
-            .map_err(|error| {
-                format_join_error(&error, room_id_or_alias.as_str())
-            }),
+        Ok(response) => {
+            let mut via = response.servers;
+            if let Some(server_name) = response.room_id.server_name() {
+                let server_name = server_name.to_owned();
+                if !via.contains(&server_name) {
+                    via.push(server_name);
+                }
+            }
+
+            client
+                .join_room_by_id_or_alias(room_id_or_alias, &via)
+                .await
+                .map_err(|error| {
+                    format_join_error(&error, room_id_or_alias.as_str())
+                })
+        }
         Err(error)
             if error.client_api_error_kind() == Some(&ErrorKind::NotFound) =>
         {
@@ -1161,10 +1194,15 @@ impl InnerServer {
             };
             let client = connection.client().clone();
             let target = room_id.clone();
+            let room_id_or_alias: OwnedRoomOrAliasId =
+                room_id.as_str().parse().expect("valid Matrix room ID");
             match connection
                 .spawn(async move {
                     tokio::time::timeout(JOIN_ROOM_TIMEOUT, async move {
-                        client.join_room_by_id(&target).await
+                        let via = room_id_join_servers(&target);
+                        client
+                            .join_room_by_id_or_alias(&room_id_or_alias, &via)
+                            .await
                     })
                     .await
                 })
@@ -2748,10 +2786,11 @@ impl InnerServer {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_room_request, missing_alias_action, secure_set_token_command,
-        with_entered_runtime_until_drop, InnerServer, MissingAliasAction,
+        create_room_request, missing_alias_action, room_id_join_servers,
+        secure_set_token_command, with_entered_runtime_until_drop, InnerServer,
+        MissingAliasAction,
     };
-    use matrix_sdk::ruma::{OwnedRoomAliasId, OwnedUserId};
+    use matrix_sdk::ruma::{OwnedRoomAliasId, OwnedRoomId, OwnedUserId};
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::sync::{
@@ -2890,6 +2929,21 @@ mod tests {
         assert_eq!(
             missing_alias_action(&alias, None),
             MissingAliasAction::RefuseUnknownAccountDomain
+        );
+    }
+
+    #[test]
+    fn uses_room_id_origin_server_as_join_via() {
+        let room_id = "!opaque-room-id:origin.example"
+            .parse::<OwnedRoomId>()
+            .expect("valid room ID");
+
+        assert_eq!(
+            room_id_join_servers(&room_id)
+                .into_iter()
+                .map(|server| server.to_string())
+                .collect::<Vec<_>>(),
+            vec!["origin.example"]
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -80,7 +80,10 @@ use matrix_sdk::{
         },
         api::error::ErrorKind,
         events::{
-            room::{member::RoomMemberEventContent, MediaSource},
+            room::{
+                member::RoomMemberEventContent,
+                tombstone::RoomTombstoneEventContent, MediaSource,
+            },
             AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
             SyncStateEvent,
         },
@@ -98,6 +101,7 @@ use weechat::{
 };
 
 const JOIN_ROOM_TIMEOUT: Duration = Duration::from_secs(120);
+const ROOM_UPGRADE_CHAIN_LIMIT: usize = 32;
 
 use crate::{
     config::ServerBuffer,
@@ -116,6 +120,14 @@ fn secure_set_token_command(name: &str, token: &str) -> Option<String> {
         });
 
     safe.then(|| format!("/secure set {name} {token}"))
+}
+
+fn tombstone_replacement_room_id(
+    event: &SyncStateEvent<RoomTombstoneEventContent>,
+) -> Option<OwnedRoomId> {
+    event
+        .as_original()
+        .map(|event| event.content.replacement_room.clone())
 }
 
 fn with_entered_runtime_until_final_drop<F>(
@@ -1116,6 +1128,123 @@ impl InnerServer {
         self.restore_room(room).await;
     }
 
+    fn room_buffer_is_current(room: &RoomHandle) -> bool {
+        room.buffer_handle()
+            .upgrade()
+            .map(|buffer| {
+                // Sync callbacks run on WeeChat's main thread, so the global
+                // context is valid for this immediate buffer comparison.
+                buffer == unsafe { Weechat::weechat() }.current_buffer()
+            })
+            .unwrap_or(false)
+    }
+
+    async fn successor_room_handle(
+        &self,
+        room_id: OwnedRoomId,
+    ) -> Option<RoomHandle> {
+        if let Some(room) = self.rooms.borrow().get(&room_id).cloned() {
+            return Some(room);
+        }
+
+        let client_room = if let Some(room) = self
+            .get_client()
+            .and_then(|client| client.get_room(&room_id))
+        {
+            Some(room)
+        } else {
+            let Some(connection) = self.connection() else {
+                self.print_error(&format!(
+                    "Room was upgraded to {room_id}, but Matrix is not connected."
+                ));
+                return None;
+            };
+            let client = connection.client().clone();
+            let target = room_id.clone();
+            match connection
+                .spawn(async move {
+                    tokio::time::timeout(JOIN_ROOM_TIMEOUT, async move {
+                        client.join_room_by_id(&target).await
+                    })
+                    .await
+                })
+                .await
+            {
+                Ok(Ok(room)) => Some(room),
+                Ok(Err(error)) => {
+                    self.print_error(&format!(
+                        "Failed to join upgraded room {room_id}: {error}"
+                    ));
+                    None
+                }
+                Err(error) => {
+                    self.print_error(&format!(
+                        "Timed out joining upgraded room {room_id} after {} seconds: {error}",
+                        JOIN_ROOM_TIMEOUT.as_secs()
+                    ));
+                    None
+                }
+            }
+        };
+
+        if let Some(room) = client_room {
+            self.restore_room(room).await;
+        }
+
+        self.rooms.borrow().get(&room_id).cloned()
+    }
+
+    async fn latest_successor_room_handle(
+        &self,
+        room_id: OwnedRoomId,
+    ) -> Option<RoomHandle> {
+        let mut next_room_id = room_id;
+        let mut seen_room_ids = HashSet::new();
+
+        for _ in 0..ROOM_UPGRADE_CHAIN_LIMIT {
+            if !seen_room_ids.insert(next_room_id.clone()) {
+                self.print_error(&format!(
+                    "Room upgrade cycle detected at {next_room_id}."
+                ));
+                return None;
+            }
+
+            let room = self.successor_room_handle(next_room_id).await?;
+            let Some(successor_room_id) = room
+                .room()
+                .successor_room()
+                .map(|successor| successor.room_id)
+            else {
+                return Some(room);
+            };
+            next_room_id = successor_room_id;
+        }
+
+        self.print_error(&format!(
+            "Room upgrade chain exceeded {ROOM_UPGRADE_CHAIN_LIMIT} rooms."
+        ));
+        None
+    }
+
+    async fn switch_current_room_to_successor(
+        &self,
+        current_room: &RoomHandle,
+        successor_room_id: OwnedRoomId,
+    ) {
+        if !Self::room_buffer_is_current(current_room) {
+            return;
+        }
+
+        let Some(successor) =
+            self.latest_successor_room_handle(successor_room_id).await
+        else {
+            return;
+        };
+        if let Ok(buffer) = successor.buffer_handle().upgrade() {
+            buffer.switch_to();
+        }
+    }
+
     pub async fn restore_room(&self, room: Room) {
         let homeserver = self
             .settings
@@ -1522,8 +1651,19 @@ impl InnerServer {
     ) {
         let refresh_parent_spaces =
             matches!(&event, AnySyncStateEvent::RoomName(_));
+        let successor_room_id = match &event {
+            AnySyncStateEvent::RoomTombstone(tombstone) => {
+                tombstone_replacement_room_id(tombstone)
+            }
+            _ => None,
+        };
         let room = self.get_or_create_room(room_id);
         room.handle_sync_state_event(&event, true).await;
+
+        if let Some(successor_room_id) = successor_room_id {
+            self.switch_current_room_to_successor(&room, successor_room_id)
+                .await;
+        }
 
         if refresh_parent_spaces {
             for room in self.rooms() {


### PR DESCRIPTION
## Summary

- expose predecessor and replacement metadata on Matrix room buffers
- restore already-joined successors and select the latest restored room in an
  upgrade chain
- keep upgraded-away rooms from remaining the active view
- apply asynchronous room metadata after restore so direct-message/private
  classification survives the restore-order race

## Root cause

Room tombstones were treated mostly as room state. Relay clients therefore had
to invent successor logic, and the plugin could restore old and new room
versions without moving the current view to the active successor. Metadata could
also arrive before the room buffer existed.

## Integration

Rebased the focused room-upgrade commits onto main `e522c7fd7ae3a636dac5172b3d0af71d3f1edc50`, which includes #270, #275 and #289. Preserves thread continuation room/root routing, reconnect backoff and bounded upgrade joins. Successor joins use the Connection runtime boundary; no unmerged sibling branches are included.

## Validation

- Head: `f1bba8dd6e9414a1d275c06c497c5f69f85f8935`
- `cargo test --lib`: 160 passed, including tombstone metadata, thread continuation routing, runtime-boundary and reconnect-backoff regressions.
- `cargo build --lib`: passed in Debian trixie with the WeeChat development header mounted.
- `git diff --check`: passed; complete branch scope is limited to `src/connection.rs`, `src/room/buffer.rs`, `src/room/mod.rs`, and `src/server.rs`.
- Merge-tree against current main is clean; the previous head reproduces the reported conflict.
- All four hosted `build-test-release` jobs passed on this exact head: Ubuntu 22.04, Ubuntu 24.04, Ubuntu latest, and Debian 13 packaging. [CI run](https://github.com/poljar/weechat-matrix-rs/actions/runs/34351493078).

No live WeeChat deployment or restart was performed.
