### PR TITLE
build: bump rust-weechat lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "weechat"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#adb96ffc9f229cbff05ad51b0ff4c9d46597e2f4"
+source = "git+https://github.com/poljar/rust-weechat#8c877b41773e973b70d46aa57611c59f2519900f"
 dependencies = [
  "async-task",
  "async-trait",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "weechat-macro"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#adb96ffc9f229cbff05ad51b0ff4c9d46597e2f4"
+source = "git+https://github.com/poljar/rust-weechat#8c877b41773e973b70d46aa57611c59f2519900f"
 dependencies = [
  "libc",
  "proc-macro2",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "weechat-sys"
 version = "0.4.0"
-source = "git+https://github.com/poljar/rust-weechat#adb96ffc9f229cbff05ad51b0ff4c9d46597e2f4"
+source = "git+https://github.com/poljar/rust-weechat#8c877b41773e973b70d46aa57611c59f2519900f"
 dependencies = [
  "bindgen",
  "libc",


### PR DESCRIPTION
Bumps the locked `rust-weechat` revision from `adb96ffc` to current upstream `8c877b41`, so this repository consumes the merged header-selection logging from poljar/rust-weechat#52.

This addresses the remaining dependency-bump part of poljar/weechat-matrix-rs#285: `weechat-sys` now reports the configured `weechat-plugin.h` path and API version during the build.

Validation:

- `WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h cargo check -p weechat-sys --locked -vv` prints `Using configured WeeChat header: /usr/include/weechat/weechat-plugin.h (API 20260704-03)`.
- `WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h cargo test reply --lib --locked` passed, 24 tests.
