### PR TITLE
fix: keep room buffer names unique

### DIFF
--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -549,8 +549,7 @@ impl RoomHandle {
             room,
         };
 
-        let buffer_name =
-            format!("{}.{}", server_name, room.buffer.calculate_buffer_name());
+        let buffer_name = format!("{}.{}", server_name, room_id);
 
         let buffer_handle = BufferBuilderAsync::new(&buffer_name)
             .input_callback(room.clone())
@@ -565,6 +564,7 @@ impl RoomHandle {
         let buffer = buffer_handle
             .upgrade()
             .expect("Can't upgrade newly created buffer");
+        buffer.set_short_name(&room.buffer.calculate_buffer_name());
 
         buffer
             .add_nicklist_group(


### PR DESCRIPTION
Fixes #295.

`947f73c4` made the WeeChat internal buffer name use the room display name. That display name can collide for two Matrix rooms, so the second buffer creation can panic.

This keeps the internal buffer name based on `room_id`, and still sets the human short name from `calculate_buffer_name()` after creating the buffer.

Credit: the issue diagnosis and patch shape came from arbelonson-source's issue comment, after kugel- corrected the bisect to `947f73c4`.

Validation:
- `git diff --check`
- Debian Bookworm container with Rust 1.96.1, `WEECHAT_BUNDLED=1`, `clang`, `libclang-dev`, `libsqlite3-dev`, `pkg-config`, and `libssl-dev`: `cargo test --locked --lib room::buffer` passed, 16 passed, 0 failed.

Host validation note: local non-container `cargo test --lib room::buffer --locked` is blocked before project tests by host OpenSSL 4.0.1 vs `openssl-sys` 0.9.111 compatibility.
