### PR TITLE
reply: select events by slash pattern

### DIFF
--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -17,6 +17,10 @@ use crate::Servers;
 
 const EVENT_ID_TAG_PREFIX: &str = "matrix_id_";
 
+fn message_matches_pattern(message: &str, pattern: &str) -> bool {
+    message.contains(pattern)
+}
+
 pub struct ReplyCommand {
     servers: Servers,
 }
@@ -25,11 +29,13 @@ impl ReplyCommand {
     pub fn create(servers: &Servers) -> Result<Command, ()> {
         let settings = CommandSettings::new("reply")
             .description("Reply to a Matrix event in the current room.")
-            .add_argument("[event-id|index] <message>")
+            .add_argument("[event-id|index|/pattern/] <message>")
             .arguments_description(
                 "event-id: The Matrix event ID to reply to.
     index: 1-based recent event index. 1, 0, or -1 select the latest event; \
            2 or -2 select the event before that.
+  pattern: A case-sensitive substring enclosed in slashes. The most recent \
+           unredacted message containing it is selected.
   message: Reply message text. If no event ID or index is given, all text is \
            sent as a reply to the latest Matrix event in the buffer.",
             );
@@ -79,6 +85,43 @@ impl ReplyCommand {
         }
     }
 
+    fn parse_pattern(argument: &str) -> Result<Option<&str>, String> {
+        let Some(pattern) = argument
+            .strip_prefix('/')
+            .and_then(|argument| argument.strip_suffix('/'))
+        else {
+            return Ok(None);
+        };
+
+        if pattern.is_empty() {
+            Err("The reply pattern cannot be empty.".to_owned())
+        } else {
+            Ok(Some(pattern))
+        }
+    }
+
+    fn event_id_matching_pattern(
+        buffer: &Buffer,
+        pattern: &str,
+    ) -> Option<OwnedEventId> {
+        buffer.lines().rev().find_map(|line| {
+            let tags = line.tags();
+
+            if tags.iter().any(|tag| tag.as_ref() == "matrix_redacted")
+                || !message_matches_pattern(
+                    &Weechat::remove_color(&line.message()),
+                    pattern,
+                )
+            {
+                return None;
+            }
+
+            tags.iter()
+                .find_map(|tag| tag.as_ref().strip_prefix(EVENT_ID_TAG_PREFIX))
+                .and_then(|event_id| EventId::parse(event_id).ok())
+        })
+    }
+
     fn parse_arguments(
         buffer: &Buffer,
         arguments: Option<Vec<&str>>,
@@ -86,38 +129,51 @@ impl ReplyCommand {
         let Some(arguments) =
             arguments.filter(|arguments| !arguments.is_empty())
         else {
-            return Err("Usage: /reply [event-id|index] <message>".to_owned());
+            return Err(
+                "Usage: /reply [event-id|index|/pattern/] <message>".to_owned()
+            );
         };
 
-        let (event_id, message) =
-            if let Some((first, rest)) = arguments.split_first() {
-                if first.starts_with('$') && EventId::parse(*first).is_err() {
-                    return Err(format!("Invalid Matrix event ID: {}", first));
-                }
+        let (event_id, message) = if let Some((first, rest)) =
+            arguments.split_first()
+        {
+            if first.starts_with('$') && EventId::parse(*first).is_err() {
+                return Err(format!("Invalid Matrix event ID: {}", first));
+            }
 
-                if let Ok(event_id) = EventId::parse(*first) {
-                    (event_id, rest.join(" "))
-                } else if let Some(index) = Self::parse_index(first) {
-                    let event_id = Self::event_id_at_index(buffer, index)
-                        .ok_or_else(|| {
-                            format!(
-                                "No Matrix event found at reply index {}.",
-                                first
-                            )
-                        })?;
+            if let Ok(event_id) = EventId::parse(*first) {
+                (event_id, rest.join(" "))
+            } else if let Some(index) = Self::parse_index(first) {
+                let event_id = Self::event_id_at_index(buffer, index)
+                    .ok_or_else(|| {
+                        format!(
+                            "No Matrix event found at reply index {}.",
+                            first
+                        )
+                    })?;
 
-                    (event_id, rest.join(" "))
-                } else {
-                    let event_id =
-                        Self::latest_event_id(buffer).ok_or_else(|| {
-                            "No Matrix event found to reply to.".to_owned()
-                        })?;
+                (event_id, rest.join(" "))
+            } else if let Some(pattern) = Self::parse_pattern(first)? {
+                let event_id = Self::event_id_matching_pattern(buffer, pattern)
+                    .ok_or_else(|| {
+                        format!(
+                            "No unredacted Matrix event matches /{}/.",
+                            pattern
+                        )
+                    })?;
 
-                    (event_id, arguments.join(" "))
-                }
+                (event_id, rest.join(" "))
             } else {
-                unreachable!("empty arguments were filtered above");
-            };
+                let event_id =
+                    Self::latest_event_id(buffer).ok_or_else(|| {
+                        "No Matrix event found to reply to.".to_owned()
+                    })?;
+
+                (event_id, arguments.join(" "))
+            }
+        } else {
+            unreachable!("empty arguments were filtered above");
+        };
 
         if message.is_empty() {
             Err("Reply message cannot be empty.".to_owned())
@@ -195,7 +251,7 @@ fn reply_content(
 mod tests {
     use matrix_sdk::ruma::{events::room::message::Relation, owned_event_id};
 
-    use super::{reply_content, ReplyCommand};
+    use super::{message_matches_pattern, reply_content, ReplyCommand};
 
     #[test]
     fn reply_index_accepts_recent_event_forms() {
@@ -205,6 +261,33 @@ mod tests {
         assert_eq!(Some(2), ReplyCommand::parse_index("2"));
         assert_eq!(Some(2), ReplyCommand::parse_index("-2"));
         assert_eq!(None, ReplyCommand::parse_index("abc"));
+    }
+
+    #[test]
+    fn reply_pattern_uses_slash_delimiters() {
+        assert_eq!(Ok(Some("needle")), ReplyCommand::parse_pattern("/needle/"));
+        assert_eq!(Ok(None), ReplyCommand::parse_pattern("needle"));
+        assert_eq!(Ok(None), ReplyCommand::parse_pattern("/needle"));
+    }
+
+    #[test]
+    fn reply_pattern_rejects_empty_match() {
+        assert_eq!(
+            Err("The reply pattern cannot be empty.".to_owned()),
+            ReplyCommand::parse_pattern("//")
+        );
+    }
+
+    #[test]
+    fn reply_pattern_matches_message_substrings() {
+        assert!(message_matches_pattern(
+            "the self-hosted version",
+            "self-hosted"
+        ));
+        assert!(!message_matches_pattern(
+            "the hosted version",
+            "self-hosted"
+        ));
     }
 
     #[test]
@@ -266,5 +349,16 @@ mod tests {
             thread.in_reply_to.expect("fallback reply target").event_id
         );
         assert!(thread.is_falling_back);
+    }
+
+    #[test]
+    fn command_parser_accepts_reply_pattern() {
+        let matches = ReplyCommand::parser()
+            .get_matches_from_safe(vec!["reply", "/needle/", "message"])
+            .unwrap();
+        let arguments: Vec<_> =
+            matches.values_of("arguments").unwrap().collect();
+
+        assert_eq!(vec!["/needle/", "message"], arguments);
     }
 }


### PR DESCRIPTION
Fixes poljar/weechat-matrix-rs#287.

This adds the same slash-delimited, case-sensitive substring selection that
`/redact` already has to `/reply`, so `/reply /needle/ message` replies to the
most recent unredacted Matrix event whose rendered line contains `needle`.

## Relationship to thread replies

poljar/weechat-matrix-rs#270 and this PR both change the `/reply` implementation.
Each head is independently mergeable with `main`, but merging the two heads
together produces a content conflict in `src/commands/reply.rs`. If
poljar/weechat-matrix-rs#270 lands first, this change must be rebased onto it so
the pattern lookup retains poljar/weechat-matrix-rs#270's thread relation and
thread-root behavior.

## Validation

- `git diff --check`
- `rustfmt --edition 2018 --check src/commands/reply.rs`
- clean Debian trixie container with bundled WeeChat headers:
  `cargo test --locked --lib` (134 passed)
- [hosted build-test-release run](https://github.com/poljar/weechat-matrix-rs/actions/runs/33339978313):
  three Ubuntu build/test jobs and the Debian 13 package job passed on head
  `82dedee4105a595f7e9f216d27341551e39324da`
