### PR TITLE
feat: show Matrix typing notices

### DIFF
--- a/src/bar_items/mod.rs
+++ b/src/bar_items/mod.rs
@@ -1,6 +1,7 @@
 mod buffer_name;
 mod buffer_plugin;
 mod status;
+mod typing_notice;
 
 use weechat::hooks::BarItem;
 
@@ -8,6 +9,7 @@ use crate::Servers;
 use buffer_name::BufferName;
 use buffer_plugin::BufferPlugin;
 use status::Status;
+use typing_notice::TypingNotice;
 
 pub struct BarItems {
     #[allow(dead_code)]
@@ -16,6 +18,8 @@ pub struct BarItems {
     buffer_name: BarItem,
     #[allow(dead_code)]
     buffer_plugin: BarItem,
+    #[allow(dead_code)]
+    typing_notice: BarItem,
 }
 
 impl BarItems {
@@ -23,7 +27,8 @@ impl BarItems {
         Ok(Self {
             status: Status::create(servers.clone())?,
             buffer_name: BufferName::create(servers.clone())?,
-            buffer_plugin: BufferPlugin::create(servers)?,
+            buffer_plugin: BufferPlugin::create(servers.clone())?,
+            typing_notice: TypingNotice::create(servers)?,
         })
     }
 }

--- a/src/bar_items/typing_notice.rs
+++ b/src/bar_items/typing_notice.rs
@@ -1,0 +1,27 @@
+use weechat::{
+    buffer::Buffer,
+    hooks::{BarItem, BarItemCallback},
+    Weechat,
+};
+
+use crate::{BufferOwner, Servers};
+
+pub(super) struct TypingNotice {
+    servers: Servers,
+}
+
+impl TypingNotice {
+    pub(super) fn create(servers: Servers) -> Result<BarItem, ()> {
+        let status = TypingNotice { servers };
+        BarItem::new("matrix_typing_notice", status)
+    }
+}
+
+impl BarItemCallback for TypingNotice {
+    fn callback(&mut self, _: &Weechat, buffer: &Buffer) -> String {
+        match self.servers.buffer_owner(buffer) {
+            BufferOwner::Room(_, room) => room.typing_notice(),
+            _ => String::new(),
+        }
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,8 +40,8 @@ use matrix_sdk::{
         },
         events::{
             room::member::RoomMemberEventContent, AnyMessageLikeEventContent,
-            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
-            SyncStateEvent,
+            AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+            AnyToDeviceEvent, SyncStateEvent,
         },
         OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId,
         OwnedUserId,
@@ -119,6 +119,7 @@ pub enum ClientMessage {
     SsoLoginUrl(String),
     SyncState(OwnedRoomId, AnySyncStateEvent),
     SyncEvent(OwnedRoomId, AnySyncTimelineEvent),
+    EphemeralRoomEvent(OwnedRoomId, AnySyncEphemeralRoomEvent),
     ToDeviceEvent(AnyToDeviceEvent),
     MemberEvent(
         OwnedRoomId,
@@ -552,6 +553,9 @@ impl Connection {
                     ClientMessage::SyncState(r, e) => {
                         server.receive_joined_state_event(&r, e).await
                     }
+                    ClientMessage::EphemeralRoomEvent(r, e) => {
+                        server.receive_joined_ephemeral_event(&r, e).await
+                    }
                     ClientMessage::RestoredRoom(room_id) => {
                         server.restore_room_by_id(room_id).await
                     }
@@ -959,6 +963,23 @@ impl Connection {
                             }
                         } else if sync_channel
                             .send(Ok(ClientMessage::SyncState(
+                                room_id.clone(),
+                                event,
+                            )))
+                            .await
+                            .is_err()
+                        {
+                            return LoopCtrl::Break;
+                        }
+                    }
+
+                    for event in room
+                        .ephemeral
+                        .iter()
+                        .filter_map(|e| e.deserialize().ok())
+                    {
+                        if sync_channel
+                            .send(Ok(ClientMessage::EphemeralRoomEvent(
                                 room_id.clone(),
                                 event,
                             )))

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -78,9 +78,10 @@ use matrix_sdk::{
                 redaction::SyncRoomRedactionEvent,
                 tombstone::RoomTombstoneEventContent,
             },
-            AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
-            AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
-            OriginalSyncMessageLikeEvent, SyncMessageLikeEvent, SyncStateEvent,
+            AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent,
+            AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+            AnyTimelineEvent, OriginalSyncMessageLikeEvent,
+            SyncMessageLikeEvent, SyncStateEvent,
         },
         room::JoinRule,
         serde::Raw,
@@ -346,6 +347,7 @@ pub struct MatrixRoom {
     latest_event_id: Rc<RefCell<Option<OwnedEventId>>>,
     latest_read_event_id: Rc<RefCell<Option<OwnedEventId>>>,
     latest_thread_event_ids: Rc<RefCell<HashMap<OwnedEventId, OwnedEventId>>>,
+    typing_users: Rc<RefCell<Vec<String>>>,
     pending_encrypted_events:
         Rc<RefCell<HashMap<OwnedEventId, PendingEncryptedEvent>>>,
     pending_encrypted_recoveries:
@@ -702,6 +704,7 @@ impl RoomHandle {
             latest_event_id: Rc::new(RefCell::new(None)),
             latest_read_event_id: Rc::new(RefCell::new(None)),
             latest_thread_event_ids: Rc::new(RefCell::new(HashMap::new())),
+            typing_users: Rc::new(RefCell::new(Vec::new())),
             pending_encrypted_events: Rc::new(RefCell::new(HashMap::new())),
             pending_encrypted_recoveries: Rc::new(RefCell::new(HashSet::new())),
             thread_history_in_flight: Rc::new(RefCell::new(HashSet::new())),
@@ -1261,6 +1264,10 @@ impl MatrixRoom {
 
     pub fn update_parent_spaces(&self) {
         self.buffer.update_parent_spaces();
+    }
+
+    pub fn typing_notice(&self) -> String {
+        typing_notice_text(&self.typing_users.borrow())
     }
 
     pub fn refresh_space_children(&self) {
@@ -3320,6 +3327,34 @@ impl MatrixRoom {
         }
     }
 
+    pub async fn handle_sync_ephemeral_event(
+        &self,
+        event: AnySyncEphemeralRoomEvent,
+    ) {
+        let AnySyncEphemeralRoomEvent::Typing(event) = event else {
+            return;
+        };
+
+        let mut typing_users = Vec::new();
+        for user_id in event
+            .content
+            .user_ids
+            .iter()
+            .filter(|user_id| user_id.as_str() != self.own_user_id.as_str())
+        {
+            let name = self
+                .members
+                .get(user_id)
+                .await
+                .map(|member| member.nick())
+                .unwrap_or_else(|| user_id.to_string());
+            typing_users.push(name);
+        }
+
+        *self.typing_users.borrow_mut() = typing_users;
+        Weechat::bar_item_update("matrix_typing_notice");
+    }
+
     pub async fn handle_room_event(&self, event: &AnyTimelineEvent) -> usize {
         let thread_root = thread_root_from_timeline_event(event);
 
@@ -3452,6 +3487,10 @@ fn reply_context_for_distance(
         .filter(|distance| threshold > 0 && *distance <= threshold as usize)
         .map(|_| ReplyContext::Inline)
         .unwrap_or(ReplyContext::Full)
+}
+
+fn typing_notice_text(typing_users: &[String]) -> String {
+    typing_users.join(", ")
 }
 
 #[cfg(test)]
@@ -3625,6 +3664,19 @@ mod tests {
         );
         assert_eq!(ReplyContext::Full, reply_context_for_distance(2, Some(3)));
         assert_eq!(ReplyContext::Full, reply_context_for_distance(2, None));
+    }
+
+    #[test]
+    fn typing_notice_is_empty_without_remote_users() {
+        assert_eq!("", typing_notice_text(&[]));
+    }
+
+    #[test]
+    fn typing_notice_lists_remote_users_in_event_order() {
+        assert_eq!(
+            "Ada, Grace",
+            typing_notice_text(&["Ada".to_owned(), "Grace".to_owned()])
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,8 +84,8 @@ use matrix_sdk::{
                 member::RoomMemberEventContent,
                 tombstone::RoomTombstoneEventContent, MediaSource,
             },
-            AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
-            SyncStateEvent,
+            AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+            AnyToDeviceEvent, SyncStateEvent,
         },
         DeviceId, DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch,
         OwnedDeviceId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
@@ -1836,6 +1836,15 @@ impl InnerServer {
     ) {
         let room = self.get_or_create_room(room_id);
         room.handle_sync_room_event(event).await
+    }
+
+    pub async fn receive_joined_ephemeral_event(
+        &self,
+        room_id: &RoomId,
+        event: AnySyncEphemeralRoomEvent,
+    ) {
+        let room = self.get_or_create_room(room_id);
+        room.handle_sync_ephemeral_event(event).await
     }
 
     pub fn receive_login(&self, response: LoginResponse) {


### PR DESCRIPTION
Adds incoming Matrix typing-notice handling for #305.

The sync loop now forwards ephemeral room events, room state tracks remote typing users, and a `matrix_typing_notice` bar item exposes the active room notice. The current user is filtered out; known members use WeeChat nicks, unknown users fall back to MXIDs.

Checked locally with the installed WeeChat header:

- `WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h cargo fmt --check`
- `WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h cargo test typing_notice --locked`
- `WEECHAT_PLUGIN_FILE=/usr/include/weechat/weechat-plugin.h cargo check --locked`

Fixes #305.