### PR TITLE
fix: keep /say in Matrix rooms

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,6 +28,7 @@ mod page_up;
 mod part;
 mod redact;
 mod reply;
+mod say;
 mod topic;
 mod upload;
 mod verification;
@@ -56,6 +57,7 @@ use page_up::PageUpCommand;
 use part::PartCommand;
 use redact::RedactCommand;
 use reply::ReplyCommand;
+use say::SayCommand;
 use topic::TopicCommand;
 use upload::UploadCommand;
 use verify::VerifyCommand;
@@ -74,6 +76,7 @@ pub struct Commands {
     _page_up: CommandRun,
     _redact: Command,
     _reply: Command,
+    _say: CommandRun,
     _topic: Command,
     _verification: Command,
     _buffer_clear: CommandRun,
@@ -108,6 +111,7 @@ impl Commands {
             _page_up: PageUpCommand::create(servers)?,
             _redact: RedactCommand::create(servers)?,
             _reply: ReplyCommand::create(servers)?,
+            _say: SayCommand::create(servers)?,
             _topic: TopicCommand::create(servers)?,
             _verification: VerificationCommand::create(servers)?,
             _buffer_clear: BufferClearCommand::create(servers)?,

--- a/src/commands/say.rs
+++ b/src/commands/say.rs
@@ -1,0 +1,68 @@
+use std::borrow::Cow;
+
+use weechat::{
+    buffer::Buffer,
+    hooks::{CommandRun, CommandRunCallback},
+    ReturnCode, Weechat,
+};
+
+use crate::Servers;
+
+pub struct SayCommand {
+    servers: Servers,
+}
+
+fn say_body(command: &str) -> Option<&str> {
+    command.strip_prefix("/say ").map(str::trim_start)
+}
+
+impl SayCommand {
+    pub fn create(servers: &Servers) -> Result<CommandRun, ()> {
+        CommandRun::new(
+            "/say *",
+            SayCommand {
+                servers: servers.clone(),
+            },
+        )
+    }
+}
+
+impl CommandRunCallback for SayCommand {
+    fn callback(
+        &mut self,
+        _: &Weechat,
+        buffer: &Buffer,
+        command: Cow<str>,
+    ) -> ReturnCode {
+        let Some(room) = self.servers.find_room(buffer) else {
+            return ReturnCode::Ok;
+        };
+
+        let Some(body) = say_body(&command) else {
+            return ReturnCode::Ok;
+        };
+
+        let content = room.text_message_content(buffer, body.to_owned());
+        Weechat::spawn(async move { room.send_message(content).await })
+            .detach();
+
+        ReturnCode::OkEat
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::say_body;
+
+    #[test]
+    fn say_body_preserves_message_text() {
+        assert_eq!(say_body("/say hello Matrix"), Some("hello Matrix"));
+        assert_eq!(say_body("/say   leading spaces"), Some("leading spaces"));
+    }
+
+    #[test]
+    fn say_body_excludes_other_commands() {
+        assert_eq!(say_body("/msg hello"), None);
+        assert_eq!(say_body("hello"), None);
+    }
+}

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -744,42 +744,40 @@ impl BufferInputCallbackAsync for MatrixRoom {
             return;
         }
 
-        let thread_root = buffer
-            .upgrade()
-            .ok()
-            .and_then(|buffer| thread_root_from_buffer(&buffer));
-        let latest_thread_event = thread_root.as_ref().and_then(|root| {
-            self.latest_thread_event_ids.borrow().get(root).cloned()
-        });
-        let content = make_text_message_content(
-            input,
-            self.config.borrow().input().markdown_input(),
-            thread_root,
-            latest_thread_event,
-        );
-
-        self.send_message(content).await;
+        if let Ok(buffer) = buffer.upgrade() {
+            let content = self.text_message_content(&buffer, input);
+            self.send_message(content).await;
+        }
     }
 }
 
 impl MatrixRoom {
+    pub(crate) fn text_message_content(
+        &self,
+        buffer: &Buffer,
+        input: String,
+    ) -> RoomMessageEventContent {
+        let thread_root = thread_root_from_buffer(buffer);
+        let latest_thread_event = thread_root.as_ref().and_then(|root| {
+            self.latest_thread_event_ids.borrow().get(root).cloned()
+        });
+
+        make_text_message_content(
+            input,
+            self.config.borrow().input().markdown_input(),
+            thread_root,
+            latest_thread_event,
+        )
+    }
+
     pub(crate) fn mention_message_content(
         &self,
         buffer: &Buffer,
         input: String,
         mentioned_user_ids: Vec<OwnedUserId>,
     ) -> RoomMessageEventContent {
-        let thread_root = thread_root_from_buffer(buffer);
-        let latest_thread_event = thread_root.as_ref().and_then(|root| {
-            self.latest_thread_event_ids.borrow().get(root).cloned()
-        });
         with_mentions(
-            make_text_message_content(
-                input,
-                self.config.borrow().input().markdown_input(),
-                thread_root,
-                latest_thread_event,
-            ),
+            self.text_message_content(buffer, input),
             mentioned_user_ids,
         )
     }


### PR DESCRIPTION
Fixes #296.

WeeChat expands `/say ...` as a command-run callback before the Matrix room input callback sees it. In a Matrix room buffer this routes `/say` through the same Matrix text-content path as normal input, preserving markdown and thread reply context, then eats the command so WeeChat does not create/use a `*` buffer.

Validation:
- `rustfmt --edition 2021 --check src/commands/say.rs`
- `git diff --check`
- `docker run --rm -v /home/kom/proj/ai_pr/weechat-matrix-say-star-296-20260903:/work -w /work weechat-rust-trixie-test:latest bash -lc 'rustc --version && cargo test say_body --lib'` (`rustc 1.97.1`, 2 tests passed)\n\nHost note: direct host `cargo test say_body --lib` is blocked here by system OpenSSL 4.0.1 versus openssl-sys support range; the Docker WeeChat test image avoids that host OpenSSL mismatch.